### PR TITLE
docs(skill): cover ssh projects, action mode, and footer display

### DIFF
--- a/lpm-config/SKILL.md
+++ b/lpm-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lpm-config
-description: Create, modify, and delete lpm (Local Project Manager) project configs at ~/.lpm/projects/*.yml. Use whenever the user mentions lpm, asks to set up lpm, create/edit/delete an lpm config, add or remove services, actions, or terminals from lpm, or says "lpm setup", "create lpm config", "add service to lpm", "configure lpm". Also trigger when the user wants to add a button or menu action to run commands, manage dev project processes, start/stop multiple services together, group related commands, set up one-shot commands with confirmation prompts, or configure interactive terminal shells through YAML config files. Also triggers when the user wants a background/silent action, a split-button with a default plus alternatives, a dropdown menu of related commands, or asks to edit lpm config for the current directory (cwd) without naming a project. If the user has lpm installed (~/.lpm/ exists), this skill applies to any request about managing project workflows.
+description: Create, modify, and delete lpm (Local Project Manager) project configs at ~/.lpm/projects/*.yml. Use whenever the user mentions lpm, asks to set up lpm, create/edit/delete an lpm config, add or remove services, actions, or terminals from lpm, or says "lpm setup", "create lpm config", "add service to lpm", "configure lpm". Also trigger when the user wants to add a button or menu action to run commands, manage dev project processes, start/stop multiple services together, group related commands, set up one-shot commands with confirmation prompts, or configure interactive terminal shells through YAML config files. Also triggers when the user wants a background/silent action, a split-button with a default plus alternatives, a dropdown menu of related commands, an action pinned to the terminal footer, an SSH/remote project, or a sync-mode action that mirrors a remote directory locally. Also triggers when the user asks to edit lpm config for the current directory (cwd) without naming a project. If the user has lpm installed (~/.lpm/ exists), this skill applies to any request about managing project workflows.
 ---
 
 ## Instructions
@@ -59,6 +59,9 @@ sudo apt install tmux
 | "make it run in background", "notify when done", "run silently" | **Modify** — add action with `type: background` |
 | "button with a default and alternatives" | **Modify** — split-button action group (parent `cmd` + nested `actions`) |
 | "dropdown of related commands", "menu of sub-actions" | **Modify** — dropdown-only action group (nested `actions`, no parent `cmd`) |
+| "pin this to the terminal footer", "tiny button next to the branch switcher" | **Modify** — set `display: footer` on the action/terminal |
+| "set up a remote project over ssh", "lpm for this server", "manage services on a remote host" | **Create** — SSH project (use `ssh:` block, omit `root`) |
+| "run this action locally against the remote files", "rsync the remote dir and run it locally", "let my local Claude Code touch the remote repo" | **Modify** — set `mode: sync` on the action (SSH projects only) |
 
 ### How to Use
 
@@ -150,6 +153,30 @@ When the user asks to add something, ask follow-up questions to pick the right c
 
 → Add the action with `type: background`. The command runs hidden and lpm shows a toast on completion. Common fits: builds, migrations, `docker pull`, `git fetch`, dependency installs. Pair with `confirm: true` when it's destructive.
 
+**"Pin it to the terminal footer / right next to the branch switcher"**
+
+→ Set `display: footer`. The action renders as a compact button in the strip at the bottom of the terminal pane. Use for tight, frequently-used controls (quick-test, redeploy, format) that should always be one click away without taking space in the main button row. Footer also accepts split buttons (parent `cmd` + nested `actions`).
+
+**"Set up a remote project over SSH"**
+
+→ Create a project with an `ssh:` block instead of `root`. Required: `host`, `user`. Optional: `port` (defaults to 22), `key` (identity file path), `dir` (default remote working directory — must be absolute or `~`-prefixed). All services, actions, and terminals run on the remote host over a shared SSH ControlMaster connection. `cwd` values are interpreted as remote paths and are **not** validated locally.
+
+```yaml
+name: prod-api
+ssh:
+  host: api.example.com
+  user: deploy
+  port: 22
+  key: ~/.ssh/id_ed25519
+  dir: ~/apps/api
+services:
+  worker: bin/worker
+```
+
+**"Run this action locally against the remote files" (SSH sync mode)**
+
+→ On SSH projects, set `mode: sync` on the action. lpm rsyncs `ssh.dir` into a local mirror, runs the action locally, then rsyncs changes back. Useful for local tooling that needs filesystem access to the remote repo (local Claude Code, IDE refactors, `prettier --write`, codegen). Default is `mode: remote` (run over SSH on the host) — `sync` is rejected on local projects.
+
 **"Button with a default action plus alternatives" (split button)**
 
 → Action group with `cmd` on the parent AND nested `actions`. Main click runs the parent's command; chevron opens the children. Example: `deploy` that defaults to staging with production/preview tucked behind it.
@@ -206,15 +233,22 @@ Config files are written to `~/.lpm/projects/<name>.yml`. Global config at `~/.l
 
 ```yaml
 name: <string>           # optional — defaults to the config filename
-root: <path>             # required — project root (supports ~)
+root: <path>             # required for local projects (supports ~). Omit when ssh: is set.
 label: <string>          # optional — display name in UI
 parent_name: <string>    # optional — duplicate from parent project
 
-services:                # required — at least one
+ssh:                     # optional — present means a remote/SSH project. Replaces root.
+  host: <string>         # required — remote hostname or IP
+  user: <string>         # required — login user
+  port: <int>            # optional (0-65535, defaults to 22)
+  key: <path>            # optional — path to identity file (~ supported)
+  dir: <path>            # optional — default remote working directory (absolute or ~)
+
+services:                # required — at least one (omitted when parent_name is set)
   <key>: <cmd>           # shorthand
   <key>:                 # full form
     cmd: <string>        # required
-    cwd: <path>          # optional
+    cwd: <path>          # optional (remote path on SSH projects)
     port: <int>          # optional (0-65535, unique)
     env: {}              # optional
     profiles: []         # optional
@@ -224,12 +258,13 @@ actions:                 # optional — one-shot commands
   <key>:                 # full form
     cmd: <string>        # required (unless nested actions)
     label: <string>      # optional — display name in UI
-    cwd: <path>          # optional
+    cwd: <path>          # optional (remote path on SSH projects)
     env: {}              # optional
     confirm: <bool>      # optional (default: false)
-    display: <string>    # optional (button | menu, default: menu)
+    display: <string>    # optional (button | menu | footer, default: menu)
     type: <string>       # optional — "terminal" (pane) or "background" (hidden + toast)
     reuse: <bool>        # optional — reuse same terminal pane
+    mode: <string>       # optional, SSH projects only — "remote" (default) or "sync"
     inputs: {}           # optional — user-prompted parameters
     actions: {}          # optional — nested sub-actions (action group)
 
@@ -238,9 +273,9 @@ terminals:               # optional — interactive shells (sugar for actions wi
   <key>:                 # full form — supports the same fields as actions
     cmd: <string>        # required (unless nested actions)
     label: <string>      # optional
-    cwd: <path>          # optional
+    cwd: <path>          # optional (remote path on SSH projects)
     env: {}              # optional
-    display: <string>    # optional (button | menu, default: menu)
+    display: <string>    # optional (button | menu | footer, default: menu)
     confirm: <bool>      # optional
     reuse: <bool>        # optional — reuse the existing pane on next launch
     inputs: {}           # optional — prompted parameters
@@ -252,27 +287,31 @@ profiles:                # optional — named service subsets
 
 **Key rules:**
 - Shorthand (`test: go test ./...`) when the command needs no options.
-- Full form when you need `cwd`, `env`, `confirm`, `display: button`, `type`, `reuse`, `inputs`, or a `label`.
+- Full form when you need `cwd`, `env`, `confirm`, `display`, `type`, `reuse`, `mode`, `inputs`, or a `label`.
 - Set `confirm: true` on destructive actions (migrations, deploys, cleanup).
-- Set `display: button` on frequently-used actions/terminals.
+- `display: button` for the main button row, `display: footer` for compact controls in the terminal footer (next to the branch switcher), default `menu` for everything else.
 - Use `type: terminal` + `reuse: true` for commands that should stay in one persistent pane (log tailers, watchers).
 - Use `type: background` for slow commands you want to fire and forget — lpm shows a toast when they finish.
-- Action groups: parent `cmd` + nested `actions` renders as a split button; nested `actions` alone renders as a dropdown. Children inherit `cwd` and `env`.
+- Action groups: parent `cmd` + nested `actions` renders as a split button; nested `actions` alone renders as a dropdown. Children inherit `cwd`, `env`, and `mode`.
+- A project is **either** local (set `root`) **or** remote (set `ssh:`, omit `root`) — never both.
+- On SSH projects, `mode: sync` makes an action run locally against an rsync mirror of `ssh.dir`; `mode: remote` (default) runs on the host. `mode: sync` is rejected on local projects.
 - Use `parent_name` to duplicate a project config for a different root directory.
 - Keys: short, lowercase, hyphen-separated (`db-migrate`, `run-tests`).
-- `~` expands to home. Relative `cwd` resolves from `root`. All `cwd` must exist.
+- `~` expands to home. Relative `cwd` resolves from `root` (local projects) or from `ssh.dir` on the remote host (SSH projects). Local `cwd` paths must exist; remote `cwd` paths are not validated locally.
 
 **Validation — verify before writing any config:**
-- `root` is set (`name` is optional — defaults to the config filename)
-- At least one service is defined (unless `parent_name` is set)
-- All `cmd` fields are non-empty strings (actions or terminals with nested `actions` may omit `cmd`)
-- All `cwd` paths point to existing directories
-- All ports are in range 0–65535 with no duplicates across services
-- `display` values are only `button` or `menu`
-- `type` values are only `terminal` or `background` (or omitted)
-- Profile entries reference defined services
-- Nested sub-actions are validated recursively
-- `parent_name` references an existing project
+- Either `root` or `ssh:` is set (but not both); `name` is optional and defaults to the config filename.
+- When `ssh:` is set: `host` and `user` are non-empty; `port` is in 0–65535 (omitted means 22); `dir` is absolute or `~`-prefixed.
+- At least one service is defined (unless `parent_name` is set).
+- All `cmd` fields are non-empty strings (actions or terminals with nested `actions` may omit `cmd`).
+- All `cwd` paths on local projects point to existing directories. SSH projects skip local cwd checks.
+- All ports are in range 0–65535 with no duplicates across services.
+- `display` values are only `button`, `menu`, or `footer`.
+- `type` values are only `terminal` or `background` (or omitted).
+- `mode` values are only `remote` or `sync` (or omitted); `sync` requires an SSH project.
+- Profile entries reference defined services.
+- Nested sub-actions are validated recursively.
+- `parent_name` references an existing project.
 
 ## Examples
 
@@ -452,7 +491,72 @@ Agent: [reads config, adds action — silent cwd match on ~/.lpm/projects/myapp.
          display: button
 ```
 
-**Example 9: Split-button action group**
+**Example 9: Pin an action to the terminal footer**
+```
+User: Add a quick "format" action right next to the branch switcher
+Agent: [adds action with display: footer]
+
+       Added to ~/.lpm/projects/myapp.yml:
+       actions.format:
+         cmd: npm run format
+         label: Format
+         display: footer
+```
+
+**Example 10: SSH project**
+```
+User: Set up lpm for our prod API box, deploy@api.example.com, code lives at ~/apps/api
+Agent: [creates SSH project — root omitted, ssh: block instead]
+
+       Created ~/.lpm/projects/prod-api.yml:
+         ssh: { host: api.example.com, user: deploy, dir: ~/apps/api }
+         services: { worker: bin/worker }
+```
+
+```yaml
+name: prod-api
+ssh:
+  host: api.example.com
+  user: deploy
+  port: 22
+  key: ~/.ssh/id_ed25519
+  dir: ~/apps/api
+
+services:
+  worker: bin/worker
+  api:
+    cmd: bin/server
+    port: 8080
+
+actions:
+  tail-logs:
+    cmd: tail -f log/production.log
+    type: terminal
+    reuse: true
+    display: footer
+
+terminals:
+  remote-shell:
+    cmd: bash -l
+    label: Shell
+    display: button
+```
+
+**Example 11: Sync-mode action on an SSH project**
+```
+User: I want to run Claude Code locally against the remote repo
+Agent: [adds sync-mode action — rsyncs ~/apps/api locally, runs the command, syncs changes back]
+
+       Added to ~/.lpm/projects/prod-api.yml:
+       actions.claude:
+         cmd: claude
+         label: Claude (local)
+         type: terminal
+         mode: sync
+         display: button
+```
+
+**Example 12: Split-button action group**
 ```
 User: Make deploy a button that defaults to staging but lets me pick production or preview
 Agent: [adds split-button group]
@@ -474,7 +578,10 @@ Agent: [adds split-button group]
 ## Limitations
 
 - Project names must be lowercase with no slashes; cannot be `.` or `..`
-- All `cwd` paths must point to existing directories — lpm validates on load
+- All `cwd` paths on local projects must point to existing directories — lpm validates on load
 - Ports must be in range 0–65535 and unique across services
 - Global config only supports `actions` and `terminals` — no services, profiles, name, or root
 - Duplicate projects (`parent_name`) inherit everything — you cannot override individual entries
+- A project cannot have both `root` and `ssh:` — pick one
+- `mode: sync` is only valid on SSH projects and requires `rsync` available locally and on the host
+- SSH projects share a ControlMaster connection per host (`/tmp/lpm-<uid>/cm-<hash>`) — disconnects affect all panes for that host

--- a/lpm-config/references/yaml-schema.md
+++ b/lpm-config/references/yaml-schema.md
@@ -6,14 +6,17 @@ Complete field reference for lpm project config files (`~/.lpm/projects/<name>.y
 
 ```yaml
 name: <string>           # optional — defaults to the config filename
-root: <path>             # required — project root directory (supports ~)
+root: <path>             # required for local projects (supports ~). Omit when ssh: is set.
 label: <string>          # optional — display name in the UI
 parent_name: <string>    # optional — name of parent project (creates a duplicate)
+ssh: {}                  # optional — SSH connection block. Replaces root for remote projects.
 services: {}             # required — at least one service (omitted in duplicates)
 actions: {}              # optional — one-shot commands or action groups
 terminals: {}            # optional — persistent interactive shells
 profiles: {}             # optional — named service subsets
 ```
+
+A project must have **either** `root` (local) **or** `ssh:` (remote), not both.
 
 ---
 
@@ -22,9 +25,10 @@ profiles: {}             # optional — named service subsets
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `name` | string | no | config filename | Project identifier. Lowercase, no slashes, not `.` or `..`. Defaults to the `.yml` filename. |
-| `root` | string | yes | — | Project root directory. Supports `~`. |
+| `root` | string | yes* | — | Project root directory. Supports `~`. *Required for local projects; omit when `ssh:` is set. |
 | `label` | string | no | — | Display name shown in the UI (defaults to `name`). |
 | `parent_name` | string | no | — | Name of a parent project. Creates a **duplicate** that inherits all services, actions, terminals, and profiles from the parent. See [Duplicate Projects](#duplicate-projects). |
+| `ssh` | object | no | — | SSH connection settings — turns the project into a remote one. Services, actions, and terminals run on the host over a shared SSH ControlMaster connection. See [SSH Projects](#ssh-projects). |
 
 ---
 
@@ -236,16 +240,18 @@ Sub-actions inherit `cwd` and `env` from the parent; child values win on conflic
 | `cwd` | string | no | `root` | Working directory. Relative paths resolve from `root`. Supports `~`. Must exist. |
 | `env` | map[string]string | no | — | Environment variables injected into the command. |
 | `confirm` | bool | no | false | Prompt for confirmation before running. Use for destructive or irreversible commands. |
-| `display` | string | no | `menu` | UI placement: `menu` (dropdown) or `button` (visible button). |
+| `display` | string | no | `menu` | UI placement: `menu` (dropdown), `button` (main button row), or `footer` (terminal footer strip). |
 | `type` | string | no | — | Action type. `terminal` runs in a terminal pane; `background` runs hidden and shows a toast on completion. Omit for the default inline runner (modal with streaming output). |
 | `reuse` | bool | no | false | When `type: terminal`, reuse the same terminal pane across runs instead of opening a new one. |
+| `mode` | string | no | — | SSH-only execution mode. `remote` (default on SSH projects) runs the command on the host. `sync` rsyncs `ssh.dir` into a local mirror, runs the action locally, then rsyncs changes back. `sync` is rejected on local projects. See [SSH Action Modes](#ssh-action-modes). |
 | `inputs` | map[string]InputField | no | — | Named inputs prompted before running. Values substitute `{{key}}` in `cmd`. |
-| `actions` | map[string]Action | no | — | Nested sub-actions. Makes this an action group. See [Action Groups](#action-groups-nested-actions). |
+| `actions` | map[string]Action | no | — | Nested sub-actions. Makes this an action group. See [Action Groups](#action-groups-nested-actions). Children inherit `cwd`, `env`, and `mode` from the parent. |
 
 ### `display` Values
 
 - **`menu`** (default) — action appears in a dropdown/overflow menu.
-- **`button`** — action appears as a visible button. Use for frequently-used actions.
+- **`button`** — action appears as a visible button in the main button row. Use for frequently-used actions.
+- **`footer`** — action appears as a compact button in the terminal footer (right next to the branch switcher). Use for tight, always-one-click controls. Footer also accepts split-button groups (parent `cmd` + nested `actions`).
 
 ### Input Fields
 
@@ -307,7 +313,7 @@ terminals:
 | `label` | string | no | key name | Display name shown in the UI. |
 | `cwd` | string | no | `root` | Working directory. Relative paths resolve from `root`. Supports `~`. Must exist. |
 | `env` | map[string]string | no | — | Environment variables injected into the shell. |
-| `display` | string | no | `menu` | UI placement: `menu` (dropdown) or `button` (visible button). |
+| `display` | string | no | `menu` | UI placement: `menu` (dropdown), `button` (visible button), or `footer` (terminal footer strip). |
 | `confirm` | bool | no | false | Prompt before opening. |
 | `reuse` | bool | no | false | Reuse the existing pane on next launch. |
 | `inputs` | map[string]InputField | no | — | Named inputs prompted before opening. Values substitute `{{key}}` in `cmd`. |
@@ -342,6 +348,91 @@ Each service name must reference a service defined in `services`.
 
 ---
 
+## SSH Projects
+
+Set `ssh:` instead of `root` to make a project remote. Services, actions, and terminals run on the host over a shared SSH ControlMaster connection (multiplexed for fast reconnects). Local `cwd` existence is **not** checked — those paths live on the remote host.
+
+```yaml
+name: prod-api
+ssh:
+  host: api.example.com
+  user: deploy
+  port: 22
+  key: ~/.ssh/id_ed25519
+  dir: ~/apps/api
+
+services:
+  worker: bin/worker
+  api:
+    cmd: bin/server
+    port: 8080
+
+actions:
+  migrate:
+    cmd: bin/rails db:migrate
+    confirm: true
+    display: button
+
+terminals:
+  remote-shell:
+    cmd: bash -l
+    display: button
+```
+
+### `ssh` Fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `host` | string | yes | — | Remote hostname or IP. |
+| `user` | string | yes | — | Login user. |
+| `port` | int | no | `22` | TCP port. 0–65535. |
+| `key` | string | no | — | Path to identity file. Supports `~`. Leave empty to use ssh-agent or `~/.ssh/config` defaults. |
+| `dir` | string | no | — | Default remote working directory. Must be absolute or `~`-prefixed (resolved on the host). Action/terminal `cwd` paths resolve relative to this. |
+
+### Connection Behavior
+
+- lpm uses a ControlMaster socket at `/tmp/lpm-<uid>/cm-<hash>` with `ControlPersist=10m`, so multiple panes share one TCP/SSH connection per host.
+- `cwd` on services, actions, and terminals is interpreted as a **remote** path. Relative values resolve from `ssh.dir`.
+- A network drop affects every pane bound to that ControlMaster.
+
+---
+
+## SSH Action Modes
+
+On SSH projects, every action has an effective `mode`:
+
+- **`remote`** (default) — runs the command on the host over SSH. Output streams back to the local pane.
+- **`sync`** — lpm rsyncs `ssh.dir` into a local mirror (under your home), runs the action **locally** in that mirror, then rsyncs changes back. Use this when you want local tooling to act on remote files (local Claude Code, IDE refactors, codegen, `prettier --write` over a large repo).
+
+```yaml
+ssh:
+  host: api.example.com
+  user: deploy
+  dir: ~/apps/api
+
+actions:
+  remote-tests:
+    cmd: bin/rspec
+    # mode: remote (default) — runs on the host
+
+  claude:
+    cmd: claude
+    label: Claude (local)
+    type: terminal
+    mode: sync       # rsync down, run locally, rsync back
+
+  format:
+    cmd: prettier --write .
+    mode: sync
+    display: footer
+```
+
+`mode: sync` is rejected on local projects (no `ssh:` block) — lpm will refuse to load the config. `sync` requires `rsync` available both locally and on the host.
+
+Children of an action group inherit `mode` from the parent unless they set their own.
+
+---
+
 ## Duplicate Projects
 
 A duplicate project inherits **all** services, actions, terminals, and profiles from a parent project. Use this when you want the same project config but with a different `root` directory (e.g., multiple checkouts of the same repo, or a branch worktree):
@@ -362,7 +453,7 @@ Location: `~/.lpm/global.yml`
 
 Supports `actions` and `terminals` only (no `services`, `profiles`, `name`, or `root`). Entries here are available in every project. When a project defines an entry with the same key, the project-level entry wins.
 
-Global entries support the full action/terminal field set — `display`, `confirm`, `type` (including `type: background`), `reuse`, `inputs`, and nested `actions`. There is no stripped-down subset.
+Global entries support the full action/terminal field set — `display` (including `footer`), `confirm`, `type` (including `type: background`), `reuse`, `inputs`, and nested `actions`. There is no stripped-down subset. `mode` is accepted but only meaningful when the entry is invoked from an SSH project.
 
 ```yaml
 actions:
@@ -407,17 +498,17 @@ terminals:
 ## Shorthand vs Full Form
 
 - **Shorthand**: the command is self-explanatory, runs from root, needs no env vars or confirmation.
-- **Full form**: you need `cwd`, `env`, `confirm`, `display: button`, `type`, `reuse`, `inputs`, or a human-friendly `label`.
+- **Full form**: you need `cwd`, `env`, `confirm`, `display`, `type`, `reuse`, `mode`, `inputs`, or a human-friendly `label`.
 
-## When to Use `display: button`
+## Picking a `display` Value
 
-Use for frequently-used items:
-- Running tests
-- Opening a database console
-- Viewing logs
-- Restarting a key service
+| Value | Where it shows | Use for |
+|-------|----------------|---------|
+| `menu` (default) | Dropdown / overflow menu | Anything you don't run constantly. Keeps the UI clean. |
+| `button` | Main button row in the project view | Frequently-used items: tests, database console, logs, restart-key-service. |
+| `footer` | Strip at the bottom of the terminal pane, next to the branch switcher | Tight, always-one-click controls — quick-format, redeploy, run-tests. Footer entries render compact and accept split-buttons. |
 
-Leave less frequent commands at the default `menu` to keep the UI clean.
+Leave less frequent commands at the default `menu` to keep the main UI uncluttered.
 
 ---
 
@@ -425,14 +516,16 @@ Leave less frequent commands at the default `menu` to keep the UI clean.
 
 lpm validates config on load:
 
-1. At least one service is defined (unless it's a duplicate with `parent_name`).
-2. All `cmd` fields are non-empty strings. Actions (and terminals) with nested `actions` may omit `cmd`.
-3. All `cwd` paths point to existing directories.
-4. Ports are in range 0–65535 with no duplicates across services.
-5. `display` is either `button` or `menu` (or omitted for default).
-6. Profile entries reference defined services.
-7. Nested sub-actions are validated recursively (cmd required if no children, cwd must exist).
-8. `parent_name` must reference an existing, loadable project.
+1. The project has either `root` or `ssh:` (but not both). When `ssh:` is set, `host` and `user` are non-empty, `port` is in 0–65535, and `dir` is absolute or `~`-prefixed.
+2. At least one service is defined (unless it's a duplicate with `parent_name`).
+3. All `cmd` fields are non-empty strings. Actions (and terminals) with nested `actions` may omit `cmd`.
+4. All `cwd` paths on local projects point to existing directories. SSH projects skip local cwd checks because `cwd` is a remote path.
+5. Ports are in range 0–65535 with no duplicates across services.
+6. `display` is `button`, `menu`, or `footer` (or omitted for default).
+7. `mode` is `remote` or `sync` (or omitted). `mode: sync` is rejected on local projects.
+8. Profile entries reference defined services.
+9. Nested sub-actions are validated recursively (cmd required if no children, cwd must exist on local projects, mode validated the same way).
+10. `parent_name` must reference an existing, loadable project.
 
 ---
 


### PR DESCRIPTION
## Summary

Brings the `lpm-config` agent skill back in sync with the YAML schema. Three features had landed upstream (SSH projects, `mode: remote | sync`, `display: footer`) but weren't reflected in `lpm-config/SKILL.md` or `lpm-config/references/yaml-schema.md`, so any agent following the skill would miss them or write invalid configs.

Docs-only — no runtime / schema changes.

## What's documented

### 🛰 SSH projects
Top-level `ssh:` block with `host`, `user`, `port`, `key`, `dir`. `root` becomes mutually exclusive with `ssh:` (the schema already enforces `anyOf: [root, ssh]`). Added:
- New **SSH Projects** section in the schema reference (field table, ControlMaster connection note, remote-`cwd` semantics).
- Trigger rows in the skill's When-to-Use table (\"set up a remote project over ssh\").
- Updated structure block, key rules, and a full SSH example.

### 🔁 Action `mode: remote | sync`
SSH-only execution mode. `remote` runs the command on the host (default); `sync` rsyncs `ssh.dir` into a local mirror, runs the action locally, and rsyncs changes back — useful for local tooling that needs filesystem access to a remote repo (local Claude Code, IDE refactors, codegen). Added:
- `mode` row in the action field table.
- New **SSH Action Modes** section with a worked example.
- Validation rule (`mode: sync` is rejected on local projects).
- Trigger row in the skill's When-to-Use table.

### 🪟 `display: footer`
Third value alongside `button` and `menu` — compact button in the terminal footer strip next to the branch switcher. Added:
- Updated `display` enum across action + terminal tables.
- New **Picking a `display` Value** guide explaining when to pick each.
- Trigger row + smart-guidance prose in the skill.
- New \"Pin to footer\" example.
- Note that the global config also accepts `display: footer`.

## Files

- \`lpm-config/SKILL.md\`
- \`lpm-config/references/yaml-schema.md\`

## Test plan

- [x] Docs-only — no code, no schema changes
- [ ] (Optional) sanity-check by asking the skill in a fresh session to \"set up an SSH lpm project\" and confirm it produces an `ssh:` block (not `root:`)