### PR TITLE
feat(desktop): upload pasted files to remote panes via scp

### DIFF
--- a/desktop/frontend/src/components/InteractivePane.tsx
+++ b/desktop/frontend/src/components/InteractivePane.tsx
@@ -11,10 +11,12 @@ import {
   ResizeTerminal,
   AckTerminalData,
   ReadClipboardFiles,
+  SaveClipboardImage,
+  IsTerminalRemote,
   UploadAndQuoteForTerminal,
   UploadClipboardImageForTerminal,
 } from "../../wailsjs/go/main/App";
-import { sendTerminalInput } from "../terminal-io";
+import { sendTerminalInput, shellQuote } from "../terminal-io";
 import { getTerminalTheme, openTerminalLink } from "./terminal-utils";
 import { registerFileDropHandler } from "../fileDrop";
 import "@xterm/xterm/css/xterm.css";
@@ -42,6 +44,10 @@ interface InteractivePaneProps {
 const ACK_SIZE = 5000;
 const HIDDEN_BUF_CAP = 1_000_000; // max chars to buffer while hidden (~1MB)
 
+function getTerminalRemote(id: string): Promise<boolean> {
+  return interactiveSessions.get(id)?.remote ?? Promise.resolve(false);
+}
+
 // Global file drop handler — routes drops to the pane under the cursor
 let fileDropInitialized = false;
 function initFileDrop() {
@@ -50,12 +56,15 @@ function initFileDrop() {
   registerFileDropHandler("terminals", (x, y, paths) => {
     const id = terminalIdAtPoint(x, y);
     if (!id) return false;
-    // For remote panes the Go side scp's the files via the existing
-    // ControlMaster socket and returns the paste-ready remote paths;
-    // for local panes it just formats the local paths.
-    UploadAndQuoteForTerminal(id, paths)
-      .then((text) => pasteToTerminal(id, text))
-      .catch((err) => writeTerminalError(id, err));
+    getTerminalRemote(id).then((remote) => {
+      if (remote) {
+        UploadAndQuoteForTerminal(id, paths)
+          .then((text) => pasteToTerminal(id, text))
+          .catch((err) => writeTerminalError(id, err));
+      } else {
+        pasteToTerminal(id, formatPastedPaths(paths));
+      }
+    });
     return true;
   });
 }
@@ -97,6 +106,7 @@ interface InteractiveSession {
   hiddenBuf: string[];
   hiddenBufLen: number;
   sessionDead: boolean;
+  remote: Promise<boolean>;
 
   // Installed by the current React mount, cleared on unmount so callbacks
   // closing over stale component state don't fire.
@@ -180,11 +190,30 @@ function saveImageBlob(terminalId: string, blob: File, mimeType: string) {
     const dataUrl = reader.result as string;
     const b64 = dataUrl.split(",")[1];
     if (!b64) return;
-    UploadClipboardImageForTerminal(terminalId, b64, mimeType)
-      .then((text) => pasteToTerminal(terminalId, text))
-      .catch((err) => writeTerminalError(terminalId, err));
+    getTerminalRemote(terminalId).then((remote) => {
+      if (remote) {
+        UploadClipboardImageForTerminal(terminalId, b64, mimeType)
+          .then((text) => pasteToTerminal(terminalId, text))
+          .catch((err) => writeTerminalError(terminalId, err));
+      } else {
+        SaveClipboardImage(b64, mimeType)
+          .then((filePath) => pasteToTerminal(terminalId, filePath))
+          .catch((err) => console.warn("SaveClipboardImage failed:", err));
+      }
+    });
   };
   reader.readAsDataURL(blob);
+}
+
+const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|bmp|tiff?|heic|heif)$/i;
+
+// Single image paths go in unquoted so a path-detecting receiver can stat
+// them; everything else is shell-quoted for shell users.
+function formatPastedPaths(paths: string[]): string {
+  if (paths.length === 1 && IMAGE_EXT_RE.test(paths[0])) {
+    return paths[0];
+  }
+  return paths.map(shellQuote).join(" ");
 }
 
 // xterm's paste() emits CSI ?2004h bracketed-paste markers when the running
@@ -271,6 +300,7 @@ function createInteractiveSession(terminalId: string): InteractiveSession {
     fit,
     search,
     host,
+    remote: IsTerminalRemote(terminalId).catch(() => false),
     visible: true,
     hiddenBuf: [],
     hiddenBufLen: 0,
@@ -370,9 +400,14 @@ function createInteractiveSession(terminalId: string): InteractiveSession {
       ReadClipboardFiles()
         .then((paths) => {
           if (paths && paths.length > 0) {
-            return UploadAndQuoteForTerminal(terminalId, paths)
-              .then((text) => pasteToTerminal(terminalId, text))
-              .catch((err) => writeTerminalError(terminalId, err));
+            return getTerminalRemote(terminalId).then((remote) => {
+              if (remote) {
+                return UploadAndQuoteForTerminal(terminalId, paths)
+                  .then((text) => pasteToTerminal(terminalId, text))
+                  .catch((err) => writeTerminalError(terminalId, err));
+              }
+              pasteToTerminal(terminalId, formatPastedPaths(paths));
+            });
           }
           fallback();
         })

--- a/desktop/frontend/src/components/InteractivePane.tsx
+++ b/desktop/frontend/src/components/InteractivePane.tsx
@@ -11,9 +11,10 @@ import {
   ResizeTerminal,
   AckTerminalData,
   ReadClipboardFiles,
-  SaveClipboardImage,
+  UploadAndQuoteForTerminal,
+  UploadClipboardImageForTerminal,
 } from "../../wailsjs/go/main/App";
-import { sendTerminalInput, shellQuote } from "../terminal-io";
+import { sendTerminalInput } from "../terminal-io";
 import { getTerminalTheme, openTerminalLink } from "./terminal-utils";
 import { registerFileDropHandler } from "../fileDrop";
 import "@xterm/xterm/css/xterm.css";
@@ -49,7 +50,12 @@ function initFileDrop() {
   registerFileDropHandler("terminals", (x, y, paths) => {
     const id = terminalIdAtPoint(x, y);
     if (!id) return false;
-    pasteToTerminal(id, formatPastedPaths(paths));
+    // For remote panes the Go side scp's the files via the existing
+    // ControlMaster socket and returns the paste-ready remote paths;
+    // for local panes it just formats the local paths.
+    UploadAndQuoteForTerminal(id, paths)
+      .then((text) => pasteToTerminal(id, text))
+      .catch((err) => writeTerminalError(id, err));
     return true;
   });
 }
@@ -174,16 +180,12 @@ function saveImageBlob(terminalId: string, blob: File, mimeType: string) {
     const dataUrl = reader.result as string;
     const b64 = dataUrl.split(",")[1];
     if (!b64) return;
-    SaveClipboardImage(b64, mimeType)
-      .then((filePath) => {
-        pasteToTerminal(terminalId, filePath);
-      })
-      .catch((err) => console.warn("SaveClipboardImage failed:", err));
+    UploadClipboardImageForTerminal(terminalId, b64, mimeType)
+      .then((text) => pasteToTerminal(terminalId, text))
+      .catch((err) => writeTerminalError(terminalId, err));
   };
   reader.readAsDataURL(blob);
 }
-
-const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|bmp|tiff?|heic|heif)$/i;
 
 // xterm's paste() emits CSI ?2004h bracketed-paste markers when the running
 // app enabled them — writing to the PTY directly would skip those, leaving
@@ -192,13 +194,11 @@ function pasteToTerminal(terminalId: string, text: string): void {
   interactiveSessions.get(terminalId)?.term.paste(text);
 }
 
-// Single image paths go in unquoted so a path-detecting receiver can stat
-// them; everything else is shell-quoted for shell users.
-function formatPastedPaths(paths: string[]): string {
-  if (paths.length === 1 && IMAGE_EXT_RE.test(paths[0])) {
-    return paths[0];
-  }
-  return paths.map(shellQuote).join(" ");
+function writeTerminalError(terminalId: string, err: unknown): void {
+  const msg = err instanceof Error ? err.message : String(err);
+  const term = interactiveSessions.get(terminalId)?.term;
+  if (!term) return;
+  term.write(`\r\n\x1b[31mlpm upload failed: ${msg}\x1b[0m\r\n`);
 }
 
 function createInteractiveSession(terminalId: string): InteractiveSession {
@@ -370,10 +370,11 @@ function createInteractiveSession(terminalId: string): InteractiveSession {
       ReadClipboardFiles()
         .then((paths) => {
           if (paths && paths.length > 0) {
-            pasteToTerminal(terminalId, formatPastedPaths(paths));
-          } else {
-            fallback();
+            return UploadAndQuoteForTerminal(terminalId, paths)
+              .then((text) => pasteToTerminal(terminalId, text))
+              .catch((err) => writeTerminalError(terminalId, err));
           }
+          fallback();
         })
         .catch(fallback);
       return;

--- a/desktop/pty.go
+++ b/desktop/pty.go
@@ -34,8 +34,14 @@ type ptySession struct {
 	id          string
 	projectName string
 	declared    map[int]bool // service ports declared in cfg; nil for local projects
-	pty         *os.File
-	cmd         *exec.Cmd
+	// remote is cfg.IsRemote() at start time (post-sync-mirror): true when
+	// the underlying shell runs on the SSH host, false for local panes
+	// including sync-mode panes whose work happens in the local mirror.
+	// File drops/pastes consult this to decide whether to upload.
+	remote bool
+	ssh    *config.SSHSettings // SSH settings copied from cfg at start, nil if !remote
+	pty    *os.File
+	cmd    *exec.Cmd
 
 	// onClose runs (in a goroutine) after the underlying process exits.
 	// Used by mode: sync terminals to push the rsync mirror back.
@@ -192,9 +198,13 @@ func (a *App) startTerminalInternal(cfg *config.ProjectConfig, projectName strin
 		id:          id,
 		projectName: projectName,
 		declared:    declared,
+		remote:      cfg.IsRemote(),
 		pty:         ptmx,
 		cmd:         cmd,
 		onClose:     onClose,
+	}
+	if sess.remote {
+		sess.ssh = cfg.SSH
 	}
 	sess.cond = sync.NewCond(&sess.mu)
 

--- a/desktop/pty.go
+++ b/desktop/pty.go
@@ -372,6 +372,19 @@ func (a *App) AckTerminalData(id string, charCount int) error {
 	return nil
 }
 
+// IsTerminalRemote reports whether the session's shell is running on the
+// SSH host (false for unknown ids, local panes, and sync-mode panes whose
+// shell runs in the local rsync mirror).
+func (a *App) IsTerminalRemote(id string) bool {
+	a.ptyMu.Lock()
+	defer a.ptyMu.Unlock()
+	sess, ok := a.ptySessions[id]
+	if !ok {
+		return false
+	}
+	return sess.remote
+}
+
 // ResizeTerminal updates the PTY window size, triggering SIGWINCH in the shell.
 func (a *App) ResizeTerminal(id string, cols int, rows int) error {
 	a.ptyMu.Lock()

--- a/desktop/pty.go
+++ b/desktop/pty.go
@@ -150,7 +150,15 @@ func (a *App) StartTerminalForConfig(projectName string, terminalName string) (T
 // applies it directly to the local process env.
 func buildTerminalCmd(cfg *config.ProjectConfig, rawCwd string, extraEnv map[string]string) (*exec.Cmd, error) {
 	if cfg.IsRemote() {
-		argv := config.SSHCommandArgv(cfg, rawCwd, extraEnv, `exec "$SHELL" -l`)
+		// SSH doesn't forward TERM_PROGRAM by default, so the local
+		// pty.go cmd.Env setting doesn't reach the remote shell.
+		// Bake it into the remote script so TUIs like Claude Code can
+		// detect kitty-keyboard support and recognize Shift+Enter.
+		remoteEnv := map[string]string{"TERM_PROGRAM": "kitty"}
+		for k, v := range extraEnv {
+			remoteEnv[k] = v
+		}
+		argv := config.SSHCommandArgv(cfg, rawCwd, remoteEnv, `exec "$SHELL" -l`)
 		cmd := exec.Command(argv[0], argv[1:]...)
 		cmd.Dir = config.RemoteLocalSpawnDir(cfg)
 		return cmd, nil

--- a/desktop/upload.go
+++ b/desktop/upload.go
@@ -3,10 +3,8 @@ package main
 import (
 	"bytes"
 	"crypto/rand"
-	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -47,7 +45,7 @@ func (a *App) UploadAndQuoteForTerminal(terminalID string, localPaths []string) 
 // image to a local temp file and routes through the same upload path,
 // so remote panes get a remote path and local panes get the local temp.
 func (a *App) UploadClipboardImageForTerminal(terminalID, b64Data, mimeType string) (string, error) {
-	localPath, err := saveClipboardImageTemp(b64Data, mimeType)
+	localPath, err := a.SaveClipboardImage(b64Data, mimeType)
 	if err != nil {
 		return "", err
 	}
@@ -143,37 +141,6 @@ func shellQuoteSingle(s string) string {
 		return s
 	}
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
-}
-
-// saveClipboardImageTemp is the file-write half of SaveClipboardImage,
-// reused so UploadClipboardImageForTerminal doesn't need a frontend
-// round-trip just to get a temp path.
-func saveClipboardImageTemp(b64Data, mimeType string) (string, error) {
-	data, err := base64.StdEncoding.DecodeString(b64Data)
-	if err != nil {
-		return "", fmt.Errorf("decode base64: %w", err)
-	}
-	ext := ".png"
-	switch mimeType {
-	case "image/jpeg":
-		ext = ".jpg"
-	case "image/gif":
-		ext = ".gif"
-	case "image/webp":
-		ext = ".webp"
-	case "image/bmp":
-		ext = ".bmp"
-	}
-	f, err := os.CreateTemp("", "clipboard-*"+ext)
-	if err != nil {
-		return "", fmt.Errorf("create temp file: %w", err)
-	}
-	defer f.Close()
-	if _, err := f.Write(data); err != nil {
-		os.Remove(f.Name())
-		return "", fmt.Errorf("write temp file: %w", err)
-	}
-	return f.Name(), nil
 }
 
 func trimOutput(s string) string {

--- a/desktop/upload.go
+++ b/desktop/upload.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/gug007/lpm/internal/config"
+)
+
+// UploadAndQuoteForTerminal uploads localPaths to the remote host of the
+// terminal's project (when the terminal was started in remote mode) and
+// returns a single string of paths formatted for paste — single images
+// unquoted (so path-detecting receivers like Claude Code can stat them),
+// everything else shell-quoted and space-joined. For non-remote panes
+// the same formatting is applied to the local paths, so the frontend
+// can call this unconditionally.
+func (a *App) UploadAndQuoteForTerminal(terminalID string, localPaths []string) (string, error) {
+	if len(localPaths) == 0 {
+		return "", nil
+	}
+
+	a.ptyMu.Lock()
+	sess, ok := a.ptySessions[terminalID]
+	a.ptyMu.Unlock()
+
+	if !ok || !sess.remote || sess.ssh == nil {
+		return formatPastePaths(localPaths), nil
+	}
+
+	remotePaths, err := a.uploadFiles(sess.ssh, localPaths)
+	if err != nil {
+		return "", err
+	}
+	return formatPastePaths(remotePaths), nil
+}
+
+// UploadClipboardImageForTerminal saves the base64-encoded clipboard
+// image to a local temp file and routes through the same upload path,
+// so remote panes get a remote path and local panes get the local temp.
+func (a *App) UploadClipboardImageForTerminal(terminalID, b64Data, mimeType string) (string, error) {
+	localPath, err := saveClipboardImageTemp(b64Data, mimeType)
+	if err != nil {
+		return "", err
+	}
+	return a.UploadAndQuoteForTerminal(terminalID, []string{localPath})
+}
+
+// uploadFiles scp's localPaths to a fresh per-batch directory on the
+// SSH host, reusing the existing ControlMaster socket. Returns the
+// absolute remote paths in the same order as localPaths.
+func (a *App) uploadFiles(s *config.SSHSettings, localPaths []string) ([]string, error) {
+	batch, err := newBatchID()
+	if err != nil {
+		return nil, fmt.Errorf("upload: %w", err)
+	}
+	_ = config.EnsureSSHControlDir()
+
+	// One ssh round-trip: create the dir and echo its absolute path.
+	// Resolving via $HOME on the remote avoids the ~-expansion-vs-quoting
+	// trap when we paste paths with special characters in basenames.
+	remoteCmd := fmt.Sprintf(`mkdir -p "$HOME/.lpm/uploads/%s" && printf '%%s' "$HOME/.lpm/uploads/%s"`, batch, batch)
+	mkdirArgs := append([]string{}, config.SSHArgs(s)...)
+	mkdirArgs = append(mkdirArgs, remoteCmd)
+
+	mkdirCmd := exec.Command("ssh", mkdirArgs...)
+	var mkdirErr bytes.Buffer
+	mkdirCmd.Stderr = &mkdirErr
+	out, err := mkdirCmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("ssh mkdir: %s: %w", trimOutput(mkdirErr.String()), err)
+	}
+	remoteDir := strings.TrimSpace(string(out))
+	if remoteDir == "" {
+		return nil, fmt.Errorf("ssh mkdir returned empty path")
+	}
+
+	// scp all files in one call. Putting -- before the source paths is
+	// belt-and-suspenders; local paths from drag/drop or the temp dir
+	// always start with /, so they can't be mistaken for flags anyway.
+	scpArgs := append([]string{}, config.SCPArgs(s)...)
+	scpArgs = append(scpArgs, "-r", "-p", "--")
+	scpArgs = append(scpArgs, localPaths...)
+	scpArgs = append(scpArgs, fmt.Sprintf("%s@%s:%s/", s.User, s.Host, remoteDir))
+
+	scpCmd := exec.Command("scp", scpArgs...)
+	var scpErr bytes.Buffer
+	scpCmd.Stderr = &scpErr
+	if _, err := scpCmd.Output(); err != nil {
+		return nil, fmt.Errorf("scp: %s: %w", trimOutput(scpErr.String()), err)
+	}
+
+	remotePaths := make([]string, len(localPaths))
+	for i, p := range localPaths {
+		remotePaths[i] = remoteDir + "/" + filepath.Base(p)
+	}
+	return remotePaths, nil
+}
+
+func newBatchID() (string, error) {
+	var rb [3]byte
+	if _, err := rand.Read(rb[:]); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%d-%s", time.Now().Unix(), hex.EncodeToString(rb[:])), nil
+}
+
+// imageExtRe mirrors IMAGE_EXT_RE in InteractivePane.tsx — keep in sync.
+var imageExtRe = regexp.MustCompile(`(?i)\.(png|jpe?g|gif|webp|bmp|tiff?|heic|heif)$`)
+
+// formatPastePaths mirrors formatPastedPaths in InteractivePane.tsx:
+// a single image path is pasted unquoted so path-detecting receivers
+// (e.g. Claude Code) can stat it; everything else is shell-quoted and
+// space-joined for shell users.
+func formatPastePaths(paths []string) string {
+	if len(paths) == 1 && imageExtRe.MatchString(paths[0]) {
+		return paths[0]
+	}
+	parts := make([]string, len(paths))
+	for i, p := range paths {
+		parts[i] = shellQuoteSingle(p)
+	}
+	return strings.Join(parts, " ")
+}
+
+// safePathChars mirrors the predicate in shellQuote (terminal-io.ts:15):
+// any path containing characters outside this set gets single-quoted.
+var safePathChars = regexp.MustCompile(`^[A-Za-z0-9_./:~-]+$`)
+
+func shellQuoteSingle(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if safePathChars.MatchString(s) {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// saveClipboardImageTemp is the file-write half of SaveClipboardImage,
+// reused so UploadClipboardImageForTerminal doesn't need a frontend
+// round-trip just to get a temp path.
+func saveClipboardImageTemp(b64Data, mimeType string) (string, error) {
+	data, err := base64.StdEncoding.DecodeString(b64Data)
+	if err != nil {
+		return "", fmt.Errorf("decode base64: %w", err)
+	}
+	ext := ".png"
+	switch mimeType {
+	case "image/jpeg":
+		ext = ".jpg"
+	case "image/gif":
+		ext = ".gif"
+	case "image/webp":
+		ext = ".webp"
+	case "image/bmp":
+		ext = ".bmp"
+	}
+	f, err := os.CreateTemp("", "clipboard-*"+ext)
+	if err != nil {
+		return "", fmt.Errorf("create temp file: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(data); err != nil {
+		os.Remove(f.Name())
+		return "", fmt.Errorf("write temp file: %w", err)
+	}
+	return f.Name(), nil
+}
+
+func trimOutput(s string) string {
+	s = strings.TrimSpace(s)
+	const max = 400
+	if len(s) > max {
+		return s[:max] + "..."
+	}
+	return s
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -248,6 +248,25 @@ func SSHArgs(s *SSHSettings) []string {
 	return args
 }
 
+// SCPArgs returns scp options that piggyback on the same ControlMaster
+// socket SSHArgs uses, so an scp call from a long-lived terminal session
+// reuses the open mux instead of opening a new auth/handshake.
+// Differs from SSHArgs only by dropping -t and using -P for port.
+func SCPArgs(s *SSHSettings) []string {
+	args := []string{
+		"-o", "ControlMaster=auto",
+		"-o", "ControlPath=" + SSHControlPath(),
+		"-o", "ControlPersist=10m",
+	}
+	if s.Port > 0 && s.Port != 22 {
+		args = append(args, "-P", strconv.Itoa(s.Port))
+	}
+	if key := strings.TrimSpace(s.Key); key != "" {
+		args = append(args, "-i", ExpandHome(key))
+	}
+	return args
+}
+
 // SSHControlDir is the parent directory for SSH ControlMaster sockets.
 // /tmp keeps the path short enough that <dir>/cm-<%C-hash> stays under
 // the 104-byte sun_path limit; the per-uid suffix avoids collisions on


### PR DESCRIPTION
Drag-drop and clipboard pastes into a remote-mode terminal now scp the files over the existing ControlMaster socket and paste the resulting remote paths, instead of pasting unreachable local paths. Local and sync-mode panes keep their previous local-path behavior.