### PR TITLE
Add terminal search and delete actions

### DIFF
--- a/desktop/frontend/src/components/PaneLayout.tsx
+++ b/desktop/frontend/src/components/PaneLayout.tsx
@@ -3,10 +3,11 @@ import { PaneView, type PaneViewProps } from "./PaneView";
 import type { PaneNode, PaneSplit } from "../paneTree";
 import { firstPaneId } from "../paneTree";
 
-export interface PaneLayoutProps extends Omit<PaneViewProps, "pane" | "focused" | "fullscreen"> {
+export interface PaneLayoutProps extends Omit<PaneViewProps, "pane" | "focused" | "fullscreen" | "searchActive"> {
   node: PaneNode;
   focusedPaneId: string | null;
   fullscreenPaneId: string | null;
+  searchPaneId: string | null;
   onRatioChange: (path: number[], ratio: number) => void;
   path?: number[];
   // services are only rendered on the first leaf in the whole tree.
@@ -16,7 +17,7 @@ export interface PaneLayoutProps extends Omit<PaneViewProps, "pane" | "focused" 
 }
 
 export function PaneLayout(props: PaneLayoutProps) {
-  const { node, path = [], focusedPaneId, fullscreenPaneId, services, primaryPaneId } = props;
+  const { node, path = [], focusedPaneId, fullscreenPaneId, searchPaneId, services, primaryPaneId } = props;
   const rootPrimaryId = primaryPaneId ?? firstPaneId(node);
 
   if (node.kind === "leaf") {
@@ -26,6 +27,7 @@ export function PaneLayout(props: PaneLayoutProps) {
         pane={node}
         focused={focusedPaneId === node.id}
         fullscreen={fullscreenPaneId === node.id}
+        searchActive={searchPaneId === node.id}
         services={node.id === rootPrimaryId ? services : undefined}
       />
     );

--- a/desktop/frontend/src/components/PaneView.tsx
+++ b/desktop/frontend/src/components/PaneView.tsx
@@ -12,6 +12,7 @@ import {
   ExpandIcon,
   ShrinkIcon,
 } from "./terminal/icons";
+import { TerminalSearchBar } from "./terminal/TerminalSearchBar";
 import { XIcon } from "./icons";
 import { Tooltip } from "./ui/Tooltip";
 import { SortableTab, TabStrip } from "./TerminalTabDnd";
@@ -31,6 +32,7 @@ export interface PaneViewProps {
   visible: boolean;
   focused: boolean;
   fullscreen: boolean;
+  searchActive: boolean;
   canClose: boolean;
   fontSize: number;
   themeOverride: ITheme | null;
@@ -58,6 +60,8 @@ export interface PaneViewProps {
     handle: PaneHandle | null,
   ) => void;
   onClearStatus: (terminalId: string, kind: StatusKind) => void;
+  onFindInPane: (paneId: string, query: string, direction: "next" | "prev") => boolean;
+  onCloseSearch: () => void;
 }
 
 function PaneViewImpl(props: PaneViewProps) {
@@ -66,6 +70,7 @@ function PaneViewImpl(props: PaneViewProps) {
     visible,
     focused,
     fullscreen,
+    searchActive,
     canClose,
     fontSize,
     themeOverride,
@@ -87,6 +92,8 @@ function PaneViewImpl(props: PaneViewProps) {
     onRegisterTerminalHandle,
     onRegisterServiceHandle,
     onClearStatus,
+    onFindInPane,
+    onCloseSearch,
   } = props;
 
   const hasMultipleServices = services.length > 1;
@@ -258,8 +265,16 @@ function PaneViewImpl(props: PaneViewProps) {
         </div>
       </div>
       <div
-        className={`flex min-h-0 min-w-0 flex-1 overflow-hidden ${isAllActive ? "divide-x divide-[var(--border)]" : ""}`}
+        className={`relative flex min-h-0 min-w-0 flex-1 overflow-hidden ${isAllActive ? "divide-x divide-[var(--border)]" : ""}`}
       >
+        {searchActive && (
+          <TerminalSearchBar
+            key={`${pane.id}:${activeServiceName ?? activeTerm?.id ?? "empty"}`}
+            onFindNext={(query) => onFindInPane(pane.id, query, "next")}
+            onFindPrevious={(query) => onFindInPane(pane.id, query, "prev")}
+            onClose={onCloseSearch}
+          />
+        )}
         {services.map((svc) => {
           const isVisible = isAllActive || activeServiceName === svc.name;
           return (

--- a/desktop/frontend/src/components/ProjectDetail.tsx
+++ b/desktop/frontend/src/components/ProjectDetail.tsx
@@ -440,6 +440,11 @@ export function ProjectDetail({
           editing={serviceEditor.editing}
           onClose={serviceEditor.closeForm}
           onSaved={onRefresh}
+          onDelete={
+            serviceEditor.editing && project.allServices.length > 1
+              ? serviceEditor.requestDelete
+              : undefined
+          }
           onPickService={serviceEditor.startEdit}
           onPickProfile={(profile) => {
             serviceEditor.closeForm();
@@ -484,6 +489,7 @@ export function ProjectDetail({
           editing={profileEditor.editing}
           onClose={profileEditor.closeForm}
           onSaved={onRefresh}
+          onDelete={profileEditor.editing ? profileEditor.requestDelete : undefined}
           onPickService={(service) => {
             profileEditor.closeForm();
             serviceEditor.startEdit(service);

--- a/desktop/frontend/src/components/TerminalView.tsx
+++ b/desktop/frontend/src/components/TerminalView.tsx
@@ -40,6 +40,7 @@ export interface TerminalViewHandle {
 export function TerminalView({ projectName, services, terminalTheme, onTerminalCountChange, fontSize, onZoomIn, onZoomOut, runningPaneIDs, donePaneIDs, waitingPaneIDs, errorPaneIDs, visible = true, ref }: TerminalViewProps) {
   const [outputs, setOutputs] = useState<string[]>([]);
   const [fullscreenPaneId, setFullscreenPaneId] = useState<string | null>(null);
+  const [searchPaneId, setSearchPaneId] = useState<string | null>(null);
 
   const terminalHandles = useRef<Map<string, InteractivePaneHandle>>(new Map());
   const serviceHandles = useRef<Map<string, PaneHandle>>(new Map());
@@ -87,6 +88,12 @@ export function TerminalView({ projectName, services, terminalTheme, onTerminalC
       setFullscreenPaneId(null);
     }
   }, [tree, fullscreenPaneId, getPane]);
+
+  useEffect(() => {
+    if (searchPaneId && !getPane(searchPaneId)) {
+      setSearchPaneId(null);
+    }
+  }, [tree, searchPaneId, getPane]);
 
   const { containerStyle, xtermTheme } = useMemo(() => {
     const colors = getTerminalThemeColors(terminalTheme);
@@ -180,25 +187,45 @@ export function TerminalView({ projectName, services, terminalTheme, onTerminalC
     [projectName],
   );
 
-  // Resolves the active tab in a pane to its xterm handle and calls
-  // clear(). Handles both interactive terminals and service log tabs.
-  const handleClearPane = useCallback(
-    (paneId: string) => {
+  const resolveActiveHandle = useCallback(
+    (paneId: string): InteractivePaneHandle | PaneHandle | null => {
       const pane = getPane(paneId);
-      if (!pane) return;
+      if (!pane) return null;
       if (pane.activeServiceName) {
-        serviceHandles.current.get(pane.activeServiceName)?.clear();
-        return;
+        return serviceHandles.current.get(pane.activeServiceName) ?? null;
       }
       const active = pane.tabs[pane.activeTabIdx];
-      if (active) terminalHandles.current.get(active.id)?.clear();
+      return active ? terminalHandles.current.get(active.id) ?? null : null;
     },
     [getPane],
+  );
+
+  const handleClearPane = useCallback(
+    (paneId: string) => {
+      resolveActiveHandle(paneId)?.clear();
+    },
+    [resolveActiveHandle],
   );
 
   const handleToggleFullscreen = useCallback((paneId: string) => {
     setFullscreenPaneId((current) => (current === paneId ? null : paneId));
   }, []);
+
+  const findInPane = useCallback(
+    (paneId: string, query: string, direction: "next" | "prev"): boolean => {
+      const handle = resolveActiveHandle(paneId);
+      if (!handle) return false;
+      return direction === "next" ? handle.findNext(query) : handle.findPrevious(query);
+    },
+    [resolveActiveHandle],
+  );
+
+  const handleCloseSearch = useCallback(() => {
+    setSearchPaneId((current) => {
+      if (current) resolveActiveHandle(current)?.clearSearch();
+      return null;
+    });
+  }, [resolveActiveHandle]);
 
   useEffect(() => {
     setOutputs(new Array(stableServices.length).fill(""));
@@ -293,6 +320,7 @@ export function TerminalView({ projectName, services, terminalTheme, onTerminalC
       { key: "-", meta: true },
       { key: "w", meta: true },
       { key: "d", meta: true },
+      { key: "f", meta: true },
       { key: "Escape", preventDefault: false },
     ],
     (event, matched) => {
@@ -308,6 +336,12 @@ export function TerminalView({ projectName, services, terminalTheme, onTerminalC
         const pane = getFocusedPane();
         if (!pane) return;
         splitPane(pane.id, event.shiftKey ? "col" : "row");
+        return;
+      }
+      if (matched.key === "f") {
+        const pane = getFocusedPane();
+        if (!pane) return;
+        setSearchPaneId(pane.id);
         return;
       }
       if (matched.key === "Escape" && fullscreenPaneId) {
@@ -346,6 +380,7 @@ export function TerminalView({ projectName, services, terminalTheme, onTerminalC
             visible={visible}
             focusedPaneId={focusedPaneId}
             fullscreenPaneId={fullscreenPaneId}
+            searchPaneId={searchPaneId}
             canClose={tree.kind === "split"}
             fontSize={fontSize}
             themeOverride={xtermTheme}
@@ -368,6 +403,8 @@ export function TerminalView({ projectName, services, terminalTheme, onTerminalC
             onRegisterServiceHandle={registerServiceHandle}
             onClearStatus={handleClearStatus}
             onRatioChange={setRatio}
+            onFindInPane={findInPane}
+            onCloseSearch={handleCloseSearch}
           />
         </TerminalTabDnd>
       ) : (

--- a/desktop/frontend/src/components/project-detail/ProfileForm.tsx
+++ b/desktop/frontend/src/components/project-detail/ProfileForm.tsx
@@ -25,6 +25,7 @@ interface ProfileFormProps {
   editing?: ProfileInfo | null;
   onClose: () => void;
   onSaved: () => void;
+  onDelete?: () => void;
   // Click on a non-draft preview row swaps the modal to that entry. Service
   // clicks cross-route to the ServiceForm; profile clicks switch the profile
   // being edited.
@@ -40,6 +41,7 @@ export function ProfileForm({
   editing,
   onClose,
   onSaved,
+  onDelete,
   onPickService,
   onPickProfile,
 }: ProfileFormProps) {
@@ -211,20 +213,29 @@ export function ProfileForm({
           />
         </div>
 
-        <footer className="flex items-center justify-between gap-3 border-t border-[var(--border)] px-8 py-4">
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-xl px-3 py-2 text-[13px] font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
-          >
-            Cancel
-          </button>
-          <div className="flex items-center gap-3">
+        <footer className="flex items-center gap-3 border-t border-[var(--border)] px-8 py-4">
+          {isEditing && onDelete && (
+            <button
+              type="button"
+              onClick={onDelete}
+              className="rounded-xl px-3 py-2 text-[13px] font-medium text-[var(--accent-red)] transition-colors hover:bg-[var(--accent-red)]/10"
+            >
+              Delete profile
+            </button>
+          )}
+          <div className="ml-auto flex items-center gap-3">
             {!canSave && errorHint && (
               <span className="hidden text-[12px] text-[var(--text-muted)] sm:inline">
                 {errorHint}
               </span>
             )}
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-xl px-3 py-2 text-[13px] font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+            >
+              Cancel
+            </button>
             <button
               type="button"
               onClick={() => void submit()}

--- a/desktop/frontend/src/components/project-detail/ServiceForm.tsx
+++ b/desktop/frontend/src/components/project-detail/ServiceForm.tsx
@@ -46,6 +46,7 @@ interface ServiceFormProps {
   editing?: ServiceInfo | null;
   onClose: () => void;
   onSaved: () => void;
+  onDelete?: () => void;
   // Click on a non-draft preview row swaps the modal to that entry. Profile
   // clicks cross-route to the ProfileForm; service clicks switch the service
   // being edited.
@@ -113,6 +114,7 @@ export function ServiceForm({
   editing,
   onClose,
   onSaved,
+  onDelete,
   onPickService,
   onPickProfile,
 }: ServiceFormProps) {
@@ -343,20 +345,29 @@ export function ServiceForm({
           />
         </div>
 
-        <footer className="flex items-center justify-between gap-3 border-t border-[var(--border)] px-8 py-4">
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-xl px-3 py-2 text-[13px] font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
-          >
-            Cancel
-          </button>
-          <div className="flex items-center gap-3">
+        <footer className="flex items-center gap-3 border-t border-[var(--border)] px-8 py-4">
+          {isEditing && onDelete && (
+            <button
+              type="button"
+              onClick={onDelete}
+              className="rounded-xl px-3 py-2 text-[13px] font-medium text-[var(--accent-red)] transition-colors hover:bg-[var(--accent-red)]/10"
+            >
+              Delete service
+            </button>
+          )}
+          <div className="ml-auto flex items-center gap-3">
             {!canSave && errorHint && (
               <span className="hidden text-[12px] text-[var(--text-muted)] sm:inline">
                 {errorHint}
               </span>
             )}
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-xl px-3 py-2 text-[13px] font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+            >
+              Cancel
+            </button>
             <button
               type="button"
               onClick={() => void submit()}

--- a/desktop/frontend/src/components/terminal/TerminalSearchBar.tsx
+++ b/desktop/frontend/src/components/terminal/TerminalSearchBar.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useRef, useState } from "react";
+import { IconBtn } from "./IconBtn";
+import { ArrowDownIcon, ChevronUpIcon, SearchIcon } from "./icons";
+import { XIcon } from "../icons";
+
+interface TerminalSearchBarProps {
+  onFindNext: (query: string) => boolean;
+  onFindPrevious: (query: string) => boolean;
+  onClose: () => void;
+}
+
+export function TerminalSearchBar({ onFindNext, onFindPrevious, onClose }: TerminalSearchBarProps) {
+  const [query, setQuery] = useState("");
+  const [notFound, setNotFound] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  const runSearch = (direction: "next" | "prev") => {
+    if (!query) {
+      setNotFound(false);
+      return;
+    }
+    const found = direction === "next" ? onFindNext(query) : onFindPrevious(query);
+    setNotFound(!found);
+  };
+
+  const handleChange = (value: string) => {
+    setQuery(value);
+    if (!value) {
+      setNotFound(false);
+      return;
+    }
+    setNotFound(!onFindNext(value));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+      return;
+    }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      runSearch(e.shiftKey ? "prev" : "next");
+    }
+  };
+
+  const inputClass = `w-44 bg-transparent font-mono text-[11px] outline-none placeholder:text-[var(--text-muted)] ${
+    notFound ? "text-[var(--accent-red)]" : "text-[var(--text-primary)]"
+  }`;
+
+  return (
+    <div className="absolute right-2 top-2 z-10 flex items-center gap-1 rounded-md border border-[var(--border)] bg-[var(--terminal-header)] px-2 py-1 shadow-md">
+      <span className="text-[var(--text-muted)]">
+        <SearchIcon />
+      </span>
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        placeholder="Find"
+        onChange={(e) => handleChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        className={inputClass}
+      />
+      <IconBtn onClick={() => runSearch("prev")} title="Previous match (Shift+Enter)">
+        <ChevronUpIcon />
+      </IconBtn>
+      <IconBtn onClick={() => runSearch("next")} title="Next match (Enter)">
+        <ArrowDownIcon />
+      </IconBtn>
+      <IconBtn onClick={onClose} title="Close (Esc)">
+        <XIcon />
+      </IconBtn>
+    </div>
+  );
+}

--- a/desktop/frontend/src/hooks/useEntityEditor.ts
+++ b/desktop/frontend/src/hooks/useEntityEditor.ts
@@ -18,6 +18,7 @@ export interface EntityEditor<T extends NamedEntity> {
   closeContextMenu: () => void;
   editFromContextMenu: () => void;
   deleteFromContextMenu: () => void;
+  requestDelete: () => void;
   cancelDelete: () => void;
   confirmDelete: () => Promise<void>;
 }
@@ -77,6 +78,10 @@ export function useEntityEditor<T extends NamedEntity>({
     setToDelete(contextMenu.entity);
   }, [contextMenu]);
 
+  const requestDelete = useCallback(() => {
+    if (editing) setToDelete(editing);
+  }, [editing]);
+
   const cancelDelete = useCallback(() => setToDelete(null), []);
 
   const confirmDelete = useCallback(async () => {
@@ -86,6 +91,10 @@ export function useEntityEditor<T extends NamedEntity>({
       await deleteFn(projectName, toDelete.name);
       toast.success(`Deleted ${toDelete.name}`);
       setToDelete(null);
+      // Close any open editor form for this entity — the entity no longer
+      // exists, so leaving the form open with stale state would be wrong.
+      setEditing(null);
+      setCreating(false);
       onChanged();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : `Could not delete ${entityLabel}`);
@@ -107,6 +116,7 @@ export function useEntityEditor<T extends NamedEntity>({
     closeContextMenu,
     editFromContextMenu,
     deleteFromContextMenu,
+    requestDelete,
     cancelDelete,
     confirmDelete,
   };


### PR DESCRIPTION
Adds search within terminal panes and brings delete actions directly into the service/profile editors. It also tightens editor state cleanup after deletions so forms close cleanly instead of lingering on removed entities.

- Added an in-pane terminal search UI with next/previous navigation, Esc-to-close, and Ctrl/Cmd+F to open search on the focused pane.
- Wired search state through the pane layout so only the active pane shows the search bar.
- Added delete actions to the ServiceForm and ProfileForm footers for easier entity management.
- Updated entity editor flow to support direct delete requests from open forms.
- After successful deletion, the editor now clears stale form state and exits edit/create mode.
- Small layout polish in form footers to keep cancel/save actions aligned consistently.