### PR TITLE
Add reuse option for terminal actions in desktop app

### DIFF
--- a/desktop/frontend/src/components/InteractivePane.tsx
+++ b/desktop/frontend/src/components/InteractivePane.tsx
@@ -8,6 +8,7 @@ import {
   EventsOn,
   BrowserOpenURL,
   OnFileDrop,
+  OnFileDropOff,
 } from "../../wailsjs/runtime/runtime";
 import {
   ResizeTerminal,
@@ -42,24 +43,368 @@ interface InteractivePaneProps {
 const ACK_SIZE = 5000;
 const HIDDEN_BUF_CAP = 1_000_000; // max chars to buffer while hidden (~1MB)
 
-// Global file drop handler — routes drops to the visible terminal
+// Global file drop handler — routes drops to the pane under the cursor
 let fileDropInitialized = false;
 function initFileDrop() {
   if (fileDropInitialized) return;
   fileDropInitialized = true;
-  OnFileDrop((_x, _y, paths) => {
-    const candidates =
-      document.querySelectorAll<HTMLElement>("[data-terminal-id]");
-    let id: string | undefined;
-    for (const el of candidates) {
-      if (el.offsetParent !== null) {
-        id = el.dataset.terminalId;
-        break;
-      }
-    }
+  OnFileDrop((x, y, paths) => {
+    const id = terminalIdAtPoint(x, y);
     if (!id) return;
     sendTerminalInput(id, paths.map(shellQuote).join(" ")).catch(() => {});
   }, false);
+}
+
+function terminalIdAtPoint(x: number, y: number): string | undefined {
+  const hit = document
+    .elementFromPoint(x, y)
+    ?.closest<HTMLElement>("[data-terminal-id]");
+  if (hit) return hit.dataset.terminalId;
+  // Fallback: elementFromPoint can miss the pane if an overlay sits above it —
+  // scan pane rects directly.
+  for (const pane of document.querySelectorAll<HTMLElement>(
+    "[data-terminal-id]",
+  )) {
+    const r = pane.getBoundingClientRect();
+    if (
+      r.width > 0 &&
+      r.height > 0 &&
+      x >= r.left &&
+      x < r.right &&
+      y >= r.top &&
+      y < r.bottom
+    ) {
+      return pane.dataset.terminalId;
+    }
+  }
+  return undefined;
+}
+
+// Cached xterm instances keyed by terminalId; survive component remount
+// (e.g. a pane split) so scrollback and PTY subscriptions stay intact.
+interface InteractiveSession {
+  term: Terminal;
+  fit: FitAddon;
+  search: SearchAddon | null;
+  host: HTMLDivElement;
+
+  visible: boolean;
+  hiddenBuf: string[];
+  hiddenBufLen: number;
+  unsentAck: number;
+  sessionDead: boolean;
+
+  // Installed by the current React mount, cleared on unmount so callbacks
+  // closing over stale component state don't fire.
+  onScrollState?: (atBottom: boolean) => void;
+  onExit?: (exitCode: number) => void;
+  themeOverride: ITheme | null;
+
+  flush: () => void;
+  destroy: () => void;
+}
+
+const interactiveSessions = new Map<string, InteractiveSession>();
+
+// One MutationObserver and one getComputedStyle per theme flip. Per-host
+// lookups would be both wasteful (every session resolves through the same
+// :root cascade) and wrong for detached hosts during the split-remount gap.
+let themeObserver: MutationObserver | null = null;
+function ensureThemeObserver() {
+  if (themeObserver) return;
+  themeObserver = new MutationObserver(() => {
+    const theme = getTerminalTheme();
+    for (const s of interactiveSessions.values()) {
+      if (!s.themeOverride) s.term.options.theme = theme;
+    }
+  });
+  themeObserver.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["data-theme"],
+  });
+}
+
+export function disposeInteractivePaneSession(terminalId: string) {
+  const s = interactiveSessions.get(terminalId);
+  if (!s) return;
+  s.destroy();
+  s.term.dispose();
+  s.host.remove();
+  interactiveSessions.delete(terminalId);
+}
+
+// Wails caches the first OnFileDrop registration per page lifetime, so under
+// Vite HMR the stale callback would keep firing with old code. Also dispose
+// all cached sessions and the theme observer so the fresh module starts clean.
+const viteHot = (
+  import.meta as ImportMeta & { hot?: { dispose: (cb: () => void) => void } }
+).hot;
+if (viteHot) {
+  viteHot.dispose(() => {
+    OnFileDropOff();
+    fileDropInitialized = false;
+    for (const s of interactiveSessions.values()) {
+      s.destroy();
+      s.term.dispose();
+      s.host.remove();
+    }
+    interactiveSessions.clear();
+    themeObserver?.disconnect();
+    themeObserver = null;
+  });
+}
+
+// Must be called during the paste event — items are invalidated after.
+function extractImageBlob(
+  items: DataTransferItemList,
+): { blob: File; mimeType: string } | null {
+  for (const item of items) {
+    if (item.type.startsWith("image/")) {
+      const blob = item.getAsFile();
+      if (blob) return { blob, mimeType: item.type };
+    }
+  }
+  return null;
+}
+
+function saveImageBlob(terminalId: string, blob: File, mimeType: string) {
+  const reader = new FileReader();
+  reader.onload = () => {
+    const dataUrl = reader.result as string;
+    const b64 = dataUrl.split(",")[1];
+    if (!b64) return;
+    SaveClipboardImage(b64, mimeType)
+      .then((filePath) => {
+        sendTerminalInput(terminalId, shellQuote(filePath));
+      })
+      .catch((err) => console.warn("SaveClipboardImage failed:", err));
+  };
+  reader.readAsDataURL(blob);
+}
+
+function createInteractiveSession(terminalId: string): InteractiveSession {
+  const host = document.createElement("div");
+  host.className = "absolute inset-0 overflow-hidden";
+  host.setAttribute("data-terminal-id", terminalId);
+
+  // fontSize and theme are placeholders — the React mount sets the real
+  // values from props before the session is ever attached.
+  const term = new Terminal({
+    fontSize: 12,
+    fontFamily: "'SF Mono', Menlo, Monaco, 'Courier New', monospace",
+    cursorBlink: true,
+    disableStdin: false,
+    scrollback: 10000,
+    theme: getTerminalTheme(),
+    allowProposedApi: true,
+    vtExtensions: { kittyKeyboard: true },
+  });
+
+  const fit = new FitAddon();
+  term.loadAddon(fit);
+
+  let search: SearchAddon | null = null;
+  try {
+    search = new SearchAddon();
+    term.loadAddon(search);
+  } catch {}
+  try {
+    term.loadAddon(new WebLinksAddon((_e, uri) => BrowserOpenURL(uri)));
+  } catch {}
+  try {
+    const u = new Unicode11Addon();
+    term.loadAddon(u);
+    term.unicode.activeVersion = "11";
+  } catch {}
+
+  // Intercept Cmd+key combos before kitty keyboard protocol encodes them.
+  // Without this, Cmd+V/C/etc. are sent as CSI u sequences instead of
+  // triggering paste/copy/other OS-level shortcuts.
+  term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
+    if (!e.metaKey) return true;
+    if (e.key === "v") {
+      return false;
+    }
+    if (e.key === "c" && e.type === "keydown") {
+      const selection = term.getSelection();
+      if (selection) navigator.clipboard.writeText(selection).catch(() => {});
+      return false;
+    }
+    // Let all other Cmd+key combos fall through to the browser
+    return false;
+  });
+
+  term.open(host);
+
+  // Load WebGL addon for GPU-accelerated rendering
+  import("@xterm/addon-webgl")
+    .then(({ WebglAddon }) => {
+      try {
+        const webgl = new WebglAddon();
+        webgl.onContextLoss(() => webgl.dispose());
+        term.loadAddon(webgl);
+      } catch {}
+    })
+    .catch(() => {});
+
+  const session: InteractiveSession = {
+    term,
+    fit,
+    search,
+    host,
+    visible: true,
+    hiddenBuf: [],
+    hiddenBufLen: 0,
+    unsentAck: 0,
+    sessionDead: false,
+    themeOverride: null,
+    flush: () => {},
+    destroy: () => {},
+  };
+
+  ensureThemeObserver();
+
+  // Flow control: batch acks to reduce IPC calls
+  const ackData = (charCount: number) => {
+    session.unsentAck += charCount;
+    while (session.unsentAck >= ACK_SIZE) {
+      session.unsentAck -= ACK_SIZE;
+      AckTerminalData(terminalId, ACK_SIZE).catch(() => {});
+    }
+  };
+
+  // Visibility-gated write: when hidden, buffer data; flush on visible.
+  // Capped to prevent unbounded memory growth from long-running background output.
+  // Don't ack while hidden — let backend flow control pause naturally.
+  // Ack on flush so xterm.js renders before backend resumes sending.
+  // Overflow: ack-and-drop so backend unacked doesn't get a permanent floor
+  // (otherwise the reader can stay paused forever after the next pause).
+  const writeData = (data: string) => {
+    if (!session.visible) {
+      if (session.hiddenBufLen < HIDDEN_BUF_CAP) {
+        session.hiddenBuf.push(data);
+        session.hiddenBufLen += data.length;
+      } else {
+        ackData(data.length);
+      }
+      return;
+    }
+    term.write(data, () => ackData(data.length));
+  };
+  session.flush = () => {
+    if (session.hiddenBuf.length === 0) return;
+    const joined = session.hiddenBuf.join("");
+    session.hiddenBuf = [];
+    session.hiddenBufLen = 0;
+    term.write(joined, () => ackData(joined.length));
+  };
+
+  const markDead = (msg: string, ansiColor: string) => {
+    if (session.sessionDead) return;
+    session.sessionDead = true;
+    term.options.disableStdin = true;
+    term.options.cursorBlink = false;
+    term.write(`\r\n\x1b[${ansiColor}m${msg}\x1b[0m\r\n`);
+  };
+
+  const handleWriteError = () => markDead("[Session disconnected]", "91");
+
+  term.onData((data) => {
+    sendTerminalInput(terminalId, data).catch(handleWriteError);
+  });
+
+  // Send binary data (mouse events, etc.) to PTY
+  term.onBinary((data) => {
+    sendTerminalInput(terminalId, data).catch(handleWriteError);
+  });
+
+  // Sync resize to PTY
+  term.onResize(({ cols, rows }) => {
+    ResizeTerminal(terminalId, cols, rows).catch(() => {});
+  });
+
+  // Scroll tracking
+  term.onScroll(() => {
+    const buf = term.buffer.active;
+    const atBottom = buf.baseY + term.rows >= buf.length;
+    session.onScrollState?.(atBottom);
+  });
+
+  // Sync initial size to PTY
+  ResizeTerminal(terminalId, term.cols, term.rows).catch(() => {});
+
+  // Attached to term.textarea — that's where xterm.js focuses and receives paste events.
+  const handlePaste = (e: ClipboardEvent) => {
+    if (!e.clipboardData) return;
+
+    const hasFiles =
+      e.clipboardData.types.includes("Files") ||
+      e.clipboardData.files.length > 0;
+
+    // Web-copied images also set "Files" but have no file URLs, so fall
+    // through to the image-save path when ReadClipboardFiles returns nothing.
+    if (hasFiles) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      const textFallback = e.clipboardData.getData("text/plain");
+      // Capture blob synchronously — clipboardData.items is invalidated
+      // after the event handler returns.
+      const imageData = extractImageBlob(e.clipboardData.items);
+      const fallback = () => {
+        if (imageData) saveImageBlob(terminalId, imageData.blob, imageData.mimeType);
+        else if (textFallback) sendTerminalInput(terminalId, textFallback);
+      };
+      ReadClipboardFiles()
+        .then((paths) => {
+          if (paths && paths.length > 0) {
+            sendTerminalInput(terminalId, paths.map(shellQuote).join(" "));
+          } else {
+            fallback();
+          }
+        })
+        .catch(fallback);
+      return;
+    }
+
+    const imgData = extractImageBlob(e.clipboardData.items);
+    if (imgData) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      saveImageBlob(terminalId, imgData.blob, imgData.mimeType);
+      return;
+    }
+    // No files or images — let the event propagate so xterm.js handles text paste
+  };
+  const textarea = term.textarea;
+  textarea?.addEventListener("paste", handlePaste, true);
+
+  const cleanupOutput = EventsOn("pty-output-" + terminalId, (data: string) => {
+    writeData(data);
+  });
+
+  const cleanupExit = EventsOn(
+    "pty-exit-" + terminalId,
+    (exitCode: number) => {
+      markDead(`[Process exited with code ${exitCode}]`, "90");
+      session.onExit?.(exitCode);
+    },
+  );
+
+  session.destroy = () => {
+    textarea?.removeEventListener("paste", handlePaste, true);
+    if (typeof cleanupOutput === "function") cleanupOutput();
+    if (typeof cleanupExit === "function") cleanupExit();
+  };
+
+  return session;
+}
+
+function getOrCreateInteractiveSession(terminalId: string): InteractiveSession {
+  const existing = interactiveSessions.get(terminalId);
+  if (existing) return existing;
+  const session = createInteractiveSession(terminalId);
+  interactiveSessions.set(terminalId, session);
+  return session;
 }
 
 export function InteractivePane({
@@ -72,41 +417,36 @@ export function InteractivePane({
   ref,
 }: InteractivePaneProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const termRef = useRef<Terminal | null>(null);
-  const fitRef = useRef<FitAddon | null>(null);
-  const searchRef = useRef<SearchAddon | null>(null);
+  const sessionRef = useRef<InteractiveSession | null>(null);
   const scrollCallbackRef = useRef(onScrollStateChange);
   const themeOverrideRef = useRef(themeOverride);
   const onExitRef = useRef(onExit);
-  const visibleRef = useRef(visible);
-  const flushRef = useRef<(() => void) | null>(null);
   scrollCallbackRef.current = onScrollStateChange;
   themeOverrideRef.current = themeOverride;
   onExitRef.current = onExit;
 
   useImperativeHandle(ref, () => ({
     clear() {
-      const term = termRef.current;
-      if (term) term.clear();
+      const session = sessionRef.current;
+      if (session) session.term.clear();
     },
     findNext(query: string) {
-      return searchRef.current?.findNext(query) ?? false;
+      return sessionRef.current?.search?.findNext(query) ?? false;
     },
     findPrevious(query: string) {
-      return searchRef.current?.findPrevious(query) ?? false;
+      return sessionRef.current?.search?.findPrevious(query) ?? false;
     },
     clearSearch() {
-      searchRef.current?.clearDecorations();
+      sessionRef.current?.search?.clearDecorations();
     },
     scrollToBottom() {
-      const term = termRef.current;
-      if (term) {
-        term.scrollToBottom();
-        scrollCallbackRef.current?.(true);
-      }
+      const session = sessionRef.current;
+      if (!session) return;
+      session.term.scrollToBottom();
+      scrollCallbackRef.current?.(true);
     },
     focus() {
-      termRef.current?.focus();
+      sessionRef.current?.term.focus();
     },
   }));
 
@@ -116,244 +456,21 @@ export function InteractivePane({
 
     initFileDrop();
 
-    const term = new Terminal({
-      fontSize,
-      fontFamily: "'SF Mono', Menlo, Monaco, 'Courier New', monospace",
-      cursorBlink: true,
-      disableStdin: false,
-      scrollback: 10000,
-      theme: themeOverride ?? getTerminalTheme(el),
-      allowProposedApi: true,
-      vtExtensions: { kittyKeyboard: true },
-    });
+    const session = getOrCreateInteractiveSession(terminalId);
+    sessionRef.current = session;
 
-    const fit = new FitAddon();
-    term.loadAddon(fit);
+    session.term.options.fontSize = fontSize;
+    session.term.options.theme =
+      themeOverrideRef.current ?? getTerminalTheme(el);
+    session.themeOverride = themeOverrideRef.current ?? null;
+    session.onScrollState = (atBottom) => scrollCallbackRef.current?.(atBottom);
+    session.onExit = (code) => onExitRef.current?.(code);
+
+    el.appendChild(session.host);
 
     try {
-      const s = new SearchAddon();
-      term.loadAddon(s);
-      searchRef.current = s;
+      session.fit.fit();
     } catch {}
-    try {
-      term.loadAddon(new WebLinksAddon((_e, uri) => BrowserOpenURL(uri)));
-    } catch {}
-    try {
-      const u = new Unicode11Addon();
-      term.loadAddon(u);
-      term.unicode.activeVersion = "11";
-    } catch {}
-
-    // Intercept Cmd+key combos before kitty keyboard protocol encodes them.
-    // Without this, Cmd+V/C/etc. are sent as CSI u sequences instead of
-    // triggering paste/copy/other OS-level shortcuts.
-    term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
-      if (!e.metaKey) return true;
-      if (e.key === "v") {
-        return false;
-      }
-      if (e.key === "c" && e.type === "keydown") {
-        const selection = term.getSelection();
-        if (selection) navigator.clipboard.writeText(selection).catch(() => {});
-        return false;
-      }
-      // Let all other Cmd+key combos fall through to the browser
-      return false;
-    });
-
-    term.open(el);
-    termRef.current = term;
-    fitRef.current = fit;
-
-    // Load WebGL addon for GPU-accelerated rendering
-    import("@xterm/addon-webgl")
-      .then(({ WebglAddon }) => {
-        if (!termRef.current) return;
-        try {
-          const webgl = new WebglAddon();
-          webgl.onContextLoss(() => webgl.dispose());
-          term.loadAddon(webgl);
-        } catch {}
-      })
-      .catch(() => {});
-
-    try {
-      fit.fit();
-    } catch {}
-
-    // Flow control: batch acks to reduce IPC calls
-    let unsentAck = 0;
-    const ackData = (charCount: number) => {
-      unsentAck += charCount;
-      while (unsentAck >= ACK_SIZE) {
-        unsentAck -= ACK_SIZE;
-        AckTerminalData(terminalId, ACK_SIZE).catch(() => {});
-      }
-    };
-
-    // Visibility-gated write: when hidden, buffer data; flush on visible.
-    // Capped to prevent unbounded memory growth from long-running background output.
-    // Don't ack while hidden — let backend flow control pause naturally.
-    // Ack on flush so xterm.js renders before backend resumes sending.
-    // Overflow: ack-and-drop so backend unacked doesn't get a permanent floor
-    // (otherwise the reader can stay paused forever after the next pause).
-    let hiddenBuf: string[] = [];
-    let hiddenBufLen = 0;
-    const writeData = (data: string) => {
-      if (!visibleRef.current) {
-        if (hiddenBufLen < HIDDEN_BUF_CAP) {
-          hiddenBuf.push(data);
-          hiddenBufLen += data.length;
-        } else {
-          ackData(data.length);
-        }
-        return;
-      }
-      term.write(data, () => ackData(data.length));
-    };
-    const flushHiddenBuf = () => {
-      if (hiddenBuf.length === 0) return;
-      const joined = hiddenBuf.join("");
-      hiddenBuf = [];
-      hiddenBufLen = 0;
-      term.write(joined, () => ackData(joined.length));
-    };
-    flushRef.current = flushHiddenBuf;
-
-    // Sync initial size to PTY
-    ResizeTerminal(terminalId, term.cols, term.rows).catch(() => {});
-
-    let sessionDead = false;
-    const markDead = (msg: string, ansiColor: string) => {
-      if (sessionDead) return;
-      sessionDead = true;
-      term.options.disableStdin = true;
-      term.options.cursorBlink = false;
-      term.write(`\r\n\x1b[${ansiColor}m${msg}\x1b[0m\r\n`);
-    };
-
-    const handleWriteError = () => markDead("[Session disconnected]", "91");
-
-    term.onData((data) => {
-      sendTerminalInput(terminalId, data).catch(handleWriteError);
-    });
-
-    // Send binary data (mouse events, etc.) to PTY
-    term.onBinary((data) => {
-      sendTerminalInput(terminalId, data).catch(handleWriteError);
-    });
-
-    // Sync resize to PTY
-    term.onResize(({ cols, rows }) => {
-      ResizeTerminal(terminalId, cols, rows).catch(() => {});
-    });
-
-    // Scroll tracking
-    term.onScroll(() => {
-      const buf = term.buffer.active;
-      const atBottom = buf.baseY + term.rows >= buf.length;
-      scrollCallbackRef.current?.(atBottom);
-    });
-
-
-    const saveImageBlob = (blob: File, mimeType: string) => {
-      const reader = new FileReader();
-      reader.onload = () => {
-        const dataUrl = reader.result as string;
-        const b64 = dataUrl.split(",")[1];
-        if (!b64) return;
-        SaveClipboardImage(b64, mimeType)
-          .then((filePath) => {
-            sendTerminalInput(terminalId, shellQuote(filePath));
-          })
-          .catch((err) => console.warn("SaveClipboardImage failed:", err));
-      };
-      reader.readAsDataURL(blob);
-    };
-
-    // Must be called during the paste event — items are invalidated after.
-    const extractImageBlob = (
-      items: DataTransferItemList,
-    ): { blob: File; mimeType: string } | null => {
-      for (const item of items) {
-        if (item.type.startsWith("image/")) {
-          const blob = item.getAsFile();
-          if (blob) return { blob, mimeType: item.type };
-        }
-      }
-      return null;
-    };
-
-    // Attached to term.textarea — that's where xterm.js focuses and receives paste events.
-    const handlePaste = (e: ClipboardEvent) => {
-      if (!e.clipboardData) return;
-
-      const hasFiles =
-        e.clipboardData.types.includes("Files") ||
-        e.clipboardData.files.length > 0;
-
-      // Web-copied images also set "Files" but have no file URLs, so fall
-      // through to the image-save path when ReadClipboardFiles returns nothing.
-      if (hasFiles) {
-        e.preventDefault();
-        e.stopImmediatePropagation();
-        const textFallback = e.clipboardData.getData("text/plain");
-        // Capture blob synchronously — clipboardData.items is invalidated
-        // after the event handler returns.
-        const imageData = extractImageBlob(e.clipboardData.items);
-        const fallback = () => {
-          if (imageData) saveImageBlob(imageData.blob, imageData.mimeType);
-          else if (textFallback) sendTerminalInput(terminalId, textFallback);
-        };
-        ReadClipboardFiles()
-          .then((paths) => {
-            if (paths && paths.length > 0) {
-              sendTerminalInput(terminalId, paths.map(shellQuote).join(" "));
-            } else {
-              fallback();
-            }
-          })
-          .catch(fallback);
-        return;
-      }
-
-      const imgData = extractImageBlob(e.clipboardData.items);
-      if (imgData) {
-        e.preventDefault();
-        e.stopImmediatePropagation();
-        saveImageBlob(imgData.blob, imgData.mimeType);
-        return;
-      }
-      // No files or images — let the event propagate so xterm.js handles text paste
-    };
-    const textarea = term.textarea;
-    textarea?.addEventListener("paste", handlePaste, true);
-
-    // Theme sync
-    const globalObserver = new MutationObserver(() => {
-      if (!themeOverrideRef.current) term.options.theme = getTerminalTheme(el);
-    });
-    globalObserver.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["data-theme"],
-    });
-
-    // Receive PTY output as plain strings, write with callback for flow control
-    const cleanupOutput = EventsOn(
-      "pty-output-" + terminalId,
-      (data: string) => {
-        writeData(data);
-      },
-    );
-
-    // Handle PTY exit
-    const cleanupExit = EventsOn(
-      "pty-exit-" + terminalId,
-      (exitCode: number) => {
-        markDead(`[Process exited with code ${exitCode}]`, "90");
-        onExitRef.current?.(exitCode);
-      },
-    );
 
     // Resize observer — debounced at 200ms to avoid garbled redraws during
     // the sidebar's CSS transition (transition-[width] duration-200)
@@ -362,62 +479,59 @@ export function InteractivePane({
       if (resizeTimer) clearTimeout(resizeTimer);
       resizeTimer = window.setTimeout(() => {
         resizeTimer = 0;
-        if (!el.clientWidth || !el.clientHeight) return;
+        if (!session.host.clientWidth || !session.host.clientHeight) return;
         try {
-          fit.fit();
+          session.fit.fit();
         } catch {}
       }, 200);
     });
-    ro.observe(el);
+    ro.observe(session.host);
 
-    term.focus();
+    session.term.focus();
 
     return () => {
       if (resizeTimer) clearTimeout(resizeTimer);
-      textarea?.removeEventListener("paste", handlePaste, true);
-      globalObserver.disconnect();
       ro.disconnect();
-      if (typeof cleanupOutput === "function") cleanupOutput();
-      if (typeof cleanupExit === "function") cleanupExit();
-      term.dispose();
-      termRef.current = null;
-      fitRef.current = null;
-      searchRef.current = null;
-      flushRef.current = null;
+      session.onScrollState = undefined;
+      session.onExit = undefined;
+      if (session.host.parentNode) {
+        session.host.parentNode.removeChild(session.host);
+      }
+      sessionRef.current = null;
     };
   }, [terminalId]);
 
   useEffect(() => {
-    const term = termRef.current;
-    if (!term) return;
-    term.options.theme =
+    const session = sessionRef.current;
+    if (!session) return;
+    session.themeOverride = themeOverride ?? null;
+    session.term.options.theme =
       themeOverride ?? getTerminalTheme(containerRef.current);
   }, [themeOverride]);
 
   useEffect(() => {
-    const term = termRef.current;
-    const fit = fitRef.current;
-    if (term && fit) {
-      term.options.fontSize = fontSize;
-      try {
-        fit.fit();
-      } catch {}
-    }
+    const session = sessionRef.current;
+    if (!session) return;
+    session.term.options.fontSize = fontSize;
+    try {
+      session.fit.fit();
+    } catch {}
   }, [fontSize]);
 
   useEffect(() => {
+    const session = sessionRef.current;
+    if (!session) return;
     if (!visible) {
-      visibleRef.current = false;
+      session.visible = false;
       return;
     }
-    // Flush synchronously before flipping visibleRef so any pty-output
+    // Flush synchronously before flipping visible so any pty-output
     // events arriving after this point see an empty buffer and write
     // directly in order — no flush/write race.
-    flushRef.current?.();
-    visibleRef.current = true;
-    const term = termRef.current;
-    const fit = fitRef.current;
-    if (!term || !fit) return;
+    session.flush();
+    session.visible = true;
+    const term = session.term;
+    const fit = session.fit;
     requestAnimationFrame(() => {
       try {
         fit.fit();

--- a/desktop/frontend/src/components/InteractivePane.tsx
+++ b/desktop/frontend/src/components/InteractivePane.tsx
@@ -91,7 +91,6 @@ interface InteractiveSession {
   visible: boolean;
   hiddenBuf: string[];
   hiddenBufLen: number;
-  unsentAck: number;
   sessionDead: boolean;
 
   // Installed by the current React mount, cleared on unmount so callbacks
@@ -105,6 +104,16 @@ interface InteractiveSession {
 }
 
 const interactiveSessions = new Map<string, InteractiveSession>();
+
+function disposeSession(s: InteractiveSession) {
+  s.destroy();
+  s.term.dispose();
+  s.host.remove();
+}
+
+export function isInteractivePaneSessionDead(terminalId: string): boolean {
+  return interactiveSessions.get(terminalId)?.sessionDead ?? false;
+}
 
 // One MutationObserver and one getComputedStyle per theme flip. Per-host
 // lookups would be both wasteful (every session resolves through the same
@@ -127,9 +136,7 @@ function ensureThemeObserver() {
 export function disposeInteractivePaneSession(terminalId: string) {
   const s = interactiveSessions.get(terminalId);
   if (!s) return;
-  s.destroy();
-  s.term.dispose();
-  s.host.remove();
+  disposeSession(s);
   interactiveSessions.delete(terminalId);
 }
 
@@ -143,11 +150,7 @@ if (viteHot) {
   viteHot.dispose(() => {
     OnFileDropOff();
     fileDropInitialized = false;
-    for (const s of interactiveSessions.values()) {
-      s.destroy();
-      s.term.dispose();
-      s.host.remove();
-    }
+    for (const s of interactiveSessions.values()) disposeSession(s);
     interactiveSessions.clear();
     themeObserver?.disconnect();
     themeObserver = null;
@@ -236,7 +239,6 @@ function createInteractiveSession(terminalId: string): InteractiveSession {
 
   term.open(host);
 
-  // Load WebGL addon for GPU-accelerated rendering
   import("@xterm/addon-webgl")
     .then(({ WebglAddon }) => {
       try {
@@ -255,7 +257,6 @@ function createInteractiveSession(terminalId: string): InteractiveSession {
     visible: true,
     hiddenBuf: [],
     hiddenBufLen: 0,
-    unsentAck: 0,
     sessionDead: false,
     themeOverride: null,
     flush: () => {},
@@ -264,11 +265,11 @@ function createInteractiveSession(terminalId: string): InteractiveSession {
 
   ensureThemeObserver();
 
-  // Flow control: batch acks to reduce IPC calls
+  let unsentAck = 0;
   const ackData = (charCount: number) => {
-    session.unsentAck += charCount;
-    while (session.unsentAck >= ACK_SIZE) {
-      session.unsentAck -= ACK_SIZE;
+    unsentAck += charCount;
+    while (unsentAck >= ACK_SIZE) {
+      unsentAck -= ACK_SIZE;
       AckTerminalData(terminalId, ACK_SIZE).catch(() => {});
     }
   };
@@ -313,24 +314,20 @@ function createInteractiveSession(terminalId: string): InteractiveSession {
     sendTerminalInput(terminalId, data).catch(handleWriteError);
   });
 
-  // Send binary data (mouse events, etc.) to PTY
   term.onBinary((data) => {
     sendTerminalInput(terminalId, data).catch(handleWriteError);
   });
 
-  // Sync resize to PTY
   term.onResize(({ cols, rows }) => {
     ResizeTerminal(terminalId, cols, rows).catch(() => {});
   });
 
-  // Scroll tracking
   term.onScroll(() => {
     const buf = term.buffer.active;
     const atBottom = buf.baseY + term.rows >= buf.length;
     session.onScrollState?.(atBottom);
   });
 
-  // Sync initial size to PTY
   ResizeTerminal(terminalId, term.cols, term.rows).catch(() => {});
 
   // Attached to term.textarea — that's where xterm.js focuses and receives paste events.
@@ -544,13 +541,11 @@ export function InteractivePane({
   }, [visible]);
 
   return (
-    <div
-      className="flex min-h-0 flex-1 flex-col overflow-hidden"
-      data-terminal-id={terminalId}
-    >
-      <div className="relative min-h-0 min-w-0 flex-1">
-        <div ref={containerRef} className="absolute inset-0 overflow-hidden" />
-      </div>
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div
+        ref={containerRef}
+        className="relative min-h-0 min-w-0 flex-1 overflow-hidden"
+      />
     </div>
   );
 }

--- a/desktop/frontend/src/components/ProjectDetail.tsx
+++ b/desktop/frontend/src/components/ProjectDetail.tsx
@@ -161,8 +161,9 @@ export function ProjectDetail({
         for (const [k, v] of Object.entries(inputValues)) {
           cmd = cmd.replaceAll(`{{${k}}}`, v);
         }
-        const opts = (action.cwd || action.env || action.reuse)
-          ? { cwd: action.cwd, env: action.env, actionName: action.reuse ? action.name : undefined }
+        const actionName = action.reuse ? action.name : undefined;
+        const opts = (action.cwd || action.env || actionName)
+          ? { cwd: action.cwd, env: action.env, actionName }
           : undefined;
         await terminalViewRef.current?.createTerminalWithCmd(action.label, cmd, opts);
       } catch (err) {

--- a/desktop/frontend/src/components/ProjectDetail.tsx
+++ b/desktop/frontend/src/components/ProjectDetail.tsx
@@ -161,7 +161,9 @@ export function ProjectDetail({
         for (const [k, v] of Object.entries(inputValues)) {
           cmd = cmd.replaceAll(`{{${k}}}`, v);
         }
-        const opts = (action.cwd || action.env) ? { cwd: action.cwd, env: action.env } : undefined;
+        const opts = (action.cwd || action.env || action.reuse)
+          ? { cwd: action.cwd, env: action.env, ...(action.reuse ? { actionName: action.name } : {}) }
+          : undefined;
         await terminalViewRef.current?.createTerminalWithCmd(action.label, cmd, opts);
       } catch (err) {
         toast.error(`${action.label}: ${err}`);

--- a/desktop/frontend/src/components/ProjectDetail.tsx
+++ b/desktop/frontend/src/components/ProjectDetail.tsx
@@ -162,7 +162,7 @@ export function ProjectDetail({
           cmd = cmd.replaceAll(`{{${k}}}`, v);
         }
         const opts = (action.cwd || action.env || action.reuse)
-          ? { cwd: action.cwd, env: action.env, ...(action.reuse ? { actionName: action.name } : {}) }
+          ? { cwd: action.cwd, env: action.env, actionName: action.reuse ? action.name : undefined }
           : undefined;
         await terminalViewRef.current?.createTerminalWithCmd(action.label, cmd, opts);
       } catch (err) {

--- a/desktop/frontend/src/components/TerminalView.tsx
+++ b/desktop/frontend/src/components/TerminalView.tsx
@@ -3,7 +3,8 @@ import { EventsOn } from "../../wailsjs/runtime/runtime";
 import { GetServiceLogs, StartLogStreaming, StopLogStreaming, ClearStatus } from "../../wailsjs/go/main/App";
 import type { ITheme } from "@xterm/xterm";
 import { disposePaneSession, type PaneHandle } from "./Pane";
-import type { InteractivePaneHandle } from "./InteractivePane";
+import { disposeInteractivePaneSession, type InteractivePaneHandle } from "./InteractivePane";
+import { collectTerminals } from "../paneTree";
 import { PaneLayout } from "./PaneLayout";
 import type { ServiceTabInfo, StatusKind } from "./PaneView";
 import { type TerminalThemeName, getTerminalThemeColors, terminalThemeCssVars } from "../terminal-themes";
@@ -126,6 +127,37 @@ export function TerminalView({ projectName, services, terminalTheme, onTerminalC
     return () => {
       for (const key of serviceKeysRef.current) disposePaneSession(key);
       serviceKeysRef.current = [];
+    };
+  }, []);
+
+  // Dispose cached xterm sessions for terminals that leave the tree, so
+  // close-tab/close-pane doesn't leak the xterm buffer and PTY listeners.
+  const interactiveKeysRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    const prev = interactiveKeysRef.current;
+    const next = new Set<string>();
+    // Walk once while also checking membership against prev, so that
+    // drags (which produce a fresh tree reference every frame with an
+    // unchanged id set) can short-circuit before touching the ref.
+    let sameAsPrev = true;
+    if (tree) {
+      for (const t of collectTerminals(tree)) {
+        next.add(t.id);
+        if (sameAsPrev && !prev.has(t.id)) sameAsPrev = false;
+      }
+    }
+    if (sameAsPrev && next.size === prev.size) return;
+    for (const id of prev) {
+      if (!next.has(id)) disposeInteractivePaneSession(id);
+    }
+    interactiveKeysRef.current = next;
+  }, [tree]);
+
+  useEffect(() => {
+    return () => {
+      for (const id of interactiveKeysRef.current) disposeInteractivePaneSession(id);
+      interactiveKeysRef.current.clear();
     };
   }, []);
 

--- a/desktop/frontend/src/hooks/useTerminals.ts
+++ b/desktop/frontend/src/hooks/useTerminals.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { StartTerminal, StartTerminalForConfig, StartTerminalWithCwdEnv, StopTerminal } from "../../wailsjs/go/main/App";
 import { EventsOn } from "../../wailsjs/runtime/runtime";
 import { sendTerminalInput } from "../terminal-io";
+import { isInteractivePaneSessionDead } from "../components/InteractivePane";
 import { getProjectTerminals, saveProjectTerminals, type PersistedPaneNode, type PersistedTerminalEntry } from "../terminals";
 import {
   type PaneNode,
@@ -265,12 +266,16 @@ export function useTerminals(
 
   const createTerminalWithCmd = useCallback(
     async (label: string, cmd: string, opts?: TerminalStartOpts) => {
-      // When reuse is requested, find an existing terminal tagged with the
-      // same actionName. If found, focus it and re-send the command instead
-      // of spawning a new PTY.
+      // When reuse is requested, find an existing live terminal tagged with
+      // the same actionName. A dead session (process exited) falls through
+      // so the user gets a fresh PTY instead of typing into a dead tab.
       if (opts?.actionName && treeRef.current) {
         for (const pane of collectPanes(treeRef.current)) {
-          const idx = pane.tabs.findIndex((t) => t.actionName === opts.actionName);
+          const idx = pane.tabs.findIndex(
+            (t) =>
+              t.actionName === opts.actionName &&
+              !isInteractivePaneSessionDead(t.id),
+          );
           if (idx !== -1) {
             applyTree(mapPane(treeRef.current, pane.id, (p) => ({
               ...p,

--- a/desktop/frontend/src/hooks/useTerminals.ts
+++ b/desktop/frontend/src/hooks/useTerminals.ts
@@ -11,6 +11,7 @@ import {
   makePaneLeaf,
   makeTerminal,
   walkPanes,
+  collectPanes,
   collectTerminals,
   findPane,
   firstPaneId,
@@ -268,22 +269,17 @@ export function useTerminals(
       // same actionName. If found, focus it and re-send the command instead
       // of spawning a new PTY.
       if (opts?.actionName && treeRef.current) {
-        let found: { paneId: string; tabIdx: number; termId: string } | null = null;
-        walkPanes(treeRef.current, (pane) => {
-          if (found) return;
+        for (const pane of collectPanes(treeRef.current)) {
           const idx = pane.tabs.findIndex((t) => t.actionName === opts.actionName);
-          if (idx !== -1) found = { paneId: pane.id, tabIdx: idx, termId: pane.tabs[idx].id };
-        });
-        if (found) {
-          const { paneId, tabIdx, termId } = found;
-          const next = mapPane(treeRef.current, paneId, (p) => ({
-            ...p,
-            activeTabIdx: tabIdx,
-            activeServiceName: undefined,
-          }));
-          applyTree(next, paneId);
-          await sendTerminalInput(termId, cmd + "\n");
-          return;
+          if (idx !== -1) {
+            applyTree(mapPane(treeRef.current, pane.id, (p) => ({
+              ...p,
+              activeTabIdx: idx,
+              activeServiceName: undefined,
+            })), pane.id);
+            await sendTerminalInput(pane.tabs[idx].id, cmd + "\n");
+            return;
+          }
         }
       }
 
@@ -294,7 +290,7 @@ export function useTerminals(
       if (opts?.configName) {
         const launch = await StartTerminalForConfig(projectName, opts.configName);
         const term = launch.resumeCmd
-          ? makeTerminal(launch.id, label, launch.startCmd, launch.resumeCmd)
+          ? makeTerminal(launch.id, label, { startCmd: launch.startCmd, resumeCmd: launch.resumeCmd })
           : makeTerminal(launch.id, label);
         addTerminal(term);
         scheduleCmdInject(launch.id, launch.startCmd);
@@ -306,7 +302,7 @@ export function useTerminals(
       const id = (opts?.cwd || opts?.env)
         ? await StartTerminalWithCwdEnv(projectName, opts.cwd ?? "", opts.env ?? {})
         : await StartTerminal(projectName);
-      addTerminal(makeTerminal(id, label, undefined, undefined, opts?.actionName));
+      addTerminal(makeTerminal(id, label, opts?.actionName ? { actionName: opts.actionName } : undefined));
       scheduleCmdInject(id, cmd);
     },
     [projectName, addTerminal, applyTree, scheduleCmdInject],
@@ -598,7 +594,11 @@ async function reifyTreeWithFreshPtys(
       const ids = await Promise.all(persistedTabs.map(() => StartTerminal(projectName)));
       ids.forEach((id) => startedIds.push(id));
       const tabs = ids.map((id, i) =>
-        makeTerminal(id, persistedTabs[i].label ?? "Terminal", persistedTabs[i].startCmd, persistedTabs[i].resumeCmd, persistedTabs[i].actionName),
+        makeTerminal(id, persistedTabs[i].label ?? "Terminal", {
+          startCmd: persistedTabs[i].startCmd,
+          resumeCmd: persistedTabs[i].resumeCmd,
+          actionName: persistedTabs[i].actionName,
+        }),
       );
       const pane = makePaneLeaf(nextPaneId(), tabs, clampIdx(node.activeTabIdx, tabs.length));
       if (node.activeServiceName) pane.activeServiceName = node.activeServiceName;

--- a/desktop/frontend/src/hooks/useTerminals.ts
+++ b/desktop/frontend/src/hooks/useTerminals.ts
@@ -27,6 +27,7 @@ export interface TerminalStartOpts {
   configName?: string;
   cwd?: string;
   env?: Record<string, string>;
+  actionName?: string;
 }
 
 // Injection waits for pty output to go quiet for PROMPT_IDLE_MS before
@@ -263,6 +264,29 @@ export function useTerminals(
 
   const createTerminalWithCmd = useCallback(
     async (label: string, cmd: string, opts?: TerminalStartOpts) => {
+      // When reuse is requested, find an existing terminal tagged with the
+      // same actionName. If found, focus it and re-send the command instead
+      // of spawning a new PTY.
+      if (opts?.actionName && treeRef.current) {
+        let found: { paneId: string; tabIdx: number; termId: string } | null = null;
+        walkPanes(treeRef.current, (pane) => {
+          if (found) return;
+          const idx = pane.tabs.findIndex((t) => t.actionName === opts.actionName);
+          if (idx !== -1) found = { paneId: pane.id, tabIdx: idx, termId: pane.tabs[idx].id };
+        });
+        if (found) {
+          const { paneId, tabIdx, termId } = found;
+          const next = mapPane(treeRef.current, paneId, (p) => ({
+            ...p,
+            activeTabIdx: tabIdx,
+            activeServiceName: undefined,
+          }));
+          applyTree(next, paneId);
+          await sendTerminalInput(termId, cmd + "\n");
+          return;
+        }
+      }
+
       // Named configs go through the restore-aware RPC: the Go side owns
       // the session-id rewrite so launch.startCmd is authoritative, and a
       // non-empty resumeCmd is the signal that this terminal opted into
@@ -282,10 +306,10 @@ export function useTerminals(
       const id = (opts?.cwd || opts?.env)
         ? await StartTerminalWithCwdEnv(projectName, opts.cwd ?? "", opts.env ?? {})
         : await StartTerminal(projectName);
-      addTerminal(makeTerminal(id, label));
+      addTerminal(makeTerminal(id, label, undefined, undefined, opts?.actionName));
       scheduleCmdInject(id, cmd);
     },
-    [projectName, addTerminal, scheduleCmdInject],
+    [projectName, addTerminal, applyTree, scheduleCmdInject],
   );
 
   const addTerminalToPane = useCallback(
@@ -574,7 +598,7 @@ async function reifyTreeWithFreshPtys(
       const ids = await Promise.all(persistedTabs.map(() => StartTerminal(projectName)));
       ids.forEach((id) => startedIds.push(id));
       const tabs = ids.map((id, i) =>
-        makeTerminal(id, persistedTabs[i].label ?? "Terminal", persistedTabs[i].startCmd, persistedTabs[i].resumeCmd),
+        makeTerminal(id, persistedTabs[i].label ?? "Terminal", persistedTabs[i].startCmd, persistedTabs[i].resumeCmd, persistedTabs[i].actionName),
       );
       const pane = makePaneLeaf(nextPaneId(), tabs, clampIdx(node.activeTabIdx, tabs.length));
       if (node.activeServiceName) pane.activeServiceName = node.activeServiceName;
@@ -613,6 +637,7 @@ function treeToPersisted(node: PaneNode): PersistedPaneNode {
         label: t.label,
         ...(t.startCmd ? { startCmd: t.startCmd } : {}),
         ...(t.resumeCmd ? { resumeCmd: t.resumeCmd } : {}),
+        ...(t.actionName ? { actionName: t.actionName } : {}),
       })),
     };
   }

--- a/desktop/frontend/src/paneTree.ts
+++ b/desktop/frontend/src/paneTree.ts
@@ -10,6 +10,7 @@ export interface TerminalInstance {
   label: string;
   startCmd?: string;
   resumeCmd?: string;
+  actionName?: string;
 }
 
 export interface PaneLeaf {
@@ -38,8 +39,8 @@ export function makePaneLeaf(id: string, tabs: TerminalInstance[], activeTabIdx 
   return { kind: "leaf", id, tabs, activeTabIdx };
 }
 
-export function makeTerminal(id: string, label: string, startCmd?: string, resumeCmd?: string): TerminalInstance {
-  return { id, label, ...(startCmd ? { startCmd } : {}), ...(resumeCmd ? { resumeCmd } : {}) };
+export function makeTerminal(id: string, label: string, startCmd?: string, resumeCmd?: string, actionName?: string): TerminalInstance {
+  return { id, label, ...(startCmd ? { startCmd } : {}), ...(resumeCmd ? { resumeCmd } : {}), ...(actionName ? { actionName } : {}) };
 }
 
 export function walkPanes(node: PaneNode, fn: (pane: PaneLeaf) => void): void {

--- a/desktop/frontend/src/paneTree.ts
+++ b/desktop/frontend/src/paneTree.ts
@@ -39,8 +39,12 @@ export function makePaneLeaf(id: string, tabs: TerminalInstance[], activeTabIdx 
   return { kind: "leaf", id, tabs, activeTabIdx };
 }
 
-export function makeTerminal(id: string, label: string, startCmd?: string, resumeCmd?: string, actionName?: string): TerminalInstance {
-  return { id, label, ...(startCmd ? { startCmd } : {}), ...(resumeCmd ? { resumeCmd } : {}), ...(actionName ? { actionName } : {}) };
+export function makeTerminal(
+  id: string,
+  label: string,
+  opts?: { startCmd?: string; resumeCmd?: string; actionName?: string },
+): TerminalInstance {
+  return { id, label, ...(opts?.startCmd ? { startCmd: opts.startCmd } : {}), ...(opts?.resumeCmd ? { resumeCmd: opts.resumeCmd } : {}), ...(opts?.actionName ? { actionName: opts.actionName } : {}) };
 }
 
 export function walkPanes(node: PaneNode, fn: (pane: PaneLeaf) => void): void {

--- a/desktop/frontend/src/terminals.ts
+++ b/desktop/frontend/src/terminals.ts
@@ -7,6 +7,7 @@ export interface PersistedTab {
   label: string;
   startCmd?: string;
   resumeCmd?: string;
+  actionName?: string;
 }
 
 // Persisted pane tree shape — mirrors the Go binding (main.PaneNode) so

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -36,6 +36,7 @@ export interface ActionInfo {
   confirm: boolean;
   display: string;
   type?: ActionType;
+  reuse?: boolean;
   inputs?: ActionInputInfo[];
   children?: ActionInfo[];
 }

--- a/desktop/projects.go
+++ b/desktop/projects.go
@@ -114,6 +114,7 @@ type ActionInfo struct {
 	Confirm  bool              `json:"confirm"`
 	Display  string            `json:"display"`
 	Type     string            `json:"type"`
+	Reuse    bool              `json:"reuse"`
 	Inputs   []ActionInputInfo `json:"inputs,omitempty"`
 	Children []ActionInfo      `json:"children,omitempty"`
 }
@@ -206,6 +207,7 @@ func toProjectInfo(name string, cfg *config.ProjectConfig, running bool, state r
 					Confirm: child.Confirm,
 					Display: child.Display,
 					Type:    child.Type,
+					Reuse:   child.Reuse,
 					Inputs:  buildInputInfos(child.Inputs),
 				})
 			}
@@ -220,6 +222,7 @@ func toProjectInfo(name string, cfg *config.ProjectConfig, running bool, state r
 			Confirm:  act.Confirm,
 			Display:  act.Display,
 			Type:     act.Type,
+			Reuse:    act.Reuse,
 			Inputs:   inputs,
 			Children: children,
 		})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,6 +70,7 @@ type Action struct {
 	Confirm bool                   `yaml:"confirm,omitempty"`
 	Display string                 `yaml:"display,omitempty"`
 	Type    string                 `yaml:"type,omitempty"`
+	Reuse   bool                   `yaml:"reuse,omitempty"`
 	Inputs  map[string]ActionInput `yaml:"inputs,omitempty"`
 	Actions ActionMap              `yaml:"actions,omitempty"`
 }


### PR DESCRIPTION
Adds a `reuse` option for terminal actions that allows re-running commands in an existing terminal instead of spawning a new one each time. When an action has `reuse: true`, the terminal is tagged with the action name, and subsequent runs will focus the existing terminal and re-send the command.

- Add `reuse` boolean field to action config (YAML), Go struct, and TypeScript types
- Tag terminal instances with an optional `actionName` for identification
- Look up existing terminals by `actionName` in `createTerminalWithCmd` before spawning a new PTY
- Persist and restore `actionName` across sessions via the pane tree serialization