### PR TITLE
Add action editing and context menus

### DIFF
--- a/desktop/frontend/src/actionConfig.ts
+++ b/desktop/frontend/src/actionConfig.ts
@@ -1,0 +1,76 @@
+import YAML from "yaml";
+import {
+  ReadConfig,
+  ReadGlobalConfig,
+  SaveConfig,
+  SaveGlobalConfig,
+} from "../wailsjs/go/main/App";
+
+// Serialize read-modify-write per project (and a single queue for global)
+// so concurrent callers can't interleave reads and clobber each other.
+const writeQueues = new Map<string, Promise<unknown>>();
+const GLOBAL_KEY = "__global__";
+
+function queueWrite<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const prev = writeQueues.get(key) ?? Promise.resolve();
+  const next = prev.catch(() => undefined).then(fn);
+  writeQueues.set(key, next);
+  return next;
+}
+
+async function tryDeleteAction(
+  read: () => Promise<string>,
+  save: (content: string) => Promise<unknown>,
+  key: string,
+): Promise<boolean> {
+  const content = await read();
+  const doc = YAML.parseDocument(content || "{}");
+  // The displayed action list merges `actions:` and `terminals:` (backend
+  // ResolvedActions). Try both sections so right-click delete works for
+  // entries declared under either.
+  let removed = false;
+  for (const section of ["actions", "terminals"] as const) {
+    const node = doc.get(section, true);
+    if (!YAML.isMap(node) || !node.has(key)) continue;
+    node.delete(key);
+    if (node.items.length === 0) doc.delete(section);
+    removed = true;
+    break;
+  }
+  if (!removed) return false;
+  await save(String(doc));
+  return true;
+}
+
+export function appendAction(projectName: string, key: string, payload: Record<string, unknown>) {
+  return queueWrite(projectName, async () => {
+    const content = await ReadConfig(projectName);
+    const doc = YAML.parseDocument(content || "{}");
+    let actions = doc.get("actions", true);
+    if (!YAML.isMap(actions)) {
+      actions = doc.createNode({});
+      doc.set("actions", actions);
+    }
+    if (YAML.isMap(actions)) actions.set(key, payload);
+    await SaveConfig(projectName, String(doc));
+  });
+}
+
+// Per-project entries take precedence in the merge, so try the project YAML
+// first; if the key only lives in the shared global config, fall through
+// and delete it there. When both configs define the same key, removing the
+// project entry lets the global fallback take over — by design, since the
+// user is acting on the project view.
+export function deleteAction(projectName: string, key: string) {
+  return queueWrite(projectName, async () => {
+    const removed = await tryDeleteAction(
+      () => ReadConfig(projectName),
+      (content) => SaveConfig(projectName, content),
+      key,
+    );
+    if (removed) return;
+    await queueWrite(GLOBAL_KEY, () =>
+      tryDeleteAction(ReadGlobalConfig, SaveGlobalConfig, key).then(() => undefined),
+    );
+  });
+}

--- a/desktop/frontend/src/actionConfig.ts
+++ b/desktop/frontend/src/actionConfig.ts
@@ -18,6 +18,17 @@ function queueWrite<T>(key: string, fn: () => Promise<T>): Promise<T> {
   return next;
 }
 
+// The displayed action list merges `actions:` and `terminals:` (backend
+// ResolvedActions). This walks both so edit/delete work for entries declared
+// under either section.
+function findActionSection(doc: ReturnType<typeof YAML.parseDocument>, key: string) {
+  for (const section of ["actions", "terminals"] as const) {
+    const node = doc.get(section, true);
+    if (YAML.isMap(node) && node.has(key)) return { section, node };
+  }
+  return null;
+}
+
 async function tryDeleteAction(
   read: () => Promise<string>,
   save: (content: string) => Promise<unknown>,
@@ -25,19 +36,10 @@ async function tryDeleteAction(
 ): Promise<boolean> {
   const content = await read();
   const doc = YAML.parseDocument(content || "{}");
-  // The displayed action list merges `actions:` and `terminals:` (backend
-  // ResolvedActions). Try both sections so right-click delete works for
-  // entries declared under either.
-  let removed = false;
-  for (const section of ["actions", "terminals"] as const) {
-    const node = doc.get(section, true);
-    if (!YAML.isMap(node) || !node.has(key)) continue;
-    node.delete(key);
-    if (node.items.length === 0) doc.delete(section);
-    removed = true;
-    break;
-  }
-  if (!removed) return false;
+  const match = findActionSection(doc, key);
+  if (!match) return false;
+  match.node.delete(key);
+  if (match.node.items.length === 0) doc.delete(match.section);
   await save(String(doc));
   return true;
 }
@@ -71,6 +73,46 @@ export function deleteAction(projectName: string, key: string) {
     if (removed) return;
     await queueWrite(GLOBAL_KEY, () =>
       tryDeleteAction(ReadGlobalConfig, SaveGlobalConfig, key).then(() => undefined),
+    );
+  });
+}
+
+export interface ActionPatch {
+  set: Record<string, unknown>;
+  remove: readonly string[];
+}
+
+// Patch in place rather than overwriting, so user-authored fields the wizard
+// doesn't manage (cwd, env, inputs, ...) survive an edit.
+async function tryReplaceAction(
+  read: () => Promise<string>,
+  save: (content: string) => Promise<unknown>,
+  key: string,
+  patch: ActionPatch,
+): Promise<boolean> {
+  const content = await read();
+  const doc = YAML.parseDocument(content || "{}");
+  const match = findActionSection(doc, key);
+  if (!match) return false;
+  const entry = match.node.get(key, true);
+  if (!YAML.isMap(entry)) return false;
+  for (const [k, v] of Object.entries(patch.set)) entry.set(k, v);
+  for (const k of patch.remove) entry.delete(k);
+  await save(String(doc));
+  return true;
+}
+
+export function replaceAction(projectName: string, key: string, patch: ActionPatch) {
+  return queueWrite(projectName, async () => {
+    const updated = await tryReplaceAction(
+      () => ReadConfig(projectName),
+      (content) => SaveConfig(projectName, content),
+      key,
+      patch,
+    );
+    if (updated) return;
+    await queueWrite(GLOBAL_KEY, () =>
+      tryReplaceAction(ReadGlobalConfig, SaveGlobalConfig, key, patch).then(() => undefined),
     );
   });
 }

--- a/desktop/frontend/src/components/ActionButton.tsx
+++ b/desktop/frontend/src/components/ActionButton.tsx
@@ -1,3 +1,5 @@
+import type { MouseEvent } from "react";
+
 const actionStyles = {
   primary:
     "bg-[var(--text-primary)] text-[var(--bg-primary)] hover:opacity-85",
@@ -11,11 +13,13 @@ const actionStyles = {
 
 export function ActionButton({
   onClick,
+  onContextMenu,
   disabled,
   variant,
   label,
 }: {
   onClick: () => void;
+  onContextMenu?: (e: MouseEvent) => void;
   disabled: boolean;
   variant: keyof typeof actionStyles;
   label: string;
@@ -23,8 +27,9 @@ export function ActionButton({
   return (
     <button
       onClick={onClick}
+      onContextMenu={onContextMenu}
       disabled={disabled}
-      className={`shrink-0 whitespace-nowrap rounded-lg px-3.5 py-1.5 text-xs font-medium transition-all disabled:opacity-40 ${actionStyles[variant]}`}
+      className={`shrink-0 select-none whitespace-nowrap rounded-lg px-3.5 py-1.5 text-xs font-medium transition-all disabled:opacity-40 ${actionStyles[variant]}`}
     >
       {label}
     </button>

--- a/desktop/frontend/src/components/ActionView.tsx
+++ b/desktop/frontend/src/components/ActionView.tsx
@@ -1,3 +1,4 @@
+import type { MouseEvent } from "react";
 import { ActionButton } from "./ActionButton";
 import { SplitButton } from "./SplitButton";
 import type { ActionInfo } from "../types";
@@ -7,19 +8,31 @@ interface ActionViewProps {
   compact: boolean;
   disabled: boolean;
   onRun: (action: ActionInfo) => void;
+  onContextMenu?: (e: MouseEvent, action: ActionInfo) => void;
 }
 
-export function ActionView({ action, compact, disabled, onRun }: ActionViewProps) {
+export function ActionView({ action, compact, disabled, onRun, onContextMenu }: ActionViewProps) {
+  const handleContextMenu = onContextMenu ? (e: MouseEvent) => onContextMenu(e, action) : undefined;
+
   if (action.children?.length) {
-    return <SplitButton action={action} disabled={disabled} onRunAction={onRun} compact={compact} />;
+    return (
+      <SplitButton
+        action={action}
+        disabled={disabled}
+        onRunAction={onRun}
+        onContextMenu={handleContextMenu}
+        compact={compact}
+      />
+    );
   }
   if (compact) {
     return (
       <button
         onClick={() => onRun(action)}
+        onContextMenu={handleContextMenu}
         disabled={disabled}
         title={action.label}
-        className="flex items-center rounded-md border border-[var(--border)] bg-[var(--bg-secondary)] px-2.5 py-1 text-[11px] font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-40"
+        className="flex select-none items-center rounded-md border border-[var(--border)] bg-[var(--bg-secondary)] px-2.5 py-1 text-[11px] font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-40"
       >
         {action.label}
       </button>
@@ -28,6 +41,7 @@ export function ActionView({ action, compact, disabled, onRun }: ActionViewProps
   return (
     <ActionButton
       onClick={() => onRun(action)}
+      onContextMenu={handleContextMenu}
       disabled={disabled}
       variant="secondary"
       label={action.label}

--- a/desktop/frontend/src/components/ProjectContextMenu.tsx
+++ b/desktop/frontend/src/components/ProjectContextMenu.tsx
@@ -1,6 +1,6 @@
-import { useEffect } from "react";
 import { ChevronRightIcon, ClipboardIcon, CopyIcon, PencilIcon, TrashIcon } from "./icons";
-import { useOutsideClick } from "../hooks/useOutsideClick";
+import { ContextMenuItem } from "./ui/ContextMenuItem";
+import { ContextMenuShell } from "./ui/ContextMenuShell";
 import { launchOpenInTarget, useOpenInTargets } from "../hooks/useOpenInTargets";
 
 interface ProjectContextMenuProps {
@@ -30,66 +30,29 @@ export function ProjectContextMenu({
   onRemove,
   onClose,
 }: ProjectContextMenuProps) {
-  const ref = useOutsideClick<HTMLDivElement>(onClose);
   const openInTargets = useOpenInTargets();
-
-  useEffect(() => {
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", handleKey);
-    return () => document.removeEventListener("keydown", handleKey);
-  }, [onClose]);
+  const close = (fn: () => void) => () => {
+    fn();
+    onClose();
+  };
 
   return (
-    <div
-      ref={ref}
-      className="fixed z-50 min-w-[180px] rounded-lg border border-[var(--border)] bg-[var(--bg-primary)] py-1 shadow-lg"
-      style={{ left: x, top: y }}
-    >
-      <button
-        onClick={() => {
-          onRename();
-          onClose();
-        }}
-        className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
-      >
-        <span className="flex-1 truncate">Rename</span>
-        <PencilIcon />
-      </button>
-      <button
-        onClick={() => {
-          onDuplicate();
-          onClose();
-        }}
+    <ContextMenuShell x={x} y={y} minWidth={180} onClose={onClose}>
+      <ContextMenuItem label="Rename" icon={<PencilIcon />} onClick={close(onRename)} />
+      <ContextMenuItem
+        label="Duplicate project"
+        icon={<CopyIcon />}
+        onClick={close(onDuplicate)}
         disabled={busy}
-        className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:cursor-not-allowed disabled:opacity-50"
-      >
-        <span className="flex-1 truncate">Duplicate project</span>
-        <CopyIcon />
-      </button>
-      <button
-        onClick={() => {
-          onDuplicateExcludeUncommitted();
-          onClose();
-        }}
+      />
+      <ContextMenuItem
+        label="Duplicate (committed only)"
+        icon={<CopyIcon />}
+        onClick={close(onDuplicateExcludeUncommitted)}
         disabled={busy}
         title="Duplicate the project and reset the copy to HEAD, discarding staged, unstaged, and untracked changes"
-        className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:cursor-not-allowed disabled:opacity-50"
-      >
-        <span className="flex-1 truncate">Duplicate (committed only)</span>
-        <CopyIcon />
-      </button>
-      <button
-        onClick={() => {
-          onCopyPath();
-          onClose();
-        }}
-        className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
-      >
-        <span className="flex-1 truncate">Copy path</span>
-        <ClipboardIcon />
-      </button>
+      />
+      <ContextMenuItem label="Copy path" icon={<ClipboardIcon />} onClick={close(onCopyPath)} />
       {projectPath && openInTargets.length > 0 && (
         <div className="group relative">
           <button
@@ -118,19 +81,15 @@ export function ProjectContextMenu({
       {canRemove && (
         <>
           <div className="my-1 border-t border-[var(--border)]" />
-          <button
-            onClick={() => {
-              onRemove();
-              onClose();
-            }}
+          <ContextMenuItem
+            destructive
+            label="Remove duplicate"
+            icon={<TrashIcon />}
+            onClick={close(onRemove)}
             disabled={busy}
-            className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[11px] text-[var(--accent-red)] transition-colors hover:bg-[var(--bg-hover)] disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            <span className="flex-1 truncate">Remove duplicate</span>
-            <TrashIcon />
-          </button>
+          />
         </>
       )}
-    </div>
+    </ContextMenuShell>
   );
 }

--- a/desktop/frontend/src/components/ProjectDetail.tsx
+++ b/desktop/frontend/src/components/ProjectDetail.tsx
@@ -7,7 +7,7 @@ import { NotesView } from "./NotesView";
 import { type TerminalViewHandle } from "./TerminalView";
 import { ConfigErrorView } from "./project-detail/ConfigErrorView";
 import { Controls } from "./project-detail/Controls";
-import { CreateActionWizard } from "./project-detail/CreateActionWizard";
+import { ActionWizard } from "./project-detail/ActionWizard";
 import { ActionContextMenu } from "./project-detail/ActionContextMenu";
 import { EmptyTerminalState } from "./project-detail/EmptyTerminalState";
 import { Header } from "./project-detail/Header";
@@ -63,6 +63,7 @@ export function ProjectDetail({
   const [loading, setLoading] = useState(false);
   const [confirmRemove, setConfirmRemove] = useState(false);
   const [showCreateAction, setShowCreateAction] = useState(false);
+  const [editingAction, setEditingAction] = useState<ActionInfo | null>(null);
   const [showQuickMenu, setShowQuickMenu] = useState(false);
   const [showTerminalSettings, setShowTerminalSettings] = useState(false);
   const [showProfileMenu, setShowProfileMenu] = useState(false);
@@ -353,19 +354,24 @@ export function ProjectDetail({
           onTerminalThemeChange={setTerminalTheme}
         />
 
-        <CreateActionWizard
-          open={showCreateAction}
+        <ActionWizard
+          open={showCreateAction || editingAction !== null}
           projectName={project.name}
           existingActionKeys={existingActionKeys}
           nextPosition={nextHeaderActionPosition}
-          onClose={() => setShowCreateAction(false)}
-          onCreated={() => onRefresh()}
+          editing={editingAction}
+          onClose={() => {
+            setShowCreateAction(false);
+            setEditingAction(null);
+          }}
+          onSaved={() => onRefresh()}
         />
 
         {actionMenu && (
           <ActionContextMenu
             x={actionMenu.x}
             y={actionMenu.y}
+            onEdit={() => setEditingAction(actionMenu.action)}
             onDelete={() => setActionToDelete(actionMenu.action)}
             onClose={() => setActionMenu(null)}
           />

--- a/desktop/frontend/src/components/ProjectDetail.tsx
+++ b/desktop/frontend/src/components/ProjectDetail.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
+import { toast } from "sonner";
 import { ActionsDnd } from "./ActionsDnd";
 import { ActionView } from "./ActionView";
 import { ConfigEditor } from "./ConfigEditor";
@@ -7,11 +8,14 @@ import { type TerminalViewHandle } from "./TerminalView";
 import { ConfigErrorView } from "./project-detail/ConfigErrorView";
 import { Controls } from "./project-detail/Controls";
 import { CreateActionWizard } from "./project-detail/CreateActionWizard";
+import { ActionContextMenu } from "./project-detail/ActionContextMenu";
 import { EmptyTerminalState } from "./project-detail/EmptyTerminalState";
 import { Header } from "./project-detail/Header";
 import { HeaderActions } from "./project-detail/HeaderActions";
 import { Modals } from "./project-detail/Modals";
 import { TerminalPane } from "./project-detail/TerminalPane";
+import { ConfirmDialog } from "./ui/ConfirmDialog";
+import { deleteAction } from "../actionConfig";
 import { EMPTY_SERVICES, noop } from "./project-detail/constants";
 import { useActionsByDisplay } from "../hooks/useActionsByDisplay";
 import { useDetailView } from "../hooks/useDetailView";
@@ -27,6 +31,7 @@ import { countPersistedTabs, getProjectTerminals } from "../terminals";
 import { useAppStore } from "../store/app";
 import {
   isFooterDisplay,
+  type ActionInfo,
   type ActionsLayout,
   type ProjectInfo,
 } from "../types";
@@ -61,6 +66,9 @@ export function ProjectDetail({
   const [showQuickMenu, setShowQuickMenu] = useState(false);
   const [showTerminalSettings, setShowTerminalSettings] = useState(false);
   const [showProfileMenu, setShowProfileMenu] = useState(false);
+  const [actionMenu, setActionMenu] = useState<{ x: number; y: number; action: ActionInfo } | null>(null);
+  const [actionToDelete, setActionToDelete] = useState<ActionInfo | null>(null);
+  const [deletingAction, setDeletingAction] = useState(false);
   const profileMenuRef = useOutsideClick<HTMLDivElement>(
     () => setShowProfileMenu(false),
     showProfileMenu,
@@ -166,7 +174,10 @@ export function ProjectDetail({
 
   // ── derived layout state ────────────────────────────────────────────
   const showProjectName = getSettings().showProjectName !== false;
-  const hasActions = true;
+  const existingActionKeys = useMemo(
+    () => (project.actions ?? []).map((action) => action.name),
+    [project.actions],
+  );
   const nextHeaderActionPosition =
     headerActions.reduce((max, action, index) => Math.max(max, action.position ?? index + 1), 0) + 1;
   const showEmptyState = !project.running && detailView === "terminal" && terminalCount === 0;
@@ -198,6 +209,26 @@ export function ProjectDetail({
     );
   }
 
+  const handleActionContextMenu = useCallback((e: MouseEvent, action: ActionInfo) => {
+    e.preventDefault();
+    setActionMenu({ x: e.clientX, y: e.clientY, action });
+  }, []);
+
+  const handleConfirmDeleteAction = async () => {
+    if (!actionToDelete) return;
+    setDeletingAction(true);
+    try {
+      await deleteAction(project.name, actionToDelete.name);
+      toast.success(`Deleted ${actionToDelete.label || actionToDelete.name}`);
+      setActionToDelete(null);
+      onRefresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Could not delete action");
+    } finally {
+      setDeletingAction(false);
+    }
+  };
+
   // ── render ──────────────────────────────────────────────────────────
   const headerActionsNode = (
     <HeaderActions
@@ -206,6 +237,7 @@ export function ProjectDetail({
       wrapped={actionsWrapped}
       disabled={runningAction !== null}
       onRun={handleRunAction}
+      onContextMenu={handleActionContextMenu}
       onAddAction={() => setShowCreateAction(true)}
     />
   );
@@ -253,7 +285,6 @@ export function ProjectDetail({
           rowRef={headerRowRef}
           innerRef={innerContainerRef}
           actionsWrapped={actionsWrapped}
-          hasActions={hasActions}
           actions={headerActionsNode}
           controls={controlsNode}
         />
@@ -284,6 +315,7 @@ export function ProjectDetail({
           onZoomIn={zoomIn}
           onZoomOut={zoomOut}
           onRunAction={handleRunAction}
+          onActionContextMenu={handleActionContextMenu}
         />
 
         {detailView === "config" && (
@@ -324,10 +356,34 @@ export function ProjectDetail({
         <CreateActionWizard
           open={showCreateAction}
           projectName={project.name}
-          existingActionKeys={(project.actions ?? []).map((action) => action.name)}
+          existingActionKeys={existingActionKeys}
           nextPosition={nextHeaderActionPosition}
           onClose={() => setShowCreateAction(false)}
           onCreated={() => onRefresh()}
+        />
+
+        {actionMenu && (
+          <ActionContextMenu
+            x={actionMenu.x}
+            y={actionMenu.y}
+            onDelete={() => setActionToDelete(actionMenu.action)}
+            onClose={() => setActionMenu(null)}
+          />
+        )}
+
+        <ConfirmDialog
+          open={actionToDelete !== null}
+          title="Delete action?"
+          body={
+            <>
+              Remove <span className="font-medium text-[var(--text-primary)]">{actionToDelete?.label || actionToDelete?.name}</span> from this project's config. This cannot be undone.
+            </>
+          }
+          confirmLabel="Delete"
+          variant="destructive"
+          disabled={deletingAction}
+          onCancel={() => setActionToDelete(null)}
+          onConfirm={handleConfirmDeleteAction}
         />
       </div>
     </ActionsDnd>

--- a/desktop/frontend/src/components/ProjectDetail.tsx
+++ b/desktop/frontend/src/components/ProjectDetail.tsx
@@ -324,7 +324,6 @@ export function ProjectDetail({
         <CreateActionWizard
           open={showCreateAction}
           projectName={project.name}
-          isRemote={project.isRemote}
           existingActionKeys={(project.actions ?? []).map((action) => action.name)}
           nextPosition={nextHeaderActionPosition}
           onClose={() => setShowCreateAction(false)}

--- a/desktop/frontend/src/components/ProjectDetail.tsx
+++ b/desktop/frontend/src/components/ProjectDetail.tsx
@@ -6,6 +6,7 @@ import { NotesView } from "./NotesView";
 import { type TerminalViewHandle } from "./TerminalView";
 import { ConfigErrorView } from "./project-detail/ConfigErrorView";
 import { Controls } from "./project-detail/Controls";
+import { CreateActionWizard } from "./project-detail/CreateActionWizard";
 import { EmptyTerminalState } from "./project-detail/EmptyTerminalState";
 import { Header } from "./project-detail/Header";
 import { HeaderActions } from "./project-detail/HeaderActions";
@@ -56,6 +57,7 @@ export function ProjectDetail({
   // ── local UI state ──────────────────────────────────────────────────
   const [loading, setLoading] = useState(false);
   const [confirmRemove, setConfirmRemove] = useState(false);
+  const [showCreateAction, setShowCreateAction] = useState(false);
   const [showQuickMenu, setShowQuickMenu] = useState(false);
   const [showTerminalSettings, setShowTerminalSettings] = useState(false);
   const [showProfileMenu, setShowProfileMenu] = useState(false);
@@ -164,7 +166,9 @@ export function ProjectDetail({
 
   // ── derived layout state ────────────────────────────────────────────
   const showProjectName = getSettings().showProjectName !== false;
-  const hasActions = headerActions.length > 0;
+  const hasActions = true;
+  const nextHeaderActionPosition =
+    headerActions.reduce((max, action, index) => Math.max(max, action.position ?? index + 1), 0) + 1;
   const showEmptyState = !project.running && detailView === "terminal" && terminalCount === 0;
 
   const {
@@ -195,15 +199,16 @@ export function ProjectDetail({
   }
 
   // ── render ──────────────────────────────────────────────────────────
-  const headerActionsNode = hasActions ? (
+  const headerActionsNode = (
     <HeaderActions
       actions={headerActions}
       ids={headerIds}
       wrapped={actionsWrapped}
       disabled={runningAction !== null}
       onRun={handleRunAction}
+      onAddAction={() => setShowCreateAction(true)}
     />
-  ) : null;
+  );
 
   const controlsNode = (
     <Controls
@@ -314,6 +319,16 @@ export function ProjectDetail({
           onZoomOut={zoomOut}
           terminalTheme={terminalTheme}
           onTerminalThemeChange={setTerminalTheme}
+        />
+
+        <CreateActionWizard
+          open={showCreateAction}
+          projectName={project.name}
+          isRemote={project.isRemote}
+          existingActionKeys={(project.actions ?? []).map((action) => action.name)}
+          nextPosition={nextHeaderActionPosition}
+          onClose={() => setShowCreateAction(false)}
+          onCreated={() => onRefresh()}
         />
       </div>
     </ActionsDnd>

--- a/desktop/frontend/src/components/SplitButton.tsx
+++ b/desktop/frontend/src/components/SplitButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type MouseEvent } from "react";
 import { useOutsideClick } from "../hooks/useOutsideClick";
 import type { ActionInfo } from "../types";
 import { ChevronDownIcon } from "./icons";
@@ -38,10 +38,11 @@ interface SplitButtonProps {
   action: ActionInfo;
   disabled: boolean;
   onRunAction: (action: ActionInfo) => void;
+  onContextMenu?: (e: MouseEvent) => void;
   compact?: boolean;
 }
 
-export function SplitButton({ action, disabled, onRunAction, compact = false }: SplitButtonProps) {
+export function SplitButton({ action, disabled, onRunAction, onContextMenu, compact = false }: SplitButtonProps) {
   const [open, setOpen] = useState(false);
   const ref = useOutsideClick<HTMLDivElement>(() => setOpen(false), open);
 
@@ -68,7 +69,7 @@ export function SplitButton({ action, disabled, onRunAction, compact = false }: 
 
   if (!isSplit) {
     return (
-      <div ref={ref} className="relative shrink-0">
+      <div ref={ref} onContextMenu={onContextMenu} className="relative shrink-0 select-none">
         <button
           onClick={() => setOpen((v) => !v)}
           disabled={disabled}
@@ -83,7 +84,7 @@ export function SplitButton({ action, disabled, onRunAction, compact = false }: 
   }
 
   return (
-    <div ref={ref} className="relative shrink-0">
+    <div ref={ref} onContextMenu={onContextMenu} className="relative shrink-0 select-none">
       <div className={`inline-flex items-stretch ${s.rounded} ${s.border}`}>
         <button
           onClick={() => onRunAction(action)}

--- a/desktop/frontend/src/components/TerminalFooter.tsx
+++ b/desktop/frontend/src/components/TerminalFooter.tsx
@@ -1,3 +1,4 @@
+import type { MouseEvent } from "react";
 import { useGitStatus } from "../hooks/useGitStatus";
 import { ActionsGroup } from "./ActionsDnd";
 import { ActionView } from "./ActionView";
@@ -10,10 +11,18 @@ interface TerminalFooterProps {
   actions: ActionInfo[];
   actionIds: string[];
   onRunAction: (action: ActionInfo) => void;
+  onActionContextMenu?: (e: MouseEvent, action: ActionInfo) => void;
   disabled: boolean;
 }
 
-export function TerminalFooter({ projectPath, actions, actionIds, onRunAction, disabled }: TerminalFooterProps) {
+export function TerminalFooter({
+  projectPath,
+  actions,
+  actionIds,
+  onRunAction,
+  onActionContextMenu,
+  disabled,
+}: TerminalFooterProps) {
   const gitState = useGitStatus(projectPath);
   const isGitRepo = !!gitState.status?.isGitRepo;
 
@@ -27,7 +36,13 @@ export function TerminalFooter({ projectPath, actions, actionIds, onRunAction, d
     >
       {actions.map((action) => (
         <SortableItem key={action.name} id={action.name}>
-          <ActionView action={action} compact disabled={disabled} onRun={onRunAction} />
+          <ActionView
+            action={action}
+            compact
+            disabled={disabled}
+            onRun={onRunAction}
+            onContextMenu={onActionContextMenu}
+          />
         </SortableItem>
       ))}
       {isGitRepo && <BranchSwitcher projectPath={projectPath} gitState={gitState} />}

--- a/desktop/frontend/src/components/VisualConfigEditor.tsx
+++ b/desktop/frontend/src/components/VisualConfigEditor.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from "react";
 import YAML from "yaml";
 import { AddNewPicker, type NewItemType } from "./AddNewPicker";
 import { PlusIcon, TrashIcon, ChevronDownIcon, ChevronRightIcon, ZapIcon, PlayIcon, TerminalIcon, LayersIcon } from "./icons";
+import { uniqueKey } from "../uniqueKey";
 
 // ── form state types ──
 
@@ -180,15 +181,6 @@ function serializeToYaml(form: ConfigForm): string {
   }
 
   return YAML.stringify(doc, { lineWidth: 0 });
-}
-
-// ── helpers ──
-
-function uniqueKey(prefix: string, existing: string[]): string {
-  if (!existing.includes(prefix)) return prefix;
-  let i = 2;
-  while (existing.includes(`${prefix}-${i}`)) i++;
-  return `${prefix}-${i}`;
 }
 
 // ── sub-components ──

--- a/desktop/frontend/src/components/project-detail/ActionContextMenu.tsx
+++ b/desktop/frontend/src/components/project-detail/ActionContextMenu.tsx
@@ -1,0 +1,26 @@
+import { TrashIcon } from "../icons";
+import { ContextMenuItem } from "../ui/ContextMenuItem";
+import { ContextMenuShell } from "../ui/ContextMenuShell";
+
+interface ActionContextMenuProps {
+  x: number;
+  y: number;
+  onDelete: () => void;
+  onClose: () => void;
+}
+
+export function ActionContextMenu({ x, y, onDelete, onClose }: ActionContextMenuProps) {
+  return (
+    <ContextMenuShell x={x} y={y} onClose={onClose}>
+      <ContextMenuItem
+        destructive
+        label="Delete action"
+        icon={<TrashIcon />}
+        onClick={() => {
+          onDelete();
+          onClose();
+        }}
+      />
+    </ContextMenuShell>
+  );
+}

--- a/desktop/frontend/src/components/project-detail/ActionContextMenu.tsx
+++ b/desktop/frontend/src/components/project-detail/ActionContextMenu.tsx
@@ -1,17 +1,26 @@
-import { TrashIcon } from "../icons";
+import { PencilIcon, TrashIcon } from "../icons";
 import { ContextMenuItem } from "../ui/ContextMenuItem";
 import { ContextMenuShell } from "../ui/ContextMenuShell";
 
 interface ActionContextMenuProps {
   x: number;
   y: number;
+  onEdit: () => void;
   onDelete: () => void;
   onClose: () => void;
 }
 
-export function ActionContextMenu({ x, y, onDelete, onClose }: ActionContextMenuProps) {
+export function ActionContextMenu({ x, y, onEdit, onDelete, onClose }: ActionContextMenuProps) {
   return (
     <ContextMenuShell x={x} y={y} onClose={onClose}>
+      <ContextMenuItem
+        label="Edit action"
+        icon={<PencilIcon />}
+        onClick={() => {
+          onEdit();
+          onClose();
+        }}
+      />
       <ContextMenuItem
         destructive
         label="Delete action"

--- a/desktop/frontend/src/components/project-detail/ActionWizard.tsx
+++ b/desktop/frontend/src/components/project-detail/ActionWizard.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useState, type KeyboardEvent, type ReactNode, type Ref } from "react";
 import YAML from "yaml";
 import { toast } from "sonner";
-import { appendAction } from "../../actionConfig";
+import { appendAction, replaceAction, type ActionPatch } from "../../actionConfig";
 import { slugify } from "../../slugify";
 import { uniqueKey } from "../../uniqueKey";
+import type { ActionInfo } from "../../types";
 import {
   ChevronDownIcon,
   ChevronLeftIcon,
@@ -41,13 +42,18 @@ interface ChildDraft {
   confirm: boolean;
 }
 
-interface CreateActionWizardProps {
+interface ActionWizardProps {
   open: boolean;
   projectName: string;
-  existingActionKeys: string[];
-  nextPosition: number;
+  // When set, the wizard runs in edit mode: prefill from this action and
+  // submit a patch to its YAML key instead of appending a new entry.
+  editing?: ActionInfo | null;
+  // Create-only: collision avoidance for the new YAML key.
+  existingActionKeys?: string[];
+  // Create-only: position assigned to the new entry.
+  nextPosition?: number;
   onClose: () => void;
-  onCreated: () => void;
+  onSaved: () => void;
 }
 
 function newChild(): ChildDraft {
@@ -81,7 +87,7 @@ function runModeHint(mode: RunMode, reuse: boolean) {
   return "Runs once and displays the result in a modal.";
 }
 
-function stepCopy(step: number, shape: Shape): { title: string; hint: string; primary: string } {
+function stepCopy(step: number, shape: Shape, editing: boolean): { title: string; hint: string; primary: string } {
   if (step === 0)
     return {
       title: "What should the button say?",
@@ -100,11 +106,17 @@ function stepCopy(step: number, shape: Shape): { title: string; hint: string; pr
       hint: "Paste the same command you would type in a terminal.",
       primary: "Review action",
     };
-  return {
-    title: "Ready to add it?",
-    hint: "Confirm the simple summary. The button appears in the header after creation.",
-    primary: "Create action",
-  };
+  return editing
+    ? {
+        title: "Ready to save changes?",
+        hint: "Confirm the updated settings. The button updates in the header after saving.",
+        primary: "Save changes",
+      }
+    : {
+        title: "Ready to add it?",
+        hint: "Confirm the simple summary. The button appears in the header after creation.",
+        primary: "Create action",
+      };
 }
 
 function actionSummary(shape: Shape, name: string, cmd: string, children: ChildDraft[], runMode: RunMode, reuse: boolean) {
@@ -120,16 +132,7 @@ function actionSummary(shape: Shape, name: string, cmd: string, children: ChildD
   return `${label} ${runModeHint(runMode, reuse).toLowerCase()} Command: ${cmd || "not set yet"}.`;
 }
 
-function buildActionPayload({
-  shape,
-  name,
-  cmd,
-  children,
-  runMode,
-  reuse,
-  confirm,
-  position,
-}: {
+interface FormDraft {
   shape: Shape;
   name: string;
   cmd: string;
@@ -137,53 +140,112 @@ function buildActionPayload({
   runMode: RunMode;
   reuse: boolean;
   confirm: boolean;
-  position: number;
-}) {
-  const payload: Record<string, unknown> = {
-    label: name.trim(),
-    display: "header",
-    position,
-  };
-
-  if (shape !== "dropdown") {
-    payload.cmd = cmd.trim();
-    if (runMode !== "once") payload.type = runMode;
-    if (runMode === "terminal" && reuse) payload.reuse = true;
-    if (confirm) payload.confirm = true;
-  }
-
-  if (shape !== "button") {
-    const childMap: Record<string, unknown> = {};
-    const used: string[] = [];
-    children
-      .filter((child) => child.cmd.trim())
-      .forEach((child, index) => {
-        const key = uniqueKey(slugify(child.label) || `option-${index + 1}`, used);
-        used.push(key);
-        const childPayload: Record<string, unknown> = {
-          label: child.label.trim() || key,
-          cmd: child.cmd.trim(),
-          position: index + 1,
-        };
-        if (child.runMode !== "once") childPayload.type = child.runMode;
-        if (child.runMode === "terminal" && child.reuse) childPayload.reuse = true;
-        if (child.confirm) childPayload.confirm = true;
-        childMap[key] = childPayload;
-      });
-    payload.actions = childMap;
-  }
-
-  return payload;
 }
 
-export function CreateActionWizard({
+function buildChildMap(children: ChildDraft[]): Record<string, unknown> {
+  const childMap: Record<string, unknown> = {};
+  const used: string[] = [];
+  children
+    .filter((child) => child.cmd.trim())
+    .forEach((child, index) => {
+      const key = uniqueKey(slugify(child.label) || `option-${index + 1}`, used);
+      used.push(key);
+      const childPayload: Record<string, unknown> = {
+        label: child.label.trim() || key,
+        cmd: child.cmd.trim(),
+        position: index + 1,
+      };
+      if (child.runMode !== "once") childPayload.type = child.runMode;
+      if (child.runMode === "terminal" && child.reuse) childPayload.reuse = true;
+      if (child.confirm) childPayload.confirm = true;
+      childMap[key] = childPayload;
+    });
+  return childMap;
+}
+
+// Returns set/remove for the wizard-managed fields. On edit, applying this
+// patch leaves user-authored fields like cwd/env/inputs untouched.
+function buildActionPatch({ shape, name, cmd, children, runMode, reuse, confirm }: FormDraft): ActionPatch {
+  const set: Record<string, unknown> = { label: name.trim() };
+  const remove: string[] = [];
+
+  if (shape === "dropdown") {
+    remove.push("cmd", "type", "reuse", "confirm");
+  } else {
+    set.cmd = cmd.trim();
+    if (runMode !== "once") set.type = runMode;
+    else remove.push("type");
+    if (runMode === "terminal" && reuse) set.reuse = true;
+    else remove.push("reuse");
+    if (confirm) set.confirm = true;
+    else remove.push("confirm");
+  }
+
+  if (shape === "button") remove.push("actions");
+  else set.actions = buildChildMap(children);
+
+  return { set, remove };
+}
+
+function buildCreatePayload(draft: FormDraft, position: number): Record<string, unknown> {
+  const { set } = buildActionPatch(draft);
+  return { ...set, display: "header", position };
+}
+
+function inferShape(action: ActionInfo): Shape {
+  const hasChildren = (action.children?.length ?? 0) > 0;
+  const hasCmd = Boolean(action.cmd);
+  if (hasChildren && hasCmd) return "split";
+  if (hasChildren) return "dropdown";
+  return "button";
+}
+
+function toRunMode(type: string | undefined): RunMode {
+  return type === "terminal" || type === "background" ? type : "once";
+}
+
+function actionToDraft(action: ActionInfo): FormDraft {
+  const children: ChildDraft[] = (action.children ?? []).map((c) => ({
+    id: crypto.randomUUID(),
+    label: c.label,
+    cmd: c.cmd,
+    runMode: toRunMode(c.type),
+    reuse: c.reuse ?? false,
+    confirm: c.confirm,
+  }));
+  return {
+    shape: inferShape(action),
+    name: action.label,
+    cmd: action.cmd,
+    children: children.length ? children : [newChild()],
+    runMode: toRunMode(action.type),
+    reuse: action.reuse ?? false,
+    confirm: action.confirm,
+  };
+}
+
+function defaultDraft(): FormDraft {
+  return {
+    shape: "button",
+    name: "",
+    cmd: "",
+    children: [newChild()],
+    runMode: "once",
+    reuse: false,
+    confirm: false,
+  };
+}
+
+export function ActionWizard({
   open,
   projectName,
-  existingActionKeys,
-  nextPosition,
+  editing,
+  existingActionKeys = [],
+  nextPosition = 1,
   onClose,
-  onCreated,
-}: CreateActionWizardProps) {
+  onSaved,
+}: ActionWizardProps) {
+  const isEditing = Boolean(editing);
   const [step, setStep] = useState(0);
   const [name, setName] = useState("");
   const [shape, setShape] = useState<Shape>("button");
@@ -199,28 +261,42 @@ export function CreateActionWizard({
 
   useEffect(() => {
     if (!open) return;
+    const draft = editing ? actionToDraft(editing) : defaultDraft();
     setStep(0);
-    setName("");
-    setShape("button");
-    setCmd("");
-    setChildren([newChild()]);
-    setRunMode("once");
-    setReuse(false);
-    setConfirm(false);
+    setName(draft.name);
+    setShape(draft.shape);
+    setCmd(draft.cmd);
+    setChildren(draft.children);
+    setRunMode(draft.runMode);
+    setReuse(draft.reuse);
+    setConfirm(draft.confirm);
     setShowYaml(false);
     setSaving(false);
     setTimeout(() => nameRef.current?.focus(), 50);
-  }, [open]);
+  }, [open, editing]);
 
   useEffect(() => {
     if (!open || step !== 2) return;
     setTimeout(() => commandRef.current?.focus(), 50);
   }, [open, step, shape]);
 
-  const buildSubmission = () => ({
-    key: uniqueKey(slugify(name) || "new-action", existingActionKeys),
-    payload: buildActionPayload({ shape, name, cmd, children, runMode, reuse, confirm, position: nextPosition }),
-  });
+  const draft: FormDraft = { shape, name, cmd, children, runMode, reuse, confirm };
+
+  type Submission =
+    | { kind: "create"; key: string; payload: Record<string, unknown> }
+    | { kind: "edit"; key: string; payload: Record<string, unknown>; patch: ActionPatch };
+
+  const buildSubmission = (): Submission => {
+    if (editing) {
+      const patch = buildActionPatch(draft);
+      return { kind: "edit", key: editing.name, payload: patch.set, patch };
+    }
+    return {
+      kind: "create",
+      key: uniqueKey(slugify(name) || "new-action", existingActionKeys),
+      payload: buildCreatePayload(draft, nextPosition),
+    };
+  };
 
   const cmdFilled = Boolean(cmd.trim());
   const hasMenuOption = children.some((child) => child.cmd.trim());
@@ -233,7 +309,7 @@ export function CreateActionWizard({
   const totalSteps = 4;
   const actionLabel = name.trim() || "New action";
 
-  const { title, hint, primary: primaryLabel } = stepCopy(step, shape);
+  const { title, hint, primary: primaryLabel } = stepCopy(step, shape, isEditing);
 
   const updateName = (value: string) => {
     setName(value);
@@ -258,13 +334,19 @@ export function CreateActionWizard({
 
     setSaving(true);
     try {
-      const { key, payload } = buildSubmission();
-      await appendAction(projectName, key, payload);
-      toast.success("Action created");
-      onCreated();
+      const submission = buildSubmission();
+      if (submission.kind === "edit") {
+        await replaceAction(projectName, submission.key, submission.patch);
+        toast.success("Action updated");
+      } else {
+        await appendAction(projectName, submission.key, submission.payload);
+        toast.success("Action created");
+      }
+      onSaved();
       onClose();
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Could not create action");
+      const fallback = editing ? "Could not update action" : "Could not create action";
+      toast.error(err instanceof Error ? err.message : fallback);
     } finally {
       setSaving(false);
     }
@@ -867,6 +949,10 @@ function CommandField({
           onEnter();
         }}
         placeholder={placeholder}
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
         className="w-full rounded-xl border border-[var(--border)] bg-[var(--bg-primary)] px-4 py-3 font-mono text-[13px] text-[var(--text-primary)] outline-none transition placeholder:font-sans placeholder:text-[var(--text-muted)] focus:border-[var(--text-primary)]"
       />
     </label>
@@ -901,13 +987,17 @@ function MenuOptionsEditor({
             <input
               value={child.label}
               onChange={(e) => updateField(child, "label", e.target.value)}
-              placeholder={index === 0 ? "Production" : "Label"}
+              placeholder="Label"
               className="rounded-lg border border-[var(--border)] bg-[var(--bg-primary)] px-3 py-2.5 text-[12px] text-[var(--text-primary)] outline-none transition focus:border-[var(--text-primary)]"
             />
             <input
               value={child.cmd}
               onChange={(e) => updateField(child, "cmd", e.target.value)}
-              placeholder={index === 0 ? "npm run deploy:production" : "Command"}
+              placeholder="Command"
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
               className="rounded-lg border border-[var(--border)] bg-[var(--bg-primary)] px-3 py-2.5 font-mono text-[12px] text-[var(--text-primary)] outline-none transition focus:border-[var(--text-primary)]"
             />
             <button
@@ -1017,7 +1107,7 @@ function ModeButton({
     <button
       type="button"
       onClick={onClick}
-      className={`flex items-center justify-center gap-1.5 rounded-xl border px-3 py-2.5 text-[12px] font-medium transition ${
+      className={`flex items-center justify-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-[11px] font-medium transition ${
         active
           ? "border-[var(--text-primary)] bg-[var(--text-primary)] text-[var(--bg-primary)] shadow-sm"
           : "border-[var(--border)] bg-[var(--bg-primary)] text-[var(--text-secondary)] hover:border-[var(--text-muted)] hover:text-[var(--text-primary)]"

--- a/desktop/frontend/src/components/project-detail/CreateActionWizard.tsx
+++ b/desktop/frontend/src/components/project-detail/CreateActionWizard.tsx
@@ -98,31 +98,18 @@ function shouldConfirm(text: string): boolean {
   return /\b(deploy|migrate|reset|drop|delete|destroy|remove|kill|prune)\b/i.test(text);
 }
 
-function suggestedCommand(name: string): { label: string; cmd: string } | null {
-  const value = name.toLowerCase();
-  if (/\b(test|spec|check)\b/.test(value)) return { label: "Use npm test", cmd: "npm test" };
-  if (/\b(build|compile)\b/.test(value)) return { label: "Use npm run build", cmd: "npm run build" };
-  if (/\b(dev|server|start)\b/.test(value)) return { label: "Use npm run dev", cmd: "npm run dev" };
-  if (/\b(log|logs|tail)\b/.test(value)) return { label: "Use tail -f log/development.log", cmd: "tail -f log/development.log" };
-  if (/\b(shell|terminal|console)\b/.test(value)) return { label: "Use current shell", cmd: "$SHELL" };
-  if (/\b(migrate|migration)\b/.test(value)) return { label: "Use rails db:migrate", cmd: "rails db:migrate" };
-  if (/\b(seed)\b/.test(value)) return { label: "Use rails db:seed", cmd: "rails db:seed" };
-  if (/\b(deploy)\b/.test(value)) return { label: "Use deploy script", cmd: "./deploy.sh" };
-  return null;
-}
-
 function runModeLabel(mode: RunMode) {
-  if (mode === "terminal") return "Terminal";
-  if (mode === "background") return "Background";
-  return "Run once";
+  if (mode === "terminal") return "Run in new terminal";
+  if (mode === "background") return "Run in background";
+  return "Show in modal";
 }
 
 function runModeHint(mode: RunMode, reuse: boolean) {
   if (mode === "terminal") {
-    return reuse ? "Opens one terminal pane and reuses it next time." : "Opens a terminal pane for the command.";
+    return reuse ? "Runs in a terminal and reuses it next time." : "Runs in a new terminal.";
   }
-  if (mode === "background") return "Runs quietly and shows a notification when it finishes.";
-  return "Runs the command once and shows the result.";
+  if (mode === "background") return "Runs in the background and shows a success notification when done.";
+  return "Runs once and displays the result in a modal.";
 }
 
 function actionSummary(shape: Shape, name: string, cmd: string, children: ChildDraft[], runMode: RunMode, reuse: boolean) {
@@ -280,7 +267,6 @@ export function CreateActionWizard({
   }, [open, step, shape]);
 
   const finalKey = useMemo(() => uniqueKey(slugify(name), existingActionKeys), [name, existingActionKeys]);
-  const commandSuggestion = useMemo(() => (cmd.trim() ? null : suggestedCommand(name)), [name, cmd]);
   const payload = useMemo(
     () =>
       buildActionPayload({
@@ -469,20 +455,6 @@ export function CreateActionWizard({
                     onEnter={() => void goNext()}
                     placeholder={shape === "split" ? "./deploy.sh staging" : "npm run dev"}
                   />
-                )}
-
-                {commandSuggestion && shape !== "dropdown" && (
-                  <button
-                    type="button"
-                    onClick={() => updateCmd(commandSuggestion.cmd)}
-                    className="flex w-full items-center justify-between gap-3 rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)] px-3 py-2.5 text-left transition hover:border-[var(--text-muted)] hover:bg-[var(--bg-hover)]"
-                  >
-                    <span>
-                      <span className="block text-[12px] font-medium text-[var(--text-primary)]">{commandSuggestion.label}</span>
-                      <span className="font-mono text-[11px] text-[var(--text-muted)]">{commandSuggestion.cmd}</span>
-                    </span>
-                    <span className="text-[11px] font-medium text-[var(--text-secondary)]">Use</span>
-                  </button>
                 )}
 
                 {shape !== "button" && (
@@ -844,9 +816,9 @@ function RunModePicker({
         <span className="text-[11px] text-[var(--text-muted)]">{runModeHint(runMode, reuse)}</span>
       </div>
       <div className="grid grid-cols-3 gap-2">
-        <ModeButton active={runMode === "once"} icon={<ZapIcon />} title="Once" onClick={() => onRunMode("once")} />
-        <ModeButton active={runMode === "terminal"} icon={<TerminalIcon />} title="Terminal" onClick={() => onRunMode("terminal")} />
-        <ModeButton active={runMode === "background"} icon={<SparkleIcon />} title="Background" onClick={() => onRunMode("background")} />
+        <ModeButton active={runMode === "once"} icon={<ZapIcon />} title="Show in modal" onClick={() => onRunMode("once")} />
+        <ModeButton active={runMode === "terminal"} icon={<TerminalIcon />} title="Run in new terminal" onClick={() => onRunMode("terminal")} />
+        <ModeButton active={runMode === "background"} icon={<SparkleIcon />} title="Run in background" onClick={() => onRunMode("background")} />
       </div>
       {runMode === "terminal" && (
         <label className="mt-3 flex items-center gap-2 text-[12px] text-[var(--text-secondary)]">

--- a/desktop/frontend/src/components/project-detail/CreateActionWizard.tsx
+++ b/desktop/frontend/src/components/project-detail/CreateActionWizard.tsx
@@ -1,11 +1,14 @@
-import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type ReactNode, type Ref } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent, type ReactNode, type Ref } from "react";
 import YAML from "yaml";
 import { toast } from "sonner";
 import { ReadConfig, SaveConfig } from "../../../wailsjs/go/main/App";
+import { slugify } from "../../slugify";
 import {
   ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
+  HelpCircleIcon,
+  PlayIcon,
   PlusIcon,
   SparkleIcon,
   TerminalIcon,
@@ -22,44 +25,28 @@ type RunMode = "once" | "terminal" | "background";
 const SHAPE_PREVIEW_BUTTON_CLASS =
   "border-[var(--border)] bg-[var(--bg-primary)] text-[var(--text-primary)]";
 
+const SHAPE_DESCRIPTION: Record<Shape, string> = {
+  button: "Header button",
+  split: "Split header button",
+  dropdown: "Header dropdown",
+};
+
 interface ChildDraft {
   id: string;
   label: string;
   cmd: string;
-}
-
-interface InputDraft {
-  id: string;
-  key: string;
-  label: string;
-  type: "text" | "password" | "radio";
-  required: boolean;
-  placeholder: string;
-  defaultValue: string;
-  options: string;
+  runMode: RunMode;
+  reuse: boolean;
+  confirm: boolean;
 }
 
 interface CreateActionWizardProps {
   open: boolean;
   projectName: string;
-  isRemote: boolean;
   existingActionKeys: string[];
   nextPosition: number;
   onClose: () => void;
   onCreated: () => void;
-}
-
-function newId() {
-  return crypto.randomUUID();
-}
-
-function slugify(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/['"]/g, "")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
 }
 
 function uniqueKey(base: string, existing: string[]): string {
@@ -71,20 +58,7 @@ function uniqueKey(base: string, existing: string[]): string {
 }
 
 function newChild(): ChildDraft {
-  return { id: newId(), label: "", cmd: "" };
-}
-
-function newInput(): InputDraft {
-  return {
-    id: newId(),
-    key: "",
-    label: "",
-    type: "text",
-    required: false,
-    placeholder: "",
-    defaultValue: "",
-    options: "",
-  };
+  return { id: crypto.randomUUID(), label: "", cmd: "", runMode: "once", reuse: false, confirm: false };
 }
 
 function inferRunMode(text: string): RunMode {
@@ -114,6 +88,32 @@ function runModeHint(mode: RunMode, reuse: boolean) {
   return "Runs once and displays the result in a modal.";
 }
 
+function stepCopy(step: number, shape: Shape): { title: string; hint: string; primary: string } {
+  if (step === 0)
+    return {
+      title: "What should the button say?",
+      hint: "Pick a short name. This is what you will click in the project header.",
+      primary: "Continue",
+    };
+  if (step === 1)
+    return {
+      title: "How should it appear?",
+      hint: "Button is best for most actions. Menus are only for related commands.",
+      primary: "Continue",
+    };
+  if (step === 2)
+    return {
+      title: shape === "button" ? "What command should it run?" : "What commands belong in the menu?",
+      hint: "Paste the same command you would type in a terminal.",
+      primary: "Review action",
+    };
+  return {
+    title: "Ready to add it?",
+    hint: "Confirm the simple summary. The button appears in the header after creation.",
+    primary: "Create action",
+  };
+}
+
 function actionSummary(shape: Shape, name: string, cmd: string, children: ChildDraft[], runMode: RunMode, reuse: boolean) {
   const label = name.trim() || "New action";
   if (shape === "dropdown") {
@@ -135,9 +135,6 @@ function buildActionPayload({
   runMode,
   reuse,
   confirm,
-  cwd,
-  inputs,
-  syncMode,
   position,
 }: {
   shape: Shape;
@@ -147,9 +144,6 @@ function buildActionPayload({
   runMode: RunMode;
   reuse: boolean;
   confirm: boolean;
-  cwd: string;
-  inputs: InputDraft[];
-  syncMode: boolean;
   position: number;
 }) {
   const payload: Record<string, unknown> = {
@@ -158,33 +152,12 @@ function buildActionPayload({
     position,
   };
 
-  if (shape !== "dropdown") payload.cmd = cmd.trim();
-  if (shape !== "dropdown" && runMode !== "once") payload.type = runMode;
-  if (shape !== "dropdown" && runMode === "terminal" && reuse) payload.reuse = true;
-  if (shape !== "dropdown" && confirm) payload.confirm = true;
-  if (cwd.trim()) payload.cwd = cwd.trim();
-  if (syncMode) payload.mode = "sync";
-
-  const inputMap: Record<string, unknown> = {};
-  for (const input of inputs) {
-    const key = slugify(input.key || input.label);
-    if (!key) continue;
-    const value: Record<string, unknown> = {};
-    if (input.label.trim()) value.label = input.label.trim();
-    if (input.type !== "text") value.type = input.type;
-    if (input.required) value.required = true;
-    if (input.placeholder.trim()) value.placeholder = input.placeholder.trim();
-    if (input.defaultValue.trim()) value.default = input.defaultValue.trim();
-    if (input.type === "radio") {
-      const options = input.options
-        .split(",")
-        .map((option) => option.trim())
-        .filter(Boolean);
-      if (options.length) value.options = options;
-    }
-    inputMap[key] = value;
+  if (shape !== "dropdown") {
+    payload.cmd = cmd.trim();
+    if (runMode !== "once") payload.type = runMode;
+    if (runMode === "terminal" && reuse) payload.reuse = true;
+    if (confirm) payload.confirm = true;
   }
-  if (shape !== "dropdown" && Object.keys(inputMap).length) payload.inputs = inputMap;
 
   if (shape !== "button") {
     const childMap: Record<string, unknown> = {};
@@ -194,11 +167,15 @@ function buildActionPayload({
       .forEach((child, index) => {
         const key = uniqueKey(slugify(child.label) || `option-${index + 1}`, used);
         used.push(key);
-        childMap[key] = {
+        const childPayload: Record<string, unknown> = {
           label: child.label.trim() || key,
           cmd: child.cmd.trim(),
           position: index + 1,
         };
+        if (child.runMode !== "once") childPayload.type = child.runMode;
+        if (child.runMode === "terminal" && child.reuse) childPayload.reuse = true;
+        if (child.confirm) childPayload.confirm = true;
+        childMap[key] = childPayload;
       });
     payload.actions = childMap;
   }
@@ -221,7 +198,6 @@ async function appendAction(projectName: string, key: string, payload: Record<st
 export function CreateActionWizard({
   open,
   projectName,
-  isRemote,
   existingActionKeys,
   nextPosition,
   onClose,
@@ -235,11 +211,7 @@ export function CreateActionWizard({
   const [runMode, setRunMode] = useState<RunMode>("once");
   const [reuse, setReuse] = useState(false);
   const [confirm, setConfirm] = useState(false);
-  const [showAdvanced, setShowAdvanced] = useState(false);
   const [showYaml, setShowYaml] = useState(false);
-  const [cwd, setCwd] = useState("");
-  const [inputs, setInputs] = useState<InputDraft[]>([]);
-  const [syncMode, setSyncMode] = useState(false);
   const [saving, setSaving] = useState(false);
   const nameRef = useRef<HTMLInputElement>(null);
   const commandRef = useRef<HTMLInputElement>(null);
@@ -254,11 +226,7 @@ export function CreateActionWizard({
     setRunMode("once");
     setReuse(false);
     setConfirm(false);
-    setShowAdvanced(false);
     setShowYaml(false);
-    setCwd("");
-    setInputs([]);
-    setSyncMode(false);
     setSaving(false);
     setTimeout(() => nameRef.current?.focus(), 50);
   }, [open]);
@@ -268,54 +236,23 @@ export function CreateActionWizard({
     setTimeout(() => commandRef.current?.focus(), 50);
   }, [open, step, shape]);
 
-  const finalKey = useMemo(() => uniqueKey(slugify(name), existingActionKeys), [name, existingActionKeys]);
-  const payload = useMemo(
-    () =>
-      buildActionPayload({
-        shape,
-        name,
-        cmd,
-        children,
-        runMode,
-        reuse,
-        confirm,
-        cwd,
-        inputs,
-        syncMode,
-        position: nextPosition,
-      }),
-    [shape, name, cmd, children, runMode, reuse, confirm, cwd, inputs, syncMode, nextPosition],
-  );
+  const buildSubmission = () => ({
+    key: uniqueKey(slugify(name), existingActionKeys),
+    payload: buildActionPayload({ shape, name, cmd, children, runMode, reuse, confirm, position: nextPosition }),
+  });
 
+  const cmdFilled = Boolean(cmd.trim());
+  const hasMenuOption = children.some((child) => child.cmd.trim());
+  const showRunMode = shape !== "dropdown" && cmdFilled;
+  const showMenuOptions = shape === "dropdown" || (shape === "split" && cmdFilled);
   const commandIsReady =
-    shape === "button"
-      ? Boolean(cmd.trim())
-      : shape === "split"
-        ? Boolean(cmd.trim()) && children.some((child) => child.cmd.trim())
-        : children.some((child) => child.cmd.trim());
-  const canContinue = step === 0 ? Boolean(name.trim()) : step === 1 ? Boolean(shape) : step === 2 ? commandIsReady : true;
+    shape === "button" ? cmdFilled : shape === "split" ? cmdFilled && hasMenuOption : hasMenuOption;
+  const canContinue =
+    step === 0 ? Boolean(name.trim()) : step === 2 ? commandIsReady : true;
   const totalSteps = 4;
   const actionLabel = name.trim() || "New action";
 
-  const title =
-    step === 0
-      ? "What should the button say?"
-      : step === 1
-        ? "How should it appear?"
-        : step === 2
-          ? shape === "button"
-            ? "What command should it run?"
-            : "What commands belong in the menu?"
-          : "Ready to add it?";
-  const hint =
-    step === 0
-      ? "Pick a short name. This is what you will click in the project header."
-      : step === 1
-        ? "Button is best for most actions. Menus are only for related commands."
-        : step === 2
-          ? "Paste the same command you would type in a terminal."
-          : "Confirm the simple summary. The button appears in the header after creation.";
-  const primaryLabel = step === 2 ? "Review action" : step === 3 ? "Create action" : "Continue";
+  const { title, hint, primary: primaryLabel } = stepCopy(step, shape);
 
   const updateName = (value: string) => {
     setName(value);
@@ -340,7 +277,8 @@ export function CreateActionWizard({
 
     setSaving(true);
     try {
-      await appendAction(projectName, finalKey, payload);
+      const { key, payload } = buildSubmission();
+      await appendAction(projectName, key, payload);
       toast.success("Action created");
       onCreated();
       onClose();
@@ -449,54 +387,16 @@ export function CreateActionWizard({
                   />
                 )}
 
-                {shape !== "button" && (
-                  <MenuOptionsEditor children={children} onChange={setChildren} />
+                {showRunMode && (
+                  <>
+                    <RunModePicker runMode={runMode} reuse={reuse} onRunMode={setRunMode} onReuse={setReuse} />
+                    <ConfirmPicker confirm={confirm} onConfirm={setConfirm} />
+                  </>
                 )}
 
-                {shape !== "dropdown" && (
-                  <RunModePicker runMode={runMode} reuse={reuse} onRunMode={setRunMode} onReuse={setReuse} />
+                {showMenuOptions && (
+                  <MenuOptionsEditor options={children} onChange={setChildren} />
                 )}
-
-                <div className="border-t border-[var(--border)] pt-5">
-                  <button
-                    type="button"
-                    onClick={() => setShowAdvanced((value) => !value)}
-                    className="-mx-2 flex w-[calc(100%+1rem)] items-center justify-between gap-3 rounded-lg px-2 py-1 text-left transition-colors hover:bg-[var(--bg-hover)]"
-                  >
-                    <span>
-                      <span className="block text-[13px] font-medium text-[var(--text-primary)]">Advanced options</span>
-                      <span className="text-[12px] text-[var(--text-muted)]">
-                        Confirmation, working folder, prompts, or SSH sync.
-                      </span>
-                    </span>
-                    <span className="text-[var(--text-muted)]">
-                      {showAdvanced ? <ChevronDownIcon /> : <ChevronRightIcon />}
-                    </span>
-                  </button>
-
-                  {showAdvanced && (
-                    <div className="mt-4 space-y-3">
-                      {shape !== "dropdown" && (
-                        <ToggleRow
-                          checked={confirm}
-                          onChange={setConfirm}
-                          title="Ask before running"
-                          description="Recommended for deploys, deletes, and migrations."
-                        />
-                      )}
-                      {isRemote && (
-                        <ToggleRow
-                          checked={syncMode}
-                          onChange={setSyncMode}
-                          title="Run locally on synced copy"
-                          description="Uses sync mode for SSH projects."
-                        />
-                      )}
-                      <CommandField label="Working folder" value={cwd} onChange={setCwd} placeholder="./frontend" />
-                      {shape !== "dropdown" && <InputsEditor inputs={inputs} onChange={setInputs} />}
-                    </div>
-                  )}
-                </div>
               </div>
             )}
 
@@ -507,7 +407,7 @@ export function CreateActionWizard({
                     <div className="min-w-0">
                       <div className="truncate text-[20px] font-semibold tracking-tight text-[var(--text-primary)]">{actionLabel}</div>
                       <div className="mt-1 text-[12px] text-[var(--text-muted)]">
-                        {shape === "button" ? "Header button" : shape === "split" ? "Split header button" : "Header dropdown"}
+                        {SHAPE_DESCRIPTION[shape]}
                       </div>
                     </div>
                     {shape !== "dropdown" && (
@@ -519,13 +419,10 @@ export function CreateActionWizard({
                   <p className="mt-3 text-[13px] leading-6 text-[var(--text-secondary)]">
                     {actionSummary(shape, name, cmd, children, runMode, reuse)}
                   </p>
-                  {(confirm || cwd.trim() || Object.keys(payload.inputs as Record<string, unknown> | undefined ?? {}).length > 0 || syncMode || (shape !== "dropdown" && runMode === "terminal" && reuse)) && (
+                  {shape !== "dropdown" && (confirm || (runMode === "terminal" && reuse)) && (
                     <div className="mt-4 flex flex-wrap gap-2">
                       {confirm && <SummaryChip>Asks before running</SummaryChip>}
-                      {cwd.trim() && <SummaryChip>Folder: {cwd.trim()}</SummaryChip>}
-                      {Object.keys(payload.inputs as Record<string, unknown> | undefined ?? {}).length > 0 && <SummaryChip>Prompts for input</SummaryChip>}
-                      {syncMode && <SummaryChip>Sync mode</SummaryChip>}
-                      {shape !== "dropdown" && runMode === "terminal" && reuse && <SummaryChip>Reuses pane on re-run</SummaryChip>}
+                      {runMode === "terminal" && reuse && <SummaryChip>Reuses pane on re-run</SummaryChip>}
                     </div>
                   )}
                 </div>
@@ -540,11 +437,14 @@ export function CreateActionWizard({
                     {showYaml ? "Hide YAML" : "Show YAML"}
                   </button>
 
-                  {showYaml && (
-                    <pre className="mt-3 max-h-56 overflow-auto whitespace-pre-wrap rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)] px-3.5 py-3 font-mono text-[12px] leading-relaxed text-[var(--text-secondary)]">
-                      {YAML.stringify({ actions: { [finalKey]: payload } }, { lineWidth: 0 })}
-                    </pre>
-                  )}
+                  {showYaml && (() => {
+                    const { key, payload } = buildSubmission();
+                    return (
+                      <pre className="mt-3 max-h-56 overflow-auto whitespace-pre-wrap rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)] px-3.5 py-3 font-mono text-[12px] leading-relaxed text-[var(--text-secondary)]">
+                        {YAML.stringify({ actions: { [key]: payload } }, { lineWidth: 0 })}
+                      </pre>
+                    );
+                  })()}
                 </div>
               </div>
             )}
@@ -818,51 +718,71 @@ function CommandField({
 }
 
 function MenuOptionsEditor({
-  children,
+  options,
   onChange,
 }: {
-  children: ChildDraft[];
-  onChange: (children: ChildDraft[]) => void;
+  options: ChildDraft[];
+  onChange: (options: ChildDraft[]) => void;
 }) {
+  const updateChild = (id: string, patch: Partial<ChildDraft>) =>
+    onChange(options.map((item) => (item.id === id ? { ...item, ...patch } : item)));
+
+  const updateField = (child: ChildDraft, field: "label" | "cmd", value: string) => {
+    const text = field === "label" ? `${value} ${child.cmd}` : `${child.label} ${value}`;
+    updateChild(child.id, {
+      [field]: value,
+      runMode: child.runMode === "once" ? inferRunMode(text) : child.runMode,
+      confirm: child.confirm || shouldConfirm(text),
+    });
+  };
+
   return (
-    <div className="space-y-2.5">
+    <div className="space-y-3">
       <div className="text-[13px] font-medium text-[var(--text-primary)]">Menu options</div>
-      {children.map((child, index) => (
-        <div key={child.id} className="grid grid-cols-[minmax(90px,0.8fr)_minmax(140px,1.4fr)_auto] gap-2">
-          <input
-            value={child.label}
-            onChange={(e) =>
-              onChange(
-                children.map((item) => (item.id === child.id ? { ...item, label: e.target.value } : item)),
-              )
-            }
-            placeholder={index === 0 ? "Production" : "Label"}
-            className="rounded-lg border border-[var(--border)] bg-[var(--bg-primary)] px-3 py-2.5 text-[12px] text-[var(--text-primary)] outline-none transition focus:border-[var(--text-primary)]"
-          />
-          <input
-            value={child.cmd}
-            onChange={(e) =>
-              onChange(
-                children.map((item) => (item.id === child.id ? { ...item, cmd: e.target.value } : item)),
-              )
-            }
-            placeholder={index === 0 ? "./deploy.sh prod" : "Command"}
-            className="rounded-lg border border-[var(--border)] bg-[var(--bg-primary)] px-3 py-2.5 font-mono text-[12px] text-[var(--text-primary)] outline-none transition focus:border-[var(--text-primary)]"
-          />
-          <button
-            type="button"
-            onClick={() => onChange(children.filter((item) => item.id !== child.id))}
-            disabled={children.length === 1}
-            aria-label="Remove option"
-            className="rounded-lg p-2 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-30"
-          >
-            <TrashIcon />
-          </button>
+      {options.map((child, index) => (
+        <div key={child.id} className="space-y-4">
+          <div className="grid grid-cols-[minmax(90px,0.8fr)_minmax(140px,1.4fr)_auto] gap-2">
+            <input
+              value={child.label}
+              onChange={(e) => updateField(child, "label", e.target.value)}
+              placeholder={index === 0 ? "Production" : "Label"}
+              className="rounded-lg border border-[var(--border)] bg-[var(--bg-primary)] px-3 py-2.5 text-[12px] text-[var(--text-primary)] outline-none transition focus:border-[var(--text-primary)]"
+            />
+            <input
+              value={child.cmd}
+              onChange={(e) => updateField(child, "cmd", e.target.value)}
+              placeholder={index === 0 ? "./deploy.sh prod" : "Command"}
+              className="rounded-lg border border-[var(--border)] bg-[var(--bg-primary)] px-3 py-2.5 font-mono text-[12px] text-[var(--text-primary)] outline-none transition focus:border-[var(--text-primary)]"
+            />
+            <button
+              type="button"
+              onClick={() => onChange(options.filter((item) => item.id !== child.id))}
+              disabled={options.length === 1}
+              aria-label="Remove option"
+              className="rounded-lg p-2 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-30"
+            >
+              <TrashIcon />
+            </button>
+          </div>
+          {child.cmd.trim() && (
+            <div className="space-y-4 border-l-2 border-[var(--border)] pl-4">
+              <RunModePicker
+                runMode={child.runMode}
+                reuse={child.reuse}
+                onRunMode={(mode) => updateChild(child.id, { runMode: mode })}
+                onReuse={(value) => updateChild(child.id, { reuse: value })}
+              />
+              <ConfirmPicker
+                confirm={child.confirm}
+                onConfirm={(value) => updateChild(child.id, { confirm: value })}
+              />
+            </div>
+          )}
         </div>
       ))}
       <button
         type="button"
-        onClick={() => onChange([...children, newChild()])}
+        onClick={() => onChange([...options, newChild()])}
         className="flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-[12px] font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
       >
         <PlusIcon /> Add menu option
@@ -903,6 +823,29 @@ function RunModePicker({
   );
 }
 
+function ConfirmPicker({
+  confirm,
+  onConfirm,
+}: {
+  confirm: boolean;
+  onConfirm: (value: boolean) => void;
+}) {
+  return (
+    <div>
+      <div className="mb-2.5 flex items-center justify-between gap-3">
+        <span className="text-[13px] font-medium text-[var(--text-primary)]">Confirm before running?</span>
+        <span className="text-[12px] text-[var(--text-muted)]">
+          {confirm ? "Shows a confirmation dialog before running." : "Runs as soon as you click."}
+        </span>
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <ModeButton active={!confirm} icon={<PlayIcon />} title="Run immediately" onClick={() => onConfirm(false)} />
+        <ModeButton active={confirm} icon={<HelpCircleIcon />} title="Ask before running" onClick={() => onConfirm(true)} />
+      </div>
+    </div>
+  );
+}
+
 function ModeButton({
   active,
   icon,
@@ -927,121 +870,6 @@ function ModeButton({
       {icon}
       {title}
     </button>
-  );
-}
-
-function ToggleRow({
-  checked,
-  onChange,
-  title,
-  description,
-}: {
-  checked: boolean;
-  onChange: (value: boolean) => void;
-  title: string;
-  description: string;
-}) {
-  return (
-    <label className="flex cursor-pointer items-start gap-3 rounded-xl border border-[var(--border)] bg-[var(--bg-primary)] px-3.5 py-3 transition-colors hover:border-[var(--text-muted)]">
-      <input className="mt-0.5" type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} />
-      <span>
-        <span className="block text-[13px] font-medium text-[var(--text-primary)]">{title}</span>
-        <span className="text-[12px] text-[var(--text-muted)]">{description}</span>
-      </span>
-    </label>
-  );
-}
-
-function InputsEditor({ inputs, onChange }: { inputs: InputDraft[]; onChange: (inputs: InputDraft[]) => void }) {
-  return (
-    <div>
-      <div className="mb-2 flex items-center justify-between">
-        <span className="text-[12px] font-medium text-[var(--text-primary)]">Ask for input before running</span>
-        <button
-          type="button"
-          onClick={() => onChange([...inputs, newInput()])}
-          className="text-[11px] font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
-        >
-          Add input
-        </button>
-      </div>
-      {inputs.length === 0 ? (
-        <div className="rounded-lg border border-dashed border-[var(--border)] px-3 py-2 text-[11px] text-[var(--text-muted)]">
-          No prompts added.
-        </div>
-      ) : (
-        <div className="space-y-2">
-          {inputs.map((input) => (
-            <div key={input.id} className="rounded-xl border border-[var(--border)] bg-[var(--bg-primary)] p-2.5">
-              <div className="grid grid-cols-2 gap-2">
-                <input
-                  value={input.key}
-                  onChange={(e) => onChange(inputs.map((item) => (item.id === input.id ? { ...item, key: e.target.value } : item)))}
-                  placeholder="tag"
-                  className="rounded-lg border border-[var(--border)] bg-transparent px-2 py-1.5 text-[11px] text-[var(--text-primary)] outline-none focus:border-[var(--text-secondary)]"
-                />
-                <input
-                  value={input.label}
-                  onChange={(e) => onChange(inputs.map((item) => (item.id === input.id ? { ...item, label: e.target.value } : item)))}
-                  placeholder="Release tag"
-                  className="rounded-lg border border-[var(--border)] bg-transparent px-2 py-1.5 text-[11px] text-[var(--text-primary)] outline-none focus:border-[var(--text-secondary)]"
-                />
-              </div>
-              <div className="mt-2 grid grid-cols-[1fr_auto] gap-2">
-                <select
-                  value={input.type}
-                  onChange={(e) =>
-                    onChange(inputs.map((item) => (item.id === input.id ? { ...item, type: e.target.value as InputDraft["type"] } : item)))
-                  }
-                  className="rounded-lg border border-[var(--border)] bg-[var(--bg-primary)] px-2 py-1.5 text-[11px] text-[var(--text-primary)] outline-none focus:border-[var(--text-secondary)]"
-                >
-                  <option value="text">Text</option>
-                  <option value="password">Password</option>
-                  <option value="radio">Choice</option>
-                </select>
-                <label className="flex items-center gap-1.5 text-[11px] text-[var(--text-secondary)]">
-                  <input
-                    type="checkbox"
-                    checked={input.required}
-                    onChange={(e) => onChange(inputs.map((item) => (item.id === input.id ? { ...item, required: e.target.checked } : item)))}
-                  />
-                  Required
-                </label>
-              </div>
-              {input.type === "radio" && (
-                <input
-                  value={input.options}
-                  onChange={(e) => onChange(inputs.map((item) => (item.id === input.id ? { ...item, options: e.target.value } : item)))}
-                  placeholder="staging, production"
-                  className="mt-2 w-full rounded-lg border border-[var(--border)] bg-transparent px-2 py-1.5 text-[11px] text-[var(--text-primary)] outline-none focus:border-[var(--text-secondary)]"
-                />
-              )}
-              <div className="mt-2 grid grid-cols-2 gap-2">
-                <input
-                  value={input.placeholder}
-                  onChange={(e) => onChange(inputs.map((item) => (item.id === input.id ? { ...item, placeholder: e.target.value } : item)))}
-                  placeholder="Placeholder"
-                  className="rounded-lg border border-[var(--border)] bg-transparent px-2 py-1.5 text-[11px] text-[var(--text-primary)] outline-none focus:border-[var(--text-secondary)]"
-                />
-                <input
-                  value={input.defaultValue}
-                  onChange={(e) => onChange(inputs.map((item) => (item.id === input.id ? { ...item, defaultValue: e.target.value } : item)))}
-                  placeholder="Default"
-                  className="rounded-lg border border-[var(--border)] bg-transparent px-2 py-1.5 text-[11px] text-[var(--text-primary)] outline-none focus:border-[var(--text-secondary)]"
-                />
-              </div>
-              <button
-                type="button"
-                onClick={() => onChange(inputs.filter((item) => item.id !== input.id))}
-                className="mt-2 text-[11px] text-[var(--text-muted)] hover:text-[var(--text-primary)]"
-              >
-                Remove input
-              </button>
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
   );
 }
 

--- a/desktop/frontend/src/components/project-detail/CreateActionWizard.tsx
+++ b/desktop/frontend/src/components/project-detail/CreateActionWizard.tsx
@@ -1,0 +1,1009 @@
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type ReactNode, type Ref } from "react";
+import YAML from "yaml";
+import { toast } from "sonner";
+import { ReadConfig, SaveConfig } from "../../../wailsjs/go/main/App";
+import {
+  CheckIcon,
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  PlusIcon,
+  SparkleIcon,
+  TerminalIcon,
+  TrashIcon,
+  XIcon,
+  ZapIcon,
+} from "../icons";
+import { Modal } from "../ui/Modal";
+
+type Shape = "button" | "split" | "dropdown";
+type RunMode = "once" | "terminal" | "background";
+
+const SHAPE_PREVIEW_BUTTON_CLASS =
+  "border-[var(--text-muted)] bg-[var(--bg-primary)] text-[var(--text-primary)] shadow-sm";
+
+interface ChildDraft {
+  id: string;
+  label: string;
+  cmd: string;
+}
+
+interface InputDraft {
+  id: string;
+  key: string;
+  label: string;
+  type: "text" | "password" | "radio";
+  required: boolean;
+  placeholder: string;
+  defaultValue: string;
+  options: string;
+}
+
+interface CreateActionWizardProps {
+  open: boolean;
+  projectName: string;
+  isRemote: boolean;
+  existingActionKeys: string[];
+  nextPosition: number;
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+function newId() {
+  return crypto.randomUUID();
+}
+
+function slugify(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/['"]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function uniqueKey(base: string, existing: string[]): string {
+  const seed = base || "new-action";
+  if (!existing.includes(seed)) return seed;
+  let i = 2;
+  while (existing.includes(`${seed}-${i}`)) i += 1;
+  return `${seed}-${i}`;
+}
+
+function newChild(): ChildDraft {
+  return { id: newId(), label: "", cmd: "" };
+}
+
+function newInput(): InputDraft {
+  return {
+    id: newId(),
+    key: "",
+    label: "",
+    type: "text",
+    required: false,
+    placeholder: "",
+    defaultValue: "",
+    options: "",
+  };
+}
+
+function inferRunMode(text: string): RunMode {
+  const value = text.toLowerCase();
+  if (/\b(tail|watch|log|logs|shell|console|server)\b/.test(value)) return "terminal";
+  if (/\b(fetch|pull|build|install|compile|generate)\b/.test(value)) return "background";
+  return "once";
+}
+
+function shouldConfirm(text: string): boolean {
+  return /\b(deploy|migrate|reset|drop|delete|destroy|remove|kill|prune)\b/i.test(text);
+}
+
+function suggestedCommand(name: string): { label: string; cmd: string } | null {
+  const value = name.toLowerCase();
+  if (/\b(test|spec|check)\b/.test(value)) return { label: "Use npm test", cmd: "npm test" };
+  if (/\b(build|compile)\b/.test(value)) return { label: "Use npm run build", cmd: "npm run build" };
+  if (/\b(dev|server|start)\b/.test(value)) return { label: "Use npm run dev", cmd: "npm run dev" };
+  if (/\b(log|logs|tail)\b/.test(value)) return { label: "Use tail -f log/development.log", cmd: "tail -f log/development.log" };
+  if (/\b(shell|terminal|console)\b/.test(value)) return { label: "Use current shell", cmd: "$SHELL" };
+  if (/\b(migrate|migration)\b/.test(value)) return { label: "Use rails db:migrate", cmd: "rails db:migrate" };
+  if (/\b(seed)\b/.test(value)) return { label: "Use rails db:seed", cmd: "rails db:seed" };
+  if (/\b(deploy)\b/.test(value)) return { label: "Use deploy script", cmd: "./deploy.sh" };
+  return null;
+}
+
+function runModeLabel(mode: RunMode) {
+  if (mode === "terminal") return "Terminal";
+  if (mode === "background") return "Background";
+  return "Run once";
+}
+
+function runModeHint(mode: RunMode, reuse: boolean) {
+  if (mode === "terminal") {
+    return reuse ? "Opens one terminal pane and reuses it next time." : "Opens a terminal pane for the command.";
+  }
+  if (mode === "background") return "Runs quietly and shows a notification when it finishes.";
+  return "Runs the command once and shows the result.";
+}
+
+function actionSummary(shape: Shape, name: string, cmd: string, children: ChildDraft[], runMode: RunMode, reuse: boolean) {
+  const label = name.trim() || "New action";
+  if (shape === "dropdown") {
+    const count = children.filter((child) => child.cmd.trim()).length;
+    return `${label} adds a header menu with ${count || "your"} command${count === 1 ? "" : "s"}.`;
+  }
+  if (shape === "split") {
+    const count = children.filter((child) => child.cmd.trim()).length;
+    return `${label} runs a default command and includes ${count || "extra"} menu option${count === 1 ? "" : "s"}.`;
+  }
+  return `${label} ${runModeHint(runMode, reuse).toLowerCase()} Command: ${cmd || "not set yet"}.`;
+}
+
+function buildActionPayload({
+  shape,
+  name,
+  cmd,
+  children,
+  runMode,
+  reuse,
+  confirm,
+  cwd,
+  inputs,
+  syncMode,
+  position,
+}: {
+  shape: Shape;
+  name: string;
+  cmd: string;
+  children: ChildDraft[];
+  runMode: RunMode;
+  reuse: boolean;
+  confirm: boolean;
+  cwd: string;
+  inputs: InputDraft[];
+  syncMode: boolean;
+  position: number;
+}) {
+  const payload: Record<string, unknown> = {
+    label: name.trim(),
+    display: "header",
+    position,
+  };
+
+  if (shape !== "dropdown") payload.cmd = cmd.trim();
+  if (shape !== "dropdown" && runMode !== "once") payload.type = runMode;
+  if (shape !== "dropdown" && runMode === "terminal" && reuse) payload.reuse = true;
+  if (shape !== "dropdown" && confirm) payload.confirm = true;
+  if (cwd.trim()) payload.cwd = cwd.trim();
+  if (syncMode) payload.mode = "sync";
+
+  const inputMap: Record<string, unknown> = {};
+  for (const input of inputs) {
+    const key = slugify(input.key || input.label);
+    if (!key) continue;
+    const value: Record<string, unknown> = {};
+    if (input.label.trim()) value.label = input.label.trim();
+    if (input.type !== "text") value.type = input.type;
+    if (input.required) value.required = true;
+    if (input.placeholder.trim()) value.placeholder = input.placeholder.trim();
+    if (input.defaultValue.trim()) value.default = input.defaultValue.trim();
+    if (input.type === "radio") {
+      const options = input.options
+        .split(",")
+        .map((option) => option.trim())
+        .filter(Boolean);
+      if (options.length) value.options = options;
+    }
+    inputMap[key] = value;
+  }
+  if (shape !== "dropdown" && Object.keys(inputMap).length) payload.inputs = inputMap;
+
+  if (shape !== "button") {
+    const childMap: Record<string, unknown> = {};
+    const used: string[] = [];
+    children
+      .filter((child) => child.cmd.trim())
+      .forEach((child, index) => {
+        const key = uniqueKey(slugify(child.label) || `option-${index + 1}`, used);
+        used.push(key);
+        childMap[key] = {
+          label: child.label.trim() || key,
+          cmd: child.cmd.trim(),
+          position: index + 1,
+        };
+      });
+    payload.actions = childMap;
+  }
+
+  return payload;
+}
+
+async function appendAction(projectName: string, key: string, payload: Record<string, unknown>) {
+  const content = await ReadConfig(projectName);
+  const doc = YAML.parseDocument(content || "{}");
+  let actions = doc.get("actions", true);
+  if (!YAML.isMap(actions)) {
+    actions = doc.createNode({});
+    doc.set("actions", actions);
+  }
+  if (YAML.isMap(actions)) actions.set(key, payload);
+  await SaveConfig(projectName, String(doc));
+}
+
+export function CreateActionWizard({
+  open,
+  projectName,
+  isRemote,
+  existingActionKeys,
+  nextPosition,
+  onClose,
+  onCreated,
+}: CreateActionWizardProps) {
+  const [step, setStep] = useState(0);
+  const [name, setName] = useState("");
+  const [shape, setShape] = useState<Shape>("button");
+  const [cmd, setCmd] = useState("");
+  const [children, setChildren] = useState<ChildDraft[]>([newChild()]);
+  const [runMode, setRunMode] = useState<RunMode>("once");
+  const [reuse, setReuse] = useState(true);
+  const [confirm, setConfirm] = useState(false);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [showYaml, setShowYaml] = useState(false);
+  const [cwd, setCwd] = useState("");
+  const [inputs, setInputs] = useState<InputDraft[]>([]);
+  const [syncMode, setSyncMode] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const nameRef = useRef<HTMLInputElement>(null);
+  const commandRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setStep(0);
+    setName("");
+    setShape("button");
+    setCmd("");
+    setChildren([newChild()]);
+    setRunMode("once");
+    setReuse(true);
+    setConfirm(false);
+    setShowAdvanced(false);
+    setShowYaml(false);
+    setCwd("");
+    setInputs([]);
+    setSyncMode(false);
+    setSaving(false);
+    setTimeout(() => nameRef.current?.focus(), 50);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || step !== 2) return;
+    setTimeout(() => commandRef.current?.focus(), 50);
+  }, [open, step, shape]);
+
+  const finalKey = useMemo(() => uniqueKey(slugify(name), existingActionKeys), [name, existingActionKeys]);
+  const commandSuggestion = useMemo(() => (cmd.trim() ? null : suggestedCommand(name)), [name, cmd]);
+  const payload = useMemo(
+    () =>
+      buildActionPayload({
+        shape,
+        name,
+        cmd,
+        children,
+        runMode,
+        reuse,
+        confirm,
+        cwd,
+        inputs,
+        syncMode,
+        position: nextPosition,
+      }),
+    [shape, name, cmd, children, runMode, reuse, confirm, cwd, inputs, syncMode, nextPosition],
+  );
+
+  const commandIsReady =
+    shape === "button"
+      ? Boolean(cmd.trim())
+      : shape === "split"
+        ? Boolean(cmd.trim()) && children.some((child) => child.cmd.trim())
+        : children.some((child) => child.cmd.trim());
+  const canContinue = step === 0 ? Boolean(name.trim()) : step === 1 ? Boolean(shape) : step === 2 ? commandIsReady : true;
+  const totalSteps = 4;
+  const progress = ((step + 1) / totalSteps) * 100;
+  const actionLabel = name.trim() || "New action";
+
+  const title =
+    step === 0
+      ? "What should the button say?"
+      : step === 1
+        ? "How should it appear?"
+        : step === 2
+          ? shape === "button"
+            ? "What command should it run?"
+            : "What commands belong in the menu?"
+          : "Ready to add it?";
+  const hint =
+    step === 0
+      ? "Pick a short name. This is what you will click in the project header."
+      : step === 1
+        ? "Button is best for most actions. Menus are only for related commands."
+        : step === 2
+          ? "Paste the same command you would type in a terminal."
+          : "Confirm the simple summary. The button appears in the header after creation.";
+  const primaryLabel = step === 2 ? "Review action" : step === 3 ? "Create action" : "Continue";
+
+  const updateName = (value: string) => {
+    setName(value);
+    const inferred = inferRunMode(`${value} ${cmd}`);
+    setRunMode((current) => (current === "once" ? inferred : current));
+    if (shouldConfirm(value)) setConfirm(true);
+  };
+
+  const updateCmd = (value: string) => {
+    setCmd(value);
+    const inferred = inferRunMode(`${name} ${value}`);
+    setRunMode((current) => (current === "once" ? inferred : current));
+    if (shouldConfirm(`${name} ${value}`)) setConfirm(true);
+  };
+
+  const goNext = async () => {
+    if (!canContinue || saving) return;
+    if (step < 3) {
+      setStep((current) => current + 1);
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await appendAction(projectName, finalKey, payload);
+      toast.success("Action created");
+      onCreated();
+      onClose();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Could not create action");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      void goNext();
+    }
+  };
+
+  const submitOnEnter = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== "Enter") return;
+    e.preventDefault();
+    void goNext();
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      contentClassName="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--bg-primary)] shadow-2xl"
+    >
+      <div className="flex max-h-[86vh] w-[min(920px,calc(100vw-32px))] flex-col" onKeyDown={onKeyDown}>
+        <div className="border-b border-[var(--border)] px-5 pb-4 pt-4">
+          <div className="mb-4 flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                Create action - Step {step + 1} of {totalSteps}
+              </div>
+              <h2 className="mt-1 text-[18px] font-semibold tracking-tight text-[var(--text-primary)]">{title}</h2>
+              <p className="mt-1 max-w-[440px] text-[12px] leading-5 text-[var(--text-secondary)]">{hint}</p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="rounded-lg p-1.5 text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+            >
+              <XIcon />
+            </button>
+          </div>
+          <div className="h-1.5 overflow-hidden rounded-full bg-[var(--bg-secondary)]">
+            <div
+              className="h-full rounded-full bg-[var(--text-primary)] transition-all duration-300"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+
+        <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
+          <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5">
+            {step === 0 && (
+              <div className="space-y-5">
+                <label className="block">
+                  <span className="mb-2 block text-[12px] font-medium text-[var(--text-primary)]">Button name</span>
+                  <input
+                    ref={nameRef}
+                    value={name}
+                    onChange={(e) => updateName(e.target.value)}
+                    onKeyDown={submitOnEnter}
+                    placeholder="Run tests"
+                    className="w-full rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)] px-3 py-3 text-[16px] text-[var(--text-primary)] outline-none transition placeholder:text-[var(--text-muted)] focus:border-[var(--text-secondary)]"
+                  />
+                </label>
+              </div>
+            )}
+
+            {step === 1 && (
+              <div className="space-y-3">
+                <ShapeChoice
+                  active={shape === "button"}
+                  shape="button"
+                  title="Button"
+                  badge="Recommended"
+                  description="One click runs one command. Best for most actions."
+                  previewLabel="Run tests"
+                  onClick={() => setShape("button")}
+                />
+                <ShapeChoice
+                  active={shape === "split"}
+                  shape="split"
+                  title="Split button"
+                  description="A main command plus a small menu of alternatives."
+                  previewLabel="Deploy"
+                  onClick={() => setShape("split")}
+                />
+                <ShapeChoice
+                  active={shape === "dropdown"}
+                  shape="dropdown"
+                  title="Dropdown menu"
+                  description="Only a menu. Good for grouped commands like database tasks."
+                  previewLabel="Database"
+                  onClick={() => setShape("dropdown")}
+                />
+              </div>
+            )}
+
+            {step === 2 && (
+              <div className="space-y-5">
+                {shape !== "dropdown" && (
+                  <CommandField
+                    inputRef={commandRef}
+                    label={shape === "split" ? "Default command" : "Command"}
+                    value={cmd}
+                    onChange={updateCmd}
+                    onEnter={() => void goNext()}
+                    placeholder={shape === "split" ? "./deploy.sh staging" : "npm run dev"}
+                  />
+                )}
+
+                {commandSuggestion && shape !== "dropdown" && (
+                  <button
+                    type="button"
+                    onClick={() => updateCmd(commandSuggestion.cmd)}
+                    className="flex w-full items-center justify-between gap-3 rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)] px-3 py-2.5 text-left transition hover:border-[var(--text-muted)] hover:bg-[var(--bg-hover)]"
+                  >
+                    <span>
+                      <span className="block text-[12px] font-medium text-[var(--text-primary)]">{commandSuggestion.label}</span>
+                      <span className="font-mono text-[11px] text-[var(--text-muted)]">{commandSuggestion.cmd}</span>
+                    </span>
+                    <span className="text-[11px] font-medium text-[var(--text-secondary)]">Use</span>
+                  </button>
+                )}
+
+                {shape !== "button" && (
+                  <MenuOptionsEditor children={children} onChange={setChildren} />
+                )}
+
+                {shape !== "dropdown" && (
+                  <RunModePicker runMode={runMode} reuse={reuse} onRunMode={setRunMode} onReuse={setReuse} />
+                )}
+
+                <div className="rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] p-3">
+                  <button
+                    type="button"
+                    onClick={() => setShowAdvanced((value) => !value)}
+                    className="flex w-full items-center justify-between gap-3 text-left"
+                  >
+                    <span>
+                      <span className="block text-[12px] font-medium text-[var(--text-primary)]">Need anything extra?</span>
+                      <span className="text-[11px] text-[var(--text-muted)]">
+                        Add confirmation, a folder, prompts, or SSH sync only if needed.
+                      </span>
+                    </span>
+                    <span className="flex items-center gap-1 text-[12px] font-medium text-[var(--text-secondary)]">
+                      {showAdvanced ? "Hide" : "Show"}
+                      {showAdvanced ? <ChevronDownIcon /> : <ChevronRightIcon />}
+                    </span>
+                  </button>
+
+                  {showAdvanced && (
+                    <div className="mt-4 space-y-4">
+                      {shape !== "dropdown" && (
+                        <ToggleRow
+                          checked={confirm}
+                          onChange={setConfirm}
+                          title="Ask before running"
+                          description="Recommended for deploys, deletes, and migrations."
+                        />
+                      )}
+                      {isRemote && (
+                        <ToggleRow
+                          checked={syncMode}
+                          onChange={setSyncMode}
+                          title="Run locally on synced copy"
+                          description="Uses sync mode for SSH projects."
+                        />
+                      )}
+                      <CommandField label="Working folder" value={cwd} onChange={setCwd} placeholder="./frontend" />
+                      {shape !== "dropdown" && <InputsEditor inputs={inputs} onChange={setInputs} />}
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {step === 3 && (
+              <div className="space-y-4">
+                <div className="rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] p-4">
+                  <div className="mb-3 flex items-center justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="truncate text-[15px] font-semibold text-[var(--text-primary)]">{actionLabel}</div>
+                      <div className="mt-1 text-[12px] text-[var(--text-secondary)]">
+                        {shape === "button" ? "Header button" : shape === "split" ? "Split header button" : "Header dropdown"}
+                      </div>
+                    </div>
+                    {shape !== "dropdown" && (
+                      <span className="rounded-full border border-[var(--border)] bg-[var(--bg-primary)] px-2 py-1 text-[11px] text-[var(--text-secondary)]">
+                        {runModeLabel(runMode)}
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-[13px] leading-5 text-[var(--text-secondary)]">
+                    {actionSummary(shape, name, cmd, children, runMode, reuse)}
+                  </p>
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {confirm && <SummaryChip>Asks before running</SummaryChip>}
+                    {cwd.trim() && <SummaryChip>Folder: {cwd.trim()}</SummaryChip>}
+                    {Object.keys(payload.inputs as Record<string, unknown> | undefined ?? {}).length > 0 && <SummaryChip>Prompts for input</SummaryChip>}
+                    {syncMode && <SummaryChip>Sync mode</SummaryChip>}
+                    {shape !== "dropdown" && runMode === "terminal" && reuse && <SummaryChip>Reuses terminal</SummaryChip>}
+                  </div>
+                </div>
+
+                <button
+                  type="button"
+                  onClick={() => setShowYaml((value) => !value)}
+                  className="flex items-center gap-1.5 rounded-lg px-1 py-1 text-[11px] font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+                >
+                  {showYaml ? <ChevronDownIcon /> : <ChevronRightIcon />}
+                  {showYaml ? "Hide YAML" : "Show YAML"}
+                </button>
+
+                {showYaml && (
+                  <pre className="max-h-56 overflow-auto whitespace-pre-wrap rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)] px-3 py-2 font-mono text-[11px] leading-relaxed text-[var(--text-secondary)]">
+                    {YAML.stringify({ actions: { [finalKey]: payload } }, { lineWidth: 0 })}
+                  </pre>
+                )}
+              </div>
+            )}
+          </div>
+
+          <ActionPreviewPanel
+            name={actionLabel}
+            shape={shape}
+          />
+        </div>
+
+        <div className="flex items-center justify-between gap-3 border-t border-[var(--border)] px-5 py-4">
+          <button
+            type="button"
+            onClick={() => (step === 0 ? onClose() : setStep((current) => current - 1))}
+            className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-[12px] font-medium text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+          >
+            {step === 0 ? (
+              "Cancel"
+            ) : (
+              <>
+                <ChevronLeftIcon /> Back
+              </>
+            )}
+          </button>
+          <div className="flex items-center gap-3">
+            {!canContinue && (
+              <span className="hidden text-[11px] text-[var(--text-muted)] sm:inline">
+                {step === 0 ? "Name is required" : "Command is required"}
+              </span>
+            )}
+            <button
+              type="button"
+              onClick={() => void goNext()}
+              disabled={!canContinue || saving}
+              className="rounded-lg bg-[var(--text-primary)] px-4 py-2 text-[12px] font-semibold text-[var(--bg-primary)] transition hover:opacity-85 disabled:opacity-40"
+            >
+              {saving ? "Creating..." : primaryLabel}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function ActionPreviewPanel({
+  name,
+  shape,
+}: {
+  name: string;
+  shape: Shape;
+}) {
+  const hasName = name.trim().length > 0 && name !== "New action";
+
+  return (
+    <aside className="flex border-t border-[var(--border)] px-5 py-5 lg:w-[300px] lg:shrink-0 lg:border-l lg:border-t-0">
+      <div className="flex min-h-[140px] flex-1 flex-col lg:min-h-0">
+        <div className="mb-3 text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
+          Preview
+        </div>
+
+        <div className="flex flex-1 items-center justify-center">
+          {hasName ? (
+            <div className="pointer-events-none max-w-full">
+              <ShapePreviewButton shape={shape} label={name} />
+            </div>
+          ) : (
+            <div className="h-7 w-24 rounded-md border border-dashed border-[var(--border)]" />
+          )}
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+function ShapeChoice({
+  active,
+  shape,
+  title,
+  badge,
+  description,
+  previewLabel,
+  onClick,
+}: {
+  active: boolean;
+  shape: Shape;
+  title: string;
+  badge?: string;
+  description: string;
+  previewLabel: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex w-full items-center gap-3 rounded-2xl border px-4 py-3 text-left transition ${
+        active
+          ? "border-[var(--text-primary)] bg-[var(--bg-hover)]"
+          : "border-[var(--border)] bg-[var(--bg-secondary)] hover:border-[var(--text-muted)]"
+      }`}
+    >
+      <span
+        className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full border ${
+          active ? "border-[var(--text-primary)] bg-[var(--text-primary)] text-[var(--bg-primary)]" : "border-[var(--border)]"
+        }`}
+      >
+        {active && <CheckIcon />}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-2">
+          <span className="text-[14px] font-medium text-[var(--text-primary)]">{title}</span>
+          {badge && (
+            <span className="rounded-full border border-[var(--border)] px-1.5 py-0.5 text-[10px] text-[var(--text-muted)]">
+              {badge}
+            </span>
+          )}
+        </span>
+        <span className="mt-0.5 block text-[12px] text-[var(--text-secondary)]">{description}</span>
+      </span>
+      <span className="hidden shrink-0 sm:block">
+        <ShapePreviewButton shape={shape} label={previewLabel} />
+      </span>
+    </button>
+  );
+}
+
+function ShapePreviewButton({ shape, label }: { shape: Shape; label: string }) {
+  if (shape === "button") {
+    return (
+      <span
+        className={`inline-flex whitespace-nowrap rounded-lg border px-3.5 py-1.5 text-xs font-medium ${SHAPE_PREVIEW_BUTTON_CLASS}`}
+      >
+        {label}
+      </span>
+    );
+  }
+
+  if (shape === "split") {
+    return (
+      <span className={`inline-flex items-stretch rounded-lg border text-xs font-medium ${SHAPE_PREVIEW_BUTTON_CLASS}`}>
+        <span className="whitespace-nowrap rounded-l-lg px-3.5 py-1.5">{label}</span>
+        <span className="flex items-center rounded-r-lg border-l border-[var(--text-muted)] px-1.5">
+          <ChevronDownIcon />
+        </span>
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 whitespace-nowrap rounded-lg border px-3.5 py-1.5 text-xs font-medium ${SHAPE_PREVIEW_BUTTON_CLASS}`}
+    >
+      {label}
+      <ChevronDownIcon />
+    </span>
+  );
+}
+
+function CommandField({
+  inputRef,
+  label,
+  value,
+  onChange,
+  onEnter,
+  placeholder,
+}: {
+  inputRef?: Ref<HTMLInputElement>;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  onEnter?: () => void;
+  placeholder: string;
+}) {
+  return (
+    <label className="block">
+      <span className="mb-2 block text-[12px] font-medium text-[var(--text-primary)]">{label}</span>
+      <input
+        ref={inputRef}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (!onEnter || e.key !== "Enter") return;
+          e.preventDefault();
+          onEnter();
+        }}
+        placeholder={placeholder}
+        className="w-full rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)] px-3 py-2.5 font-mono text-[13px] text-[var(--text-primary)] outline-none transition placeholder:font-sans placeholder:text-[var(--text-muted)] focus:border-[var(--text-secondary)]"
+      />
+    </label>
+  );
+}
+
+function MenuOptionsEditor({
+  children,
+  onChange,
+}: {
+  children: ChildDraft[];
+  onChange: (children: ChildDraft[]) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="text-[12px] font-medium text-[var(--text-primary)]">Menu options</div>
+      {children.map((child, index) => (
+        <div key={child.id} className="grid grid-cols-[minmax(90px,0.8fr)_minmax(140px,1.4fr)_auto] gap-2">
+          <input
+            value={child.label}
+            onChange={(e) =>
+              onChange(
+                children.map((item) => (item.id === child.id ? { ...item, label: e.target.value } : item)),
+              )
+            }
+            placeholder={index === 0 ? "Production" : "Label"}
+            className="rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)] px-2.5 py-2 text-[12px] text-[var(--text-primary)] outline-none focus:border-[var(--text-secondary)]"
+          />
+          <input
+            value={child.cmd}
+            onChange={(e) =>
+              onChange(
+                children.map((item) => (item.id === child.id ? { ...item, cmd: e.target.value } : item)),
+              )
+            }
+            placeholder={index === 0 ? "./deploy.sh prod" : "Command"}
+            className="rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)] px-2.5 py-2 font-mono text-[12px] text-[var(--text-primary)] outline-none focus:border-[var(--text-secondary)]"
+          />
+          <button
+            type="button"
+            onClick={() => onChange(children.filter((item) => item.id !== child.id))}
+            disabled={children.length === 1}
+            aria-label="Remove option"
+            className="rounded-lg p-2 text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-30"
+          >
+            <TrashIcon />
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={() => onChange([...children, newChild()])}
+        className="flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-[12px] font-medium text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+      >
+        <PlusIcon /> Add menu option
+      </button>
+    </div>
+  );
+}
+
+function RunModePicker({
+  runMode,
+  reuse,
+  onRunMode,
+  onReuse,
+}: {
+  runMode: RunMode;
+  reuse: boolean;
+  onRunMode: (mode: RunMode) => void;
+  onReuse: (value: boolean) => void;
+}) {
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <span className="text-[12px] font-medium text-[var(--text-primary)]">How should it run?</span>
+        <span className="text-[11px] text-[var(--text-muted)]">{runModeHint(runMode, reuse)}</span>
+      </div>
+      <div className="grid grid-cols-3 gap-2">
+        <ModeButton active={runMode === "once"} icon={<ZapIcon />} title="Once" onClick={() => onRunMode("once")} />
+        <ModeButton active={runMode === "terminal"} icon={<TerminalIcon />} title="Terminal" onClick={() => onRunMode("terminal")} />
+        <ModeButton active={runMode === "background"} icon={<SparkleIcon />} title="Background" onClick={() => onRunMode("background")} />
+      </div>
+      {runMode === "terminal" && (
+        <label className="mt-3 flex items-center gap-2 text-[12px] text-[var(--text-secondary)]">
+          <input type="checkbox" checked={reuse} onChange={(e) => onReuse(e.target.checked)} />
+          Reuse the same terminal pane next time
+        </label>
+      )}
+    </div>
+  );
+}
+
+function ModeButton({
+  active,
+  icon,
+  title,
+  onClick,
+}: {
+  active: boolean;
+  icon: ReactNode;
+  title: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center justify-center gap-1.5 rounded-xl border px-2 py-2 text-[12px] font-medium transition ${
+        active
+          ? "border-[var(--text-primary)] bg-[var(--text-primary)] text-[var(--bg-primary)]"
+          : "border-[var(--border)] bg-[var(--bg-secondary)] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+      }`}
+    >
+      {icon}
+      {title}
+    </button>
+  );
+}
+
+function ToggleRow({
+  checked,
+  onChange,
+  title,
+  description,
+}: {
+  checked: boolean;
+  onChange: (value: boolean) => void;
+  title: string;
+  description: string;
+}) {
+  return (
+    <label className="flex items-start gap-3 rounded-xl border border-[var(--border)] bg-[var(--bg-primary)] px-3 py-2.5">
+      <input className="mt-0.5" type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} />
+      <span>
+        <span className="block text-[12px] font-medium text-[var(--text-primary)]">{title}</span>
+        <span className="text-[11px] text-[var(--text-muted)]">{description}</span>
+      </span>
+    </label>
+  );
+}
+
+function InputsEditor({ inputs, onChange }: { inputs: InputDraft[]; onChange: (inputs: InputDraft[]) => void }) {
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-[12px] font-medium text-[var(--text-primary)]">Ask for input before running</span>
+        <button
+          type="button"
+          onClick={() => onChange([...inputs, newInput()])}
+          className="text-[11px] font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+        >
+          Add input
+        </button>
+      </div>
+      {inputs.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-[var(--border)] px-3 py-2 text-[11px] text-[var(--text-muted)]">
+          No prompts added.
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {inputs.map((input) => (
+            <div key={input.id} className="rounded-xl border border-[var(--border)] bg-[var(--bg-primary)] p-2.5">
+              <div className="grid grid-cols-2 gap-2">
+                <input
+                  value={input.key}
+                  onChange={(e) => onChange(inputs.map((item) => (item.id === input.id ? { ...item, key: e.target.value } : item)))}
+                  placeholder="tag"
+                  className="rounded-lg border border-[var(--border)] bg-transparent px-2 py-1.5 text-[11px] text-[var(--text-primary)] outline-none focus:border-[var(--text-secondary)]"
+                />
+                <input
+                  value={input.label}
+                  onChange={(e) => onChange(inputs.map((item) => (item.id === input.id ? { ...item, label: e.target.value } : item)))}
+                  placeholder="Release tag"
+                  className="rounded-lg border border-[var(--border)] bg-transparent px-2 py-1.5 text-[11px] text-[var(--text-primary)] outline-none focus:border-[var(--text-secondary)]"
+                />
+              </div>
+              <div className="mt-2 grid grid-cols-[1fr_auto] gap-2">
+                <select
+                  value={input.type}
+                  onChange={(e) =>
+                    onChange(inputs.map((item) => (item.id === input.id ? { ...item, type: e.target.value as InputDraft["type"] } : item)))
+                  }
+                  className="rounded-lg border border-[var(--border)] bg-[var(--bg-primary)] px-2 py-1.5 text-[11px] text-[var(--text-primary)] outline-none focus:border-[var(--text-secondary)]"
+                >
+                  <option value="text">Text</option>
+                  <option value="password">Password</option>
+                  <option value="radio">Choice</option>
+                </select>
+                <label className="flex items-center gap-1.5 text-[11px] text-[var(--text-secondary)]">
+                  <input
+                    type="checkbox"
+                    checked={input.required}
+                    onChange={(e) => onChange(inputs.map((item) => (item.id === input.id ? { ...item, required: e.target.checked } : item)))}
+                  />
+                  Required
+                </label>
+              </div>
+              {input.type === "radio" && (
+                <input
+                  value={input.options}
+                  onChange={(e) => onChange(inputs.map((item) => (item.id === input.id ? { ...item, options: e.target.value } : item)))}
+                  placeholder="staging, production"
+                  className="mt-2 w-full rounded-lg border border-[var(--border)] bg-transparent px-2 py-1.5 text-[11px] text-[var(--text-primary)] outline-none focus:border-[var(--text-secondary)]"
+                />
+              )}
+              <div className="mt-2 grid grid-cols-2 gap-2">
+                <input
+                  value={input.placeholder}
+                  onChange={(e) => onChange(inputs.map((item) => (item.id === input.id ? { ...item, placeholder: e.target.value } : item)))}
+                  placeholder="Placeholder"
+                  className="rounded-lg border border-[var(--border)] bg-transparent px-2 py-1.5 text-[11px] text-[var(--text-primary)] outline-none focus:border-[var(--text-secondary)]"
+                />
+                <input
+                  value={input.defaultValue}
+                  onChange={(e) => onChange(inputs.map((item) => (item.id === input.id ? { ...item, defaultValue: e.target.value } : item)))}
+                  placeholder="Default"
+                  className="rounded-lg border border-[var(--border)] bg-transparent px-2 py-1.5 text-[11px] text-[var(--text-primary)] outline-none focus:border-[var(--text-secondary)]"
+                />
+              </div>
+              <button
+                type="button"
+                onClick={() => onChange(inputs.filter((item) => item.id !== input.id))}
+                className="mt-2 text-[11px] text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+              >
+                Remove input
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SummaryChip({ children }: { children: ReactNode }) {
+  return (
+    <span className="rounded-full border border-[var(--border)] bg-[var(--bg-primary)] px-2 py-1 text-[11px] text-[var(--text-secondary)]">
+      {children}
+    </span>
+  );
+}

--- a/desktop/frontend/src/components/project-detail/CreateActionWizard.tsx
+++ b/desktop/frontend/src/components/project-detail/CreateActionWizard.tsx
@@ -436,7 +436,7 @@ export function CreateActionWizard({
                   title="Button"
                   badge="Recommended"
                   description="One click runs one command. Best for most actions."
-                  previewLabel="Run tests"
+                  previewLabel={actionLabel}
                   onClick={() => setShape("button")}
                 />
                 <ShapeChoice
@@ -444,7 +444,7 @@ export function CreateActionWizard({
                   shape="split"
                   title="Split button"
                   description="A main command plus a small menu of alternatives."
-                  previewLabel="Deploy"
+                  previewLabel={actionLabel}
                   onClick={() => setShape("split")}
                 />
                 <ShapeChoice
@@ -452,7 +452,7 @@ export function CreateActionWizard({
                   shape="dropdown"
                   title="Dropdown menu"
                   description="Only a menu. Good for grouped commands like database tasks."
-                  previewLabel="Database"
+                  previewLabel={actionLabel}
                   onClick={() => setShape("dropdown")}
                 />
               </div>

--- a/desktop/frontend/src/components/project-detail/CreateActionWizard.tsx
+++ b/desktop/frontend/src/components/project-detail/CreateActionWizard.tsx
@@ -3,7 +3,6 @@ import YAML from "yaml";
 import { toast } from "sonner";
 import { ReadConfig, SaveConfig } from "../../../wailsjs/go/main/App";
 import {
-  CheckIcon,
   ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
@@ -21,7 +20,7 @@ type Shape = "button" | "split" | "dropdown";
 type RunMode = "once" | "terminal" | "background";
 
 const SHAPE_PREVIEW_BUTTON_CLASS =
-  "border-[var(--text-muted)] bg-[var(--bg-primary)] text-[var(--text-primary)] shadow-sm";
+  "border-[var(--border)] bg-[var(--bg-primary)] text-[var(--text-primary)]";
 
 interface ChildDraft {
   id: string;
@@ -107,7 +106,9 @@ function runModeLabel(mode: RunMode) {
 
 function runModeHint(mode: RunMode, reuse: boolean) {
   if (mode === "terminal") {
-    return reuse ? "Runs in a terminal and reuses it next time." : "Runs in a new terminal.";
+    return reuse
+      ? "Runs in a terminal. Running this action again reuses the same pane."
+      : "Opens a new terminal every time this action runs.";
   }
   if (mode === "background") return "Runs in the background and shows a success notification when done.";
   return "Runs once and displays the result in a modal.";
@@ -232,7 +233,7 @@ export function CreateActionWizard({
   const [cmd, setCmd] = useState("");
   const [children, setChildren] = useState<ChildDraft[]>([newChild()]);
   const [runMode, setRunMode] = useState<RunMode>("once");
-  const [reuse, setReuse] = useState(true);
+  const [reuse, setReuse] = useState(false);
   const [confirm, setConfirm] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [showYaml, setShowYaml] = useState(false);
@@ -251,7 +252,7 @@ export function CreateActionWizard({
     setCmd("");
     setChildren([newChild()]);
     setRunMode("once");
-    setReuse(true);
+    setReuse(false);
     setConfirm(false);
     setShowAdvanced(false);
     setShowYaml(false);
@@ -294,7 +295,6 @@ export function CreateActionWizard({
         : children.some((child) => child.cmd.trim());
   const canContinue = step === 0 ? Boolean(name.trim()) : step === 1 ? Boolean(shape) : step === 2 ? commandIsReady : true;
   const totalSteps = 4;
-  const progress = ((step + 1) / totalSteps) * 100;
   const actionLabel = name.trim() || "New action";
 
   const title =
@@ -368,48 +368,39 @@ export function CreateActionWizard({
     <Modal
       open={open}
       onClose={onClose}
+      backdropClassName="bg-black/50 backdrop-blur-sm"
       contentClassName="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--bg-primary)] shadow-2xl"
     >
-      <div className="flex max-h-[86vh] w-[min(920px,calc(100vw-32px))] flex-col" onKeyDown={onKeyDown}>
-        <div className="border-b border-[var(--border)] px-5 pb-4 pt-4">
-          <div className="mb-4 flex items-start justify-between gap-4">
-            <div className="min-w-0">
-              <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
-                Create action - Step {step + 1} of {totalSteps}
-              </div>
-              <h2 className="mt-1 text-[18px] font-semibold tracking-tight text-[var(--text-primary)]">{title}</h2>
-              <p className="mt-1 max-w-[440px] text-[12px] leading-5 text-[var(--text-secondary)]">{hint}</p>
-            </div>
-            <button
-              type="button"
-              onClick={onClose}
-              aria-label="Close"
-              className="rounded-lg p-1.5 text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
-            >
-              <XIcon />
-            </button>
+      <div className="flex max-h-[88vh] w-[min(960px,calc(100vw-32px))] flex-col" onKeyDown={onKeyDown}>
+        <header className="flex items-start justify-between gap-4 px-8 pb-7 pt-7">
+          <div className="min-w-0 flex-1">
+            <StepDots step={step} total={totalSteps} />
+            <h2 className="mt-5 text-[22px] font-semibold leading-tight tracking-tight text-[var(--text-primary)]">{title}</h2>
+            <p className="mt-2 max-w-[520px] text-[13px] leading-5 text-[var(--text-secondary)]">{hint}</p>
           </div>
-          <div className="h-1.5 overflow-hidden rounded-full bg-[var(--bg-secondary)]">
-            <div
-              className="h-full rounded-full bg-[var(--text-primary)] transition-all duration-300"
-              style={{ width: `${progress}%` }}
-            />
-          </div>
-        </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="-mr-2 -mt-2 rounded-xl p-2 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+          >
+            <XIcon />
+          </button>
+        </header>
 
-        <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
-          <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5">
+        <div className="flex min-h-0 flex-1 flex-col border-t border-[var(--border)] lg:flex-row">
+          <div className="min-h-0 flex-1 overflow-y-auto px-8 py-7">
             {step === 0 && (
               <div className="space-y-5">
                 <label className="block">
-                  <span className="mb-2 block text-[12px] font-medium text-[var(--text-primary)]">Button name</span>
+                  <span className="mb-2 block text-[13px] font-medium text-[var(--text-primary)]">Button name</span>
                   <input
                     ref={nameRef}
                     value={name}
                     onChange={(e) => updateName(e.target.value)}
                     onKeyDown={submitOnEnter}
                     placeholder="Run tests"
-                    className="w-full rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)] px-3 py-3 text-[16px] text-[var(--text-primary)] outline-none transition placeholder:text-[var(--text-muted)] focus:border-[var(--text-secondary)]"
+                    className="w-full rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)] px-4 py-3.5 text-[15px] text-[var(--text-primary)] outline-none transition placeholder:text-[var(--text-muted)] focus:border-[var(--text-primary)] focus:bg-[var(--bg-primary)]"
                   />
                 </label>
               </div>
@@ -466,26 +457,25 @@ export function CreateActionWizard({
                   <RunModePicker runMode={runMode} reuse={reuse} onRunMode={setRunMode} onReuse={setReuse} />
                 )}
 
-                <div className="rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] p-3">
+                <div className="border-t border-[var(--border)] pt-5">
                   <button
                     type="button"
                     onClick={() => setShowAdvanced((value) => !value)}
-                    className="flex w-full items-center justify-between gap-3 text-left"
+                    className="-mx-2 flex w-[calc(100%+1rem)] items-center justify-between gap-3 rounded-lg px-2 py-1 text-left transition-colors hover:bg-[var(--bg-hover)]"
                   >
                     <span>
-                      <span className="block text-[12px] font-medium text-[var(--text-primary)]">Need anything extra?</span>
-                      <span className="text-[11px] text-[var(--text-muted)]">
-                        Add confirmation, a folder, prompts, or SSH sync only if needed.
+                      <span className="block text-[13px] font-medium text-[var(--text-primary)]">Advanced options</span>
+                      <span className="text-[12px] text-[var(--text-muted)]">
+                        Confirmation, working folder, prompts, or SSH sync.
                       </span>
                     </span>
-                    <span className="flex items-center gap-1 text-[12px] font-medium text-[var(--text-secondary)]">
-                      {showAdvanced ? "Hide" : "Show"}
+                    <span className="text-[var(--text-muted)]">
                       {showAdvanced ? <ChevronDownIcon /> : <ChevronRightIcon />}
                     </span>
                   </button>
 
                   {showAdvanced && (
-                    <div className="mt-4 space-y-4">
+                    <div className="mt-4 space-y-3">
                       {shape !== "dropdown" && (
                         <ToggleRow
                           checked={confirm}
@@ -511,47 +501,51 @@ export function CreateActionWizard({
             )}
 
             {step === 3 && (
-              <div className="space-y-4">
-                <div className="rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] p-4">
-                  <div className="mb-3 flex items-center justify-between gap-3">
+              <div className="space-y-6">
+                <div>
+                  <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0">
-                      <div className="truncate text-[15px] font-semibold text-[var(--text-primary)]">{actionLabel}</div>
-                      <div className="mt-1 text-[12px] text-[var(--text-secondary)]">
+                      <div className="truncate text-[20px] font-semibold tracking-tight text-[var(--text-primary)]">{actionLabel}</div>
+                      <div className="mt-1 text-[12px] text-[var(--text-muted)]">
                         {shape === "button" ? "Header button" : shape === "split" ? "Split header button" : "Header dropdown"}
                       </div>
                     </div>
                     {shape !== "dropdown" && (
-                      <span className="rounded-full border border-[var(--border)] bg-[var(--bg-primary)] px-2 py-1 text-[11px] text-[var(--text-secondary)]">
+                      <span className="shrink-0 rounded-full border border-[var(--border)] px-2.5 py-1 text-[11px] font-medium text-[var(--text-secondary)]">
                         {runModeLabel(runMode)}
                       </span>
                     )}
                   </div>
-                  <p className="text-[13px] leading-5 text-[var(--text-secondary)]">
+                  <p className="mt-3 text-[13px] leading-6 text-[var(--text-secondary)]">
                     {actionSummary(shape, name, cmd, children, runMode, reuse)}
                   </p>
-                  <div className="mt-4 flex flex-wrap gap-2">
-                    {confirm && <SummaryChip>Asks before running</SummaryChip>}
-                    {cwd.trim() && <SummaryChip>Folder: {cwd.trim()}</SummaryChip>}
-                    {Object.keys(payload.inputs as Record<string, unknown> | undefined ?? {}).length > 0 && <SummaryChip>Prompts for input</SummaryChip>}
-                    {syncMode && <SummaryChip>Sync mode</SummaryChip>}
-                    {shape !== "dropdown" && runMode === "terminal" && reuse && <SummaryChip>Reuses terminal</SummaryChip>}
-                  </div>
+                  {(confirm || cwd.trim() || Object.keys(payload.inputs as Record<string, unknown> | undefined ?? {}).length > 0 || syncMode || (shape !== "dropdown" && runMode === "terminal" && reuse)) && (
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      {confirm && <SummaryChip>Asks before running</SummaryChip>}
+                      {cwd.trim() && <SummaryChip>Folder: {cwd.trim()}</SummaryChip>}
+                      {Object.keys(payload.inputs as Record<string, unknown> | undefined ?? {}).length > 0 && <SummaryChip>Prompts for input</SummaryChip>}
+                      {syncMode && <SummaryChip>Sync mode</SummaryChip>}
+                      {shape !== "dropdown" && runMode === "terminal" && reuse && <SummaryChip>Reuses pane on re-run</SummaryChip>}
+                    </div>
+                  )}
                 </div>
 
-                <button
-                  type="button"
-                  onClick={() => setShowYaml((value) => !value)}
-                  className="flex items-center gap-1.5 rounded-lg px-1 py-1 text-[11px] font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)]"
-                >
-                  {showYaml ? <ChevronDownIcon /> : <ChevronRightIcon />}
-                  {showYaml ? "Hide YAML" : "Show YAML"}
-                </button>
+                <div className="border-t border-[var(--border)] pt-5">
+                  <button
+                    type="button"
+                    onClick={() => setShowYaml((value) => !value)}
+                    className="flex items-center gap-1.5 text-[12px] font-medium text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)]"
+                  >
+                    {showYaml ? <ChevronDownIcon /> : <ChevronRightIcon />}
+                    {showYaml ? "Hide YAML" : "Show YAML"}
+                  </button>
 
-                {showYaml && (
-                  <pre className="max-h-56 overflow-auto whitespace-pre-wrap rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)] px-3 py-2 font-mono text-[11px] leading-relaxed text-[var(--text-secondary)]">
-                    {YAML.stringify({ actions: { [finalKey]: payload } }, { lineWidth: 0 })}
-                  </pre>
-                )}
+                  {showYaml && (
+                    <pre className="mt-3 max-h-56 overflow-auto whitespace-pre-wrap rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)] px-3.5 py-3 font-mono text-[12px] leading-relaxed text-[var(--text-secondary)]">
+                      {YAML.stringify({ actions: { [finalKey]: payload } }, { lineWidth: 0 })}
+                    </pre>
+                  )}
+                </div>
               </div>
             )}
           </div>
@@ -563,11 +557,11 @@ export function CreateActionWizard({
           />
         </div>
 
-        <div className="flex items-center justify-between gap-3 border-t border-[var(--border)] px-5 py-4">
+        <footer className="flex items-center justify-between gap-3 border-t border-[var(--border)] px-8 py-4">
           <button
             type="button"
             onClick={() => (step === 0 ? onClose() : setStep((current) => current - 1))}
-            className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-[12px] font-medium text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+            className="flex items-center gap-1.5 rounded-xl px-3 py-2 text-[13px] font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
           >
             {step === 0 ? (
               "Cancel"
@@ -579,7 +573,7 @@ export function CreateActionWizard({
           </button>
           <div className="flex items-center gap-3">
             {!canContinue && (
-              <span className="hidden text-[11px] text-[var(--text-muted)] sm:inline">
+              <span className="hidden text-[12px] text-[var(--text-muted)] sm:inline">
                 {step === 0 ? "Name is required" : "Command is required"}
               </span>
             )}
@@ -587,14 +581,38 @@ export function CreateActionWizard({
               type="button"
               onClick={() => void goNext()}
               disabled={!canContinue || saving}
-              className="rounded-lg bg-[var(--text-primary)] px-4 py-2 text-[12px] font-semibold text-[var(--bg-primary)] transition hover:opacity-85 disabled:opacity-40"
+              className="rounded-xl bg-[var(--text-primary)] px-5 py-2.5 text-[13px] font-semibold text-[var(--bg-primary)] shadow-sm transition hover:opacity-90 disabled:opacity-40 disabled:shadow-none"
             >
               {saving ? "Creating..." : primaryLabel}
             </button>
           </div>
-        </div>
+        </footer>
       </div>
     </Modal>
+  );
+}
+
+function StepDots({ step, total }: { step: number; total: number }) {
+  return (
+    <div className="flex items-center gap-2.5">
+      <div className="flex items-center gap-1">
+        {Array.from({ length: total }).map((_, i) => (
+          <span
+            key={i}
+            className={`h-1 rounded-full transition-all duration-300 ${
+              i === step
+                ? "w-6 bg-[var(--text-primary)]"
+                : i < step
+                  ? "w-1 bg-[var(--text-primary)]"
+                  : "w-1 bg-[var(--border)]"
+            }`}
+          />
+        ))}
+      </div>
+      <span className="text-[10px] font-medium uppercase tracking-[0.12em] text-[var(--text-muted)]">
+        {step + 1} / {total}
+      </span>
+    </div>
   );
 }
 
@@ -635,9 +653,9 @@ function ActionPreviewPanel({
   );
 
   return (
-    <aside className="flex border-t border-[var(--border)] px-5 py-5 lg:w-[300px] lg:shrink-0 lg:border-l lg:border-t-0">
+    <aside className="flex border-t border-[var(--border)] bg-[var(--bg-secondary)] px-6 py-7 lg:w-[300px] lg:shrink-0 lg:border-l lg:border-t-0">
       <div className="flex min-h-[140px] flex-1 flex-col lg:min-h-0">
-        <div className="mb-3 text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
+        <div className="mb-4 text-[10px] font-medium uppercase tracking-[0.12em] text-[var(--text-muted)]">
           Preview
         </div>
 
@@ -653,7 +671,7 @@ function ActionPreviewPanel({
                 <button
                   type="button"
                   onClick={() => setOpen((v) => !v)}
-                  className={`flex items-center rounded-r-lg border-l border-[var(--text-muted)] px-1.5 transition-colors hover:bg-[var(--bg-hover)] ${open ? "bg-[var(--bg-hover)]" : ""}`}
+                  className={`flex items-center rounded-r-lg border-l border-[var(--border)] px-1.5 transition-colors hover:bg-[var(--bg-hover)] ${open ? "bg-[var(--bg-hover)]" : ""}`}
                 >
                   <ChevronDownIcon />
                 </button>
@@ -700,29 +718,31 @@ function ShapeChoice({
     <button
       type="button"
       onClick={onClick}
-      className={`flex w-full items-center gap-3 rounded-2xl border px-4 py-3 text-left transition ${
+      className={`group relative flex w-full items-center gap-4 rounded-xl border px-5 py-4 text-left transition ${
         active
-          ? "border-[var(--text-primary)] bg-[var(--bg-hover)]"
-          : "border-[var(--border)] bg-[var(--bg-secondary)] hover:border-[var(--text-muted)]"
+          ? "border-[var(--text-primary)] bg-[var(--bg-primary)]"
+          : "border-[var(--border)] bg-[var(--bg-primary)] hover:border-[var(--text-muted)]"
       }`}
     >
       <span
-        className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full border ${
-          active ? "border-[var(--text-primary)] bg-[var(--text-primary)] text-[var(--bg-primary)]" : "border-[var(--border)]"
+        className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-colors ${
+          active
+            ? "border-[var(--text-primary)] bg-[var(--text-primary)]"
+            : "border-[var(--border)] group-hover:border-[var(--text-muted)]"
         }`}
       >
-        {active && <CheckIcon />}
+        {active && <span className="h-1.5 w-1.5 rounded-full bg-[var(--bg-primary)]" />}
       </span>
       <span className="min-w-0 flex-1">
         <span className="flex items-center gap-2">
-          <span className="text-[14px] font-medium text-[var(--text-primary)]">{title}</span>
+          <span className="text-[14px] font-semibold text-[var(--text-primary)]">{title}</span>
           {badge && (
-            <span className="rounded-full border border-[var(--border)] px-1.5 py-0.5 text-[10px] text-[var(--text-muted)]">
+            <span className="rounded-md bg-[var(--bg-secondary)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--text-secondary)]">
               {badge}
             </span>
           )}
         </span>
-        <span className="mt-0.5 block text-[12px] text-[var(--text-secondary)]">{description}</span>
+        <span className="mt-0.5 block text-[12px] leading-5 text-[var(--text-secondary)]">{description}</span>
       </span>
       <span className="hidden shrink-0 sm:block">
         <ShapePreviewButton shape={shape} label={previewLabel} />
@@ -746,7 +766,7 @@ function ShapePreviewButton({ shape, label }: { shape: Shape; label: string }) {
     return (
       <span className={`inline-flex items-stretch rounded-lg border text-xs font-medium ${SHAPE_PREVIEW_BUTTON_CLASS}`}>
         <span className="whitespace-nowrap rounded-l-lg px-3.5 py-1.5">{label}</span>
-        <span className="flex items-center rounded-r-lg border-l border-[var(--text-muted)] px-1.5">
+        <span className="flex items-center rounded-r-lg border-l border-[var(--border)] px-1.5">
           <ChevronDownIcon />
         </span>
       </span>
@@ -780,7 +800,7 @@ function CommandField({
 }) {
   return (
     <label className="block">
-      <span className="mb-2 block text-[12px] font-medium text-[var(--text-primary)]">{label}</span>
+      <span className="mb-2 block text-[13px] font-medium text-[var(--text-primary)]">{label}</span>
       <input
         ref={inputRef}
         value={value}
@@ -791,7 +811,7 @@ function CommandField({
           onEnter();
         }}
         placeholder={placeholder}
-        className="w-full rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)] px-3 py-2.5 font-mono text-[13px] text-[var(--text-primary)] outline-none transition placeholder:font-sans placeholder:text-[var(--text-muted)] focus:border-[var(--text-secondary)]"
+        className="w-full rounded-xl border border-[var(--border)] bg-[var(--bg-primary)] px-4 py-3 font-mono text-[13px] text-[var(--text-primary)] outline-none transition placeholder:font-sans placeholder:text-[var(--text-muted)] focus:border-[var(--text-primary)]"
       />
     </label>
   );
@@ -805,8 +825,8 @@ function MenuOptionsEditor({
   onChange: (children: ChildDraft[]) => void;
 }) {
   return (
-    <div className="space-y-2">
-      <div className="text-[12px] font-medium text-[var(--text-primary)]">Menu options</div>
+    <div className="space-y-2.5">
+      <div className="text-[13px] font-medium text-[var(--text-primary)]">Menu options</div>
       {children.map((child, index) => (
         <div key={child.id} className="grid grid-cols-[minmax(90px,0.8fr)_minmax(140px,1.4fr)_auto] gap-2">
           <input
@@ -817,7 +837,7 @@ function MenuOptionsEditor({
               )
             }
             placeholder={index === 0 ? "Production" : "Label"}
-            className="rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)] px-2.5 py-2 text-[12px] text-[var(--text-primary)] outline-none focus:border-[var(--text-secondary)]"
+            className="rounded-lg border border-[var(--border)] bg-[var(--bg-primary)] px-3 py-2.5 text-[12px] text-[var(--text-primary)] outline-none transition focus:border-[var(--text-primary)]"
           />
           <input
             value={child.cmd}
@@ -827,14 +847,14 @@ function MenuOptionsEditor({
               )
             }
             placeholder={index === 0 ? "./deploy.sh prod" : "Command"}
-            className="rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)] px-2.5 py-2 font-mono text-[12px] text-[var(--text-primary)] outline-none focus:border-[var(--text-secondary)]"
+            className="rounded-lg border border-[var(--border)] bg-[var(--bg-primary)] px-3 py-2.5 font-mono text-[12px] text-[var(--text-primary)] outline-none transition focus:border-[var(--text-primary)]"
           />
           <button
             type="button"
             onClick={() => onChange(children.filter((item) => item.id !== child.id))}
             disabled={children.length === 1}
             aria-label="Remove option"
-            className="rounded-lg p-2 text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-30"
+            className="rounded-lg p-2 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-30"
           >
             <TrashIcon />
           </button>
@@ -843,7 +863,7 @@ function MenuOptionsEditor({
       <button
         type="button"
         onClick={() => onChange([...children, newChild()])}
-        className="flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-[12px] font-medium text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+        className="flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-[12px] font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
       >
         <PlusIcon /> Add menu option
       </button>
@@ -864,9 +884,9 @@ function RunModePicker({
 }) {
   return (
     <div>
-      <div className="mb-2 flex items-center justify-between gap-3">
-        <span className="text-[12px] font-medium text-[var(--text-primary)]">How should it run?</span>
-        <span className="text-[11px] text-[var(--text-muted)]">{runModeHint(runMode, reuse)}</span>
+      <div className="mb-2.5 flex items-center justify-between gap-3">
+        <span className="text-[13px] font-medium text-[var(--text-primary)]">How should it run?</span>
+        <span className="text-[12px] text-[var(--text-muted)]">{runModeHint(runMode, reuse)}</span>
       </div>
       <div className="grid grid-cols-3 gap-2">
         <ModeButton active={runMode === "once"} icon={<ZapIcon />} title="Show in modal" onClick={() => onRunMode("once")} />
@@ -876,7 +896,7 @@ function RunModePicker({
       {runMode === "terminal" && (
         <label className="mt-3 flex items-center gap-2 text-[12px] text-[var(--text-secondary)]">
           <input type="checkbox" checked={reuse} onChange={(e) => onReuse(e.target.checked)} />
-          Reuse the same terminal pane next time
+          Reuse the same pane when I run this action again
         </label>
       )}
     </div>
@@ -898,10 +918,10 @@ function ModeButton({
     <button
       type="button"
       onClick={onClick}
-      className={`flex items-center justify-center gap-1.5 rounded-xl border px-2 py-2 text-[12px] font-medium transition ${
+      className={`flex items-center justify-center gap-1.5 rounded-xl border px-3 py-2.5 text-[12px] font-medium transition ${
         active
-          ? "border-[var(--text-primary)] bg-[var(--text-primary)] text-[var(--bg-primary)]"
-          : "border-[var(--border)] bg-[var(--bg-secondary)] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+          ? "border-[var(--text-primary)] bg-[var(--text-primary)] text-[var(--bg-primary)] shadow-sm"
+          : "border-[var(--border)] bg-[var(--bg-primary)] text-[var(--text-secondary)] hover:border-[var(--text-muted)] hover:text-[var(--text-primary)]"
       }`}
     >
       {icon}
@@ -922,11 +942,11 @@ function ToggleRow({
   description: string;
 }) {
   return (
-    <label className="flex items-start gap-3 rounded-xl border border-[var(--border)] bg-[var(--bg-primary)] px-3 py-2.5">
+    <label className="flex cursor-pointer items-start gap-3 rounded-xl border border-[var(--border)] bg-[var(--bg-primary)] px-3.5 py-3 transition-colors hover:border-[var(--text-muted)]">
       <input className="mt-0.5" type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} />
       <span>
-        <span className="block text-[12px] font-medium text-[var(--text-primary)]">{title}</span>
-        <span className="text-[11px] text-[var(--text-muted)]">{description}</span>
+        <span className="block text-[13px] font-medium text-[var(--text-primary)]">{title}</span>
+        <span className="text-[12px] text-[var(--text-muted)]">{description}</span>
       </span>
     </label>
   );
@@ -1027,7 +1047,7 @@ function InputsEditor({ inputs, onChange }: { inputs: InputDraft[]; onChange: (i
 
 function SummaryChip({ children }: { children: ReactNode }) {
   return (
-    <span className="rounded-full border border-[var(--border)] bg-[var(--bg-primary)] px-2 py-1 text-[11px] text-[var(--text-secondary)]">
+    <span className="rounded-full border border-[var(--border)] bg-[var(--bg-primary)] px-2.5 py-1 text-[11px] font-medium text-[var(--text-secondary)]">
       {children}
     </span>
   );

--- a/desktop/frontend/src/components/project-detail/CreateActionWizard.tsx
+++ b/desktop/frontend/src/components/project-detail/CreateActionWizard.tsx
@@ -15,6 +15,7 @@ import {
   ZapIcon,
 } from "../icons";
 import { Modal } from "../ui/Modal";
+import { useOutsideClick } from "../../hooks/useOutsideClick";
 
 type Shape = "button" | "split" | "dropdown";
 type RunMode = "once" | "terminal" | "background";
@@ -558,6 +559,7 @@ export function CreateActionWizard({
           <ActionPreviewPanel
             name={actionLabel}
             shape={shape}
+            options={children}
           />
         </div>
 
@@ -599,11 +601,38 @@ export function CreateActionWizard({
 function ActionPreviewPanel({
   name,
   shape,
+  options,
 }: {
   name: string;
   shape: Shape;
+  options: ChildDraft[];
 }) {
   const hasName = name.trim().length > 0 && name !== "New action";
+  const [open, setOpen] = useState(false);
+  const ref = useOutsideClick<HTMLDivElement>(() => setOpen(false), open);
+  const interactive = hasName && shape !== "button";
+  const visibleOptions = options.filter((option) => option.label.trim() || option.cmd.trim());
+
+  const dropdown = open && (
+    <div className="absolute right-0 top-full z-10 mt-2 w-56 overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--bg-primary)] py-1.5 shadow-2xl">
+      {visibleOptions.length === 0 ? (
+        <div className="px-4 py-2 text-[12px] italic text-[var(--text-muted)]">
+          Add menu options to fill this menu.
+        </div>
+      ) : (
+        visibleOptions.map((option, index) => (
+          <div
+            key={option.id}
+            className="flex items-center gap-2.5 px-4 py-2 text-[12px] text-[var(--text-secondary)]"
+          >
+            <span className="flex-1 truncate">
+              {option.label.trim() || `Option ${index + 1}`}
+            </span>
+          </div>
+        ))
+      )}
+    </div>
+  );
 
   return (
     <aside className="flex border-t border-[var(--border)] px-5 py-5 lg:w-[300px] lg:shrink-0 lg:border-l lg:border-t-0">
@@ -613,12 +642,36 @@ function ActionPreviewPanel({
         </div>
 
         <div className="flex flex-1 items-center justify-center">
-          {hasName ? (
-            <div className="pointer-events-none max-w-full">
-              <ShapePreviewButton shape={shape} label={name} />
+          {!hasName ? (
+            <div className="h-7 w-24 rounded-md border border-dashed border-[var(--border)]" />
+          ) : !interactive ? (
+            <ShapePreviewButton shape={shape} label={name} />
+          ) : shape === "split" ? (
+            <div ref={ref} className="relative">
+              <span className={`inline-flex items-stretch rounded-lg border text-xs font-medium ${SHAPE_PREVIEW_BUTTON_CLASS}`}>
+                <span className="whitespace-nowrap rounded-l-lg px-3.5 py-1.5">{name}</span>
+                <button
+                  type="button"
+                  onClick={() => setOpen((v) => !v)}
+                  className={`flex items-center rounded-r-lg border-l border-[var(--text-muted)] px-1.5 transition-colors hover:bg-[var(--bg-hover)] ${open ? "bg-[var(--bg-hover)]" : ""}`}
+                >
+                  <ChevronDownIcon />
+                </button>
+              </span>
+              {dropdown}
             </div>
           ) : (
-            <div className="h-7 w-24 rounded-md border border-dashed border-[var(--border)]" />
+            <div ref={ref} className="relative">
+              <button
+                type="button"
+                onClick={() => setOpen((v) => !v)}
+                className={`inline-flex items-center gap-1 whitespace-nowrap rounded-lg border px-3.5 py-1.5 text-xs font-medium transition-colors hover:bg-[var(--bg-hover)] ${SHAPE_PREVIEW_BUTTON_CLASS} ${open ? "bg-[var(--bg-hover)]" : ""}`}
+              >
+                {name}
+                <ChevronDownIcon />
+              </button>
+              {dropdown}
+            </div>
           )}
         </div>
       </div>

--- a/desktop/frontend/src/components/project-detail/CreateActionWizard.tsx
+++ b/desktop/frontend/src/components/project-detail/CreateActionWizard.tsx
@@ -75,7 +75,7 @@ function shouldConfirm(text: string): boolean {
 function runModeLabel(mode: RunMode) {
   if (mode === "terminal") return "Run in new terminal";
   if (mode === "background") return "Run in background";
-  return "Show in modal";
+  return "Run in modal";
 }
 
 function runModeHint(mode: RunMode, reuse: boolean) {
@@ -383,7 +383,7 @@ export function CreateActionWizard({
                     value={cmd}
                     onChange={updateCmd}
                     onEnter={() => void goNext()}
-                    placeholder={shape === "split" ? "./deploy.sh staging" : "npm run dev"}
+                    placeholder={shape === "split" ? "npm run deploy:staging" : "npm run dev"}
                   />
                 )}
 
@@ -434,7 +434,7 @@ export function CreateActionWizard({
                     className="flex items-center gap-1.5 text-[12px] font-medium text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)]"
                   >
                     {showYaml ? <ChevronDownIcon /> : <ChevronRightIcon />}
-                    {showYaml ? "Hide YAML" : "Show YAML"}
+                    {showYaml ? "Hide Config" : "Show Config"}
                   </button>
 
                   {showYaml && (() => {
@@ -454,6 +454,9 @@ export function CreateActionWizard({
             name={actionLabel}
             shape={shape}
             options={children}
+            runMode={runMode}
+            confirm={confirm}
+            cmd={cmd}
           />
         </div>
 
@@ -516,22 +519,43 @@ function StepDots({ step, total }: { step: number; total: number }) {
   );
 }
 
+type DemoState = RunMode | "confirm" | null;
+
 function ActionPreviewPanel({
   name,
   shape,
   options,
+  runMode,
+  confirm,
+  cmd,
 }: {
   name: string;
   shape: Shape;
   options: ChildDraft[];
+  runMode: RunMode;
+  confirm: boolean;
+  cmd: string;
 }) {
   const hasName = name.trim().length > 0 && name !== "New action";
-  const [open, setOpen] = useState(false);
-  const ref = useOutsideClick<HTMLDivElement>(() => setOpen(false), open);
-  const interactive = hasName && shape !== "button";
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [running, setRunning] = useState<DemoState>(null);
+  const menuRef = useOutsideClick<HTMLDivElement>(() => setMenuOpen(false), menuOpen);
   const visibleOptions = options.filter((option) => option.label.trim() || option.cmd.trim());
+  const canRun = shape !== "dropdown" && cmd.trim().length > 0;
 
-  const dropdown = open && (
+  useEffect(() => {
+    setRunning(canRun ? runMode : null);
+  }, [runMode, canRun]);
+
+  const triggerRun = () => {
+    if (!canRun) return;
+    setRunning(confirm ? "confirm" : runMode);
+  };
+
+  const handleConfirm = () => setRunning(runMode);
+  const handleCancel = () => setRunning(null);
+
+  const dropdown = menuOpen && (
     <div className="absolute right-0 top-full z-10 mt-2 w-56 overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--bg-primary)] py-1.5 shadow-2xl">
       {visibleOptions.length === 0 ? (
         <div className="px-4 py-2 text-[12px] italic text-[var(--text-muted)]">
@@ -559,19 +583,31 @@ function ActionPreviewPanel({
           Preview
         </div>
 
-        <div className="flex flex-1 items-center justify-center">
+        <div className="flex flex-1 flex-col items-center justify-center gap-5">
           {!hasName ? (
             <div className="h-7 w-24 rounded-md border border-dashed border-[var(--border)]" />
-          ) : !interactive ? (
-            <ShapePreviewButton shape={shape} label={name} />
+          ) : shape === "button" ? (
+            <button
+              type="button"
+              onClick={triggerRun}
+              className={`inline-flex whitespace-nowrap rounded-lg border px-3.5 py-1.5 text-xs font-medium transition-colors hover:bg-[var(--bg-hover)] ${SHAPE_PREVIEW_BUTTON_CLASS}`}
+            >
+              {name}
+            </button>
           ) : shape === "split" ? (
-            <div ref={ref} className="relative">
+            <div ref={menuRef} className="relative">
               <span className={`inline-flex items-stretch rounded-lg border text-xs font-medium ${SHAPE_PREVIEW_BUTTON_CLASS}`}>
-                <span className="whitespace-nowrap rounded-l-lg px-3.5 py-1.5">{name}</span>
                 <button
                   type="button"
-                  onClick={() => setOpen((v) => !v)}
-                  className={`flex items-center rounded-r-lg border-l border-[var(--border)] px-1.5 transition-colors hover:bg-[var(--bg-hover)] ${open ? "bg-[var(--bg-hover)]" : ""}`}
+                  onClick={triggerRun}
+                  className="whitespace-nowrap rounded-l-lg px-3.5 py-1.5 transition-colors hover:bg-[var(--bg-hover)]"
+                >
+                  {name}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setMenuOpen((v) => !v)}
+                  className={`flex items-center rounded-r-lg border-l border-[var(--border)] px-1.5 transition-colors hover:bg-[var(--bg-hover)] ${menuOpen ? "bg-[var(--bg-hover)]" : ""}`}
                 >
                   <ChevronDownIcon />
                 </button>
@@ -579,11 +615,11 @@ function ActionPreviewPanel({
               {dropdown}
             </div>
           ) : (
-            <div ref={ref} className="relative">
+            <div ref={menuRef} className="relative">
               <button
                 type="button"
-                onClick={() => setOpen((v) => !v)}
-                className={`inline-flex items-center gap-1 whitespace-nowrap rounded-lg border px-3.5 py-1.5 text-xs font-medium transition-colors hover:bg-[var(--bg-hover)] ${SHAPE_PREVIEW_BUTTON_CLASS} ${open ? "bg-[var(--bg-hover)]" : ""}`}
+                onClick={() => setMenuOpen((v) => !v)}
+                className={`inline-flex items-center gap-1 whitespace-nowrap rounded-lg border px-3.5 py-1.5 text-xs font-medium transition-colors hover:bg-[var(--bg-hover)] ${SHAPE_PREVIEW_BUTTON_CLASS} ${menuOpen ? "bg-[var(--bg-hover)]" : ""}`}
               >
                 {name}
                 <ChevronDownIcon />
@@ -591,9 +627,148 @@ function ActionPreviewPanel({
               {dropdown}
             </div>
           )}
+
+          {canRun && (
+            <RunModeDemo
+              key={running ?? "idle"}
+              running={running}
+              cmd={cmd}
+              label={name}
+              onTrigger={triggerRun}
+              onConfirm={handleConfirm}
+              onCancel={handleCancel}
+            />
+          )}
         </div>
       </div>
     </aside>
+  );
+}
+
+function MockModalShell({ width, children }: { width: number; children: ReactNode }) {
+  return (
+    <>
+      <div className="demo-dim absolute inset-0 bg-black/45" />
+      <div
+        className="demo-modal absolute left-1/2 top-1/2 overflow-hidden rounded border border-[var(--border)] bg-[var(--bg-primary)] shadow-lg"
+        style={{ width }}
+      >
+        {children}
+      </div>
+    </>
+  );
+}
+
+function RunModeDemo({
+  running,
+  cmd,
+  label,
+  onTrigger,
+  onConfirm,
+  onCancel,
+}: {
+  running: DemoState;
+  cmd: string;
+  label: string;
+  onTrigger: () => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div className="relative w-full max-w-[240px] overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--bg-primary)] shadow-md">
+      <div className="flex h-[14px] items-center gap-1 border-b border-[var(--border)] bg-[var(--bg-secondary)] px-2">
+        <span className="h-1.5 w-1.5 rounded-full bg-[#ff5f57]" />
+        <span className="h-1.5 w-1.5 rounded-full bg-[#febc2e]" />
+        <span className="h-1.5 w-1.5 rounded-full bg-[#28c840]" />
+      </div>
+
+      <div className="flex h-[140px]">
+        <div className="flex w-[36px] shrink-0 flex-col gap-1 border-r border-[var(--border)] bg-[var(--bg-secondary)] p-1.5">
+          <div className="h-1.5 rounded bg-[var(--border)]" />
+          <div className="h-1.5 rounded bg-[var(--border)]" />
+          <div className="h-1.5 w-2/3 rounded bg-[var(--border)] opacity-70" />
+        </div>
+
+        <div className="relative flex flex-1 flex-col overflow-hidden">
+          <div className="flex h-[16px] items-center justify-end border-b border-[var(--border)] px-1.5">
+            <button
+              type="button"
+              onClick={onTrigger}
+              className="max-w-[80px] truncate rounded border border-[var(--border)] bg-[var(--bg-primary)] px-1 py-[1px] text-[7px] font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--bg-hover)]"
+            >
+              {label}
+            </button>
+          </div>
+
+          <div className="relative flex-1 overflow-hidden p-2">
+            <div className="space-y-1">
+              <div className="h-[3px] w-3/4 rounded bg-[var(--border)] opacity-70" />
+              <div className="h-[3px] w-1/2 rounded bg-[var(--border)] opacity-70" />
+              <div className="h-[3px] w-2/3 rounded bg-[var(--border)] opacity-70" />
+              <div className="h-[3px] w-1/3 rounded bg-[var(--border)] opacity-70" />
+            </div>
+
+            {running === "confirm" && (
+              <MockModalShell width={140}>
+                <div className="space-y-1 px-2 py-1.5">
+                  <div className="text-[8px] font-medium text-[var(--text-primary)]">Run {label}?</div>
+                  <div className="truncate font-mono text-[7px] text-[var(--text-muted)]">$ {cmd}</div>
+                </div>
+                <div className="flex justify-end gap-1 border-t border-[var(--border)] px-1.5 py-1">
+                  <button
+                    type="button"
+                    onClick={onCancel}
+                    className="rounded px-1.5 py-[1px] text-[7px] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={onConfirm}
+                    className="rounded bg-[var(--text-primary)] px-1.5 py-[1px] text-[7px] font-medium text-[var(--bg-primary)]"
+                  >
+                    Run
+                  </button>
+                </div>
+              </MockModalShell>
+            )}
+
+            {running === "once" && (
+              <MockModalShell width={124}>
+                <div className="flex items-center justify-between border-b border-[var(--border)] px-1.5 py-1">
+                  <span className="truncate text-[7px] font-medium text-[var(--text-primary)]">{label}</span>
+                  <button
+                    type="button"
+                    onClick={onCancel}
+                    className="rounded text-[7px] text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+                  >
+                    ×
+                  </button>
+                </div>
+                <div className="space-y-0.5 px-1.5 py-1 font-mono text-[6px] leading-tight">
+                  <div className="truncate text-[var(--text-primary)]">$ {cmd}</div>
+                  <div className="text-[var(--text-muted)]">output…</div>
+                </div>
+              </MockModalShell>
+            )}
+
+            {running === "terminal" && (
+              <div className="demo-terminal absolute inset-0 bg-black p-1.5 font-mono text-[7px] leading-tight text-white/90">
+                <div className="truncate">$ {cmd}</div>
+                <span className="demo-cursor mt-0.5 inline-block h-[6px] w-[3px] bg-white/80" />
+              </div>
+            )}
+
+            {running === "background" && (
+              <div className="demo-toast absolute right-1.5 top-1.5 flex items-center gap-1 rounded border border-[var(--border)] bg-[var(--bg-primary)] px-1.5 py-1 shadow">
+                <span className="h-1 w-1 animate-pulse rounded-full bg-[var(--text-secondary)]" />
+                <span className="max-w-[90px] truncate text-[7px] text-[var(--text-secondary)]">{label} running…</span>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -751,7 +926,7 @@ function MenuOptionsEditor({
             <input
               value={child.cmd}
               onChange={(e) => updateField(child, "cmd", e.target.value)}
-              placeholder={index === 0 ? "./deploy.sh prod" : "Command"}
+              placeholder={index === 0 ? "npm run deploy:production" : "Command"}
               className="rounded-lg border border-[var(--border)] bg-[var(--bg-primary)] px-3 py-2.5 font-mono text-[12px] text-[var(--text-primary)] outline-none transition focus:border-[var(--text-primary)]"
             />
             <button

--- a/desktop/frontend/src/components/project-detail/CreateActionWizard.tsx
+++ b/desktop/frontend/src/components/project-detail/CreateActionWizard.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState, type KeyboardEvent, type ReactNode, type Ref } from "react";
 import YAML from "yaml";
 import { toast } from "sonner";
-import { ReadConfig, SaveConfig } from "../../../wailsjs/go/main/App";
+import { appendAction } from "../../actionConfig";
 import { slugify } from "../../slugify";
+import { uniqueKey } from "../../uniqueKey";
 import {
   ChevronDownIcon,
   ChevronLeftIcon,
@@ -47,14 +48,6 @@ interface CreateActionWizardProps {
   nextPosition: number;
   onClose: () => void;
   onCreated: () => void;
-}
-
-function uniqueKey(base: string, existing: string[]): string {
-  const seed = base || "new-action";
-  if (!existing.includes(seed)) return seed;
-  let i = 2;
-  while (existing.includes(`${seed}-${i}`)) i += 1;
-  return `${seed}-${i}`;
 }
 
 function newChild(): ChildDraft {
@@ -183,18 +176,6 @@ function buildActionPayload({
   return payload;
 }
 
-async function appendAction(projectName: string, key: string, payload: Record<string, unknown>) {
-  const content = await ReadConfig(projectName);
-  const doc = YAML.parseDocument(content || "{}");
-  let actions = doc.get("actions", true);
-  if (!YAML.isMap(actions)) {
-    actions = doc.createNode({});
-    doc.set("actions", actions);
-  }
-  if (YAML.isMap(actions)) actions.set(key, payload);
-  await SaveConfig(projectName, String(doc));
-}
-
 export function CreateActionWizard({
   open,
   projectName,
@@ -237,7 +218,7 @@ export function CreateActionWizard({
   }, [open, step, shape]);
 
   const buildSubmission = () => ({
-    key: uniqueKey(slugify(name), existingActionKeys),
+    key: uniqueKey(slugify(name) || "new-action", existingActionKeys),
     payload: buildActionPayload({ shape, name, cmd, children, runMode, reuse, confirm, position: nextPosition }),
   });
 

--- a/desktop/frontend/src/components/project-detail/Header.tsx
+++ b/desktop/frontend/src/components/project-detail/Header.tsx
@@ -7,7 +7,6 @@ interface HeaderProps {
   rowRef: RefObject<HTMLDivElement | null>;
   innerRef: RefObject<HTMLDivElement | null>;
   actionsWrapped: boolean;
-  hasActions: boolean;
   actions: ReactNode;
   controls: ReactNode;
 }
@@ -21,7 +20,6 @@ export function Header({
   rowRef,
   innerRef,
   actionsWrapped,
-  hasActions,
   actions,
   controls,
 }: HeaderProps) {
@@ -40,7 +38,7 @@ export function Header({
           {controls}
         </div>
       </div>
-      {actionsWrapped && hasActions && (
+      {actionsWrapped && (
         <div className={`wails-drag -mx-3 mt-2 pb-1 transition-[padding] duration-200 ${indent}`}>
           {actions}
         </div>

--- a/desktop/frontend/src/components/project-detail/HeaderActions.tsx
+++ b/desktop/frontend/src/components/project-detail/HeaderActions.tsx
@@ -1,6 +1,8 @@
 import { ActionsGroup } from "../ActionsDnd";
 import { ActionView } from "../ActionView";
+import { PlusIcon } from "../icons";
 import { SortableItem } from "../ui/SortableList";
+import { Tooltip } from "../ui/Tooltip";
 import type { ActionInfo } from "../../types";
 import { NO_DRAG_STYLE } from "./constants";
 
@@ -10,11 +12,20 @@ interface HeaderActionsProps {
   wrapped: boolean;
   disabled: boolean;
   onRun: (action: ActionInfo) => void;
+  onAddAction: () => void;
 }
 
 // The drag-sortable list of header-display actions. The wrapper is also
-// the droppable zone for cross-group drops from the footer.
-export function HeaderActions({ actions, ids, wrapped, disabled, onRun }: HeaderActionsProps) {
+// the droppable zone for cross-group drops from the footer. A trailing
+// plus button starts the guided Create Action flow.
+export function HeaderActions({
+  actions,
+  ids,
+  wrapped,
+  disabled,
+  onRun,
+  onAddAction,
+}: HeaderActionsProps) {
   return (
     <ActionsGroup
       group="header"
@@ -31,6 +42,16 @@ export function HeaderActions({ actions, ids, wrapped, disabled, onRun }: Header
           <ActionView action={action} compact={false} disabled={disabled} onRun={onRun} />
         </SortableItem>
       ))}
+      <Tooltip content="Create action" side="bottom">
+        <button
+          type="button"
+          onClick={onAddAction}
+          aria-label="Create action"
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-dashed border-[var(--border)] text-[var(--text-muted)] transition-colors hover:border-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+        >
+          <PlusIcon />
+        </button>
+      </Tooltip>
     </ActionsGroup>
   );
 }

--- a/desktop/frontend/src/components/project-detail/HeaderActions.tsx
+++ b/desktop/frontend/src/components/project-detail/HeaderActions.tsx
@@ -16,8 +16,7 @@ interface HeaderActionsProps {
 }
 
 // The drag-sortable list of header-display actions. The wrapper is also
-// the droppable zone for cross-group drops from the footer. A trailing
-// plus button starts the guided Create Action flow.
+// the droppable zone for cross-group drops from the footer.
 export function HeaderActions({
   actions,
   ids,

--- a/desktop/frontend/src/components/project-detail/HeaderActions.tsx
+++ b/desktop/frontend/src/components/project-detail/HeaderActions.tsx
@@ -1,3 +1,4 @@
+import type { MouseEvent } from "react";
 import { ActionsGroup } from "../ActionsDnd";
 import { ActionView } from "../ActionView";
 import { PlusIcon } from "../icons";
@@ -12,6 +13,7 @@ interface HeaderActionsProps {
   wrapped: boolean;
   disabled: boolean;
   onRun: (action: ActionInfo) => void;
+  onContextMenu?: (e: MouseEvent, action: ActionInfo) => void;
   onAddAction: () => void;
 }
 
@@ -23,6 +25,7 @@ export function HeaderActions({
   wrapped,
   disabled,
   onRun,
+  onContextMenu,
   onAddAction,
 }: HeaderActionsProps) {
   return (
@@ -38,7 +41,13 @@ export function HeaderActions({
     >
       {actions.map((action) => (
         <SortableItem key={action.name} id={action.name}>
-          <ActionView action={action} compact={false} disabled={disabled} onRun={onRun} />
+          <ActionView
+            action={action}
+            compact={false}
+            disabled={disabled}
+            onRun={onRun}
+            onContextMenu={onContextMenu}
+          />
         </SortableItem>
       ))}
       <Tooltip content="Create action" side="bottom">

--- a/desktop/frontend/src/components/project-detail/TerminalPane.tsx
+++ b/desktop/frontend/src/components/project-detail/TerminalPane.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, type RefObject } from "react";
+import { type CSSProperties, type MouseEvent, type RefObject } from "react";
 import { TerminalView, type TerminalViewHandle } from "../TerminalView";
 import { TerminalFooter } from "../TerminalFooter";
 import type { PaneStatus } from "../../hooks/usePaneStatus";
@@ -27,6 +27,7 @@ interface TerminalPaneProps {
   onZoomIn: () => void;
   onZoomOut: () => void;
   onRunAction: (action: ActionInfo) => void;
+  onActionContextMenu?: (e: MouseEvent, action: ActionInfo) => void;
 }
 
 export function TerminalPane({
@@ -47,6 +48,7 @@ export function TerminalPane({
   onZoomIn,
   onZoomOut,
   onRunAction,
+  onActionContextMenu,
 }: TerminalPaneProps) {
   return (
     <div
@@ -73,6 +75,7 @@ export function TerminalPane({
         actions={footerActions}
         actionIds={footerIds}
         onRunAction={onRunAction}
+        onActionContextMenu={onActionContextMenu}
         disabled={disabled}
       />
     </div>

--- a/desktop/frontend/src/components/ui/ContextMenuItem.tsx
+++ b/desktop/frontend/src/components/ui/ContextMenuItem.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+
+interface ContextMenuItemProps {
+  label: ReactNode;
+  icon?: ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+  destructive?: boolean;
+  title?: string;
+}
+
+export function ContextMenuItem({
+  label,
+  icon,
+  onClick,
+  disabled,
+  destructive,
+  title,
+}: ContextMenuItemProps) {
+  const tone = destructive
+    ? "text-[var(--accent-red)] hover:bg-[var(--bg-hover)]"
+    : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]";
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-[11px] transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${tone}`}
+    >
+      <span className="flex-1 truncate">{label}</span>
+      {icon}
+    </button>
+  );
+}

--- a/desktop/frontend/src/components/ui/ContextMenuShell.tsx
+++ b/desktop/frontend/src/components/ui/ContextMenuShell.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react";
+import { useLayoutEffect, useState, type ReactNode } from "react";
 import { useEventListener } from "../../hooks/useEventListener";
 import { useOutsideClick } from "../../hooks/useOutsideClick";
 
@@ -10,17 +10,31 @@ interface ContextMenuShellProps {
   children: ReactNode;
 }
 
+const VIEWPORT_MARGIN = 8;
+
 export function ContextMenuShell({ x, y, minWidth = 160, onClose, children }: ContextMenuShellProps) {
   const ref = useOutsideClick<HTMLDivElement>(onClose);
   useEventListener("keydown", (e) => {
     if (e.key === "Escape") onClose();
   }, document);
 
+  // Shift the menu up/left when the click lands too close to the bottom or
+  // right edge — without this, footer-action menus render off-screen.
+  const [pos, setPos] = useState({ left: x, top: y });
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const { width, height } = el.getBoundingClientRect();
+    const left = Math.max(VIEWPORT_MARGIN, Math.min(x, window.innerWidth - width - VIEWPORT_MARGIN));
+    const top = Math.max(VIEWPORT_MARGIN, Math.min(y, window.innerHeight - height - VIEWPORT_MARGIN));
+    setPos((prev) => (prev.left === left && prev.top === top ? prev : { left, top }));
+  }, [x, y]);
+
   return (
     <div
       ref={ref}
       className="fixed z-50 rounded-lg border border-[var(--border)] bg-[var(--bg-primary)] py-1 shadow-lg"
-      style={{ left: x, top: y, minWidth }}
+      style={{ left: pos.left, top: pos.top, minWidth }}
     >
       {children}
     </div>

--- a/desktop/frontend/src/components/ui/ContextMenuShell.tsx
+++ b/desktop/frontend/src/components/ui/ContextMenuShell.tsx
@@ -1,0 +1,28 @@
+import { type ReactNode } from "react";
+import { useEventListener } from "../../hooks/useEventListener";
+import { useOutsideClick } from "../../hooks/useOutsideClick";
+
+interface ContextMenuShellProps {
+  x: number;
+  y: number;
+  minWidth?: number;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export function ContextMenuShell({ x, y, minWidth = 160, onClose, children }: ContextMenuShellProps) {
+  const ref = useOutsideClick<HTMLDivElement>(onClose);
+  useEventListener("keydown", (e) => {
+    if (e.key === "Escape") onClose();
+  }, document);
+
+  return (
+    <div
+      ref={ref}
+      className="fixed z-50 rounded-lg border border-[var(--border)] bg-[var(--bg-primary)] py-1 shadow-lg"
+      style={{ left: x, top: y, minWidth }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/desktop/frontend/src/styles/globals.css
+++ b/desktop/frontend/src/styles/globals.css
@@ -124,3 +124,15 @@ body {
 @keyframes check-draw {
   to { stroke-dashoffset: 0; }
 }
+
+@keyframes run-dim-in   { from { opacity: 0; } to { opacity: 1; } }
+@keyframes run-modal-in { from { opacity: 0; transform: translate(-50%, calc(-50% + 6px)) scale(0.92); } to { opacity: 1; transform: translate(-50%, -50%) scale(1); } }
+@keyframes run-term-in  { from { transform: translateX(100%); } to { transform: none; } }
+@keyframes run-toast-in { from { opacity: 0; transform: translateY(-6px) scale(0.92); } to { opacity: 1; transform: none; } }
+@keyframes term-cursor  { 0%, 49% { opacity: 1; } 50%, 100% { opacity: 0; } }
+
+.demo-dim      { animation: run-dim-in    180ms ease-out both; }
+.demo-modal    { animation: run-modal-in  260ms cubic-bezier(0.2, 0.9, 0.3, 1) 80ms both; }
+.demo-terminal { animation: run-term-in   320ms cubic-bezier(0.2, 0.9, 0.3, 1) both; }
+.demo-toast    { animation: run-toast-in  300ms cubic-bezier(0.2, 0.9, 0.3, 1) both; }
+.demo-cursor   { animation: term-cursor   1s steps(1) infinite; }

--- a/desktop/frontend/src/uniqueKey.ts
+++ b/desktop/frontend/src/uniqueKey.ts
@@ -1,0 +1,6 @@
+export function uniqueKey(prefix: string, existing: string[]): string {
+  if (!existing.includes(prefix)) return prefix;
+  let i = 2;
+  while (existing.includes(`${prefix}-${i}`)) i += 1;
+  return `${prefix}-${i}`;
+}


### PR DESCRIPTION
This branch adds a full action management flow to the desktop app, letting users create, preview, edit, duplicate, and delete project actions directly from the project detail view. It also refreshes the action wizard UI and context menu behavior so action controls feel more polished and stay usable in tighter layouts.

- Added a new action creation wizard with shape selection, command previews, run-mode guidance, and richer form copy
- Added action run previews and preview menus so users can inspect what an action will do before saving
- Added right-click context menus for actions with edit and delete options
- Added action editing support, including patch-based YAML updates that preserve unmanaged fields
- Added action deletion support with confirmation and toast feedback
- Updated action buttons, split buttons, and footer/header action rendering to support context menus
- Improved project context menu layout and viewport handling so menus stay in view
- Refactored wizard and project-detail UI to use action labels consistently and simplify existing flows