### PR TITLE
feat(desktop): pin terminal tab

### DIFF
--- a/desktop/frontend/package-lock.json
+++ b/desktop/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "@xterm/addon-webgl": "^0.20.0-beta.219",
         "@xterm/xterm": "^6.1.0-beta.220",
         "frimousse": "^0.3.0",
+        "lucide-react": "^1.16.0",
         "monaco-editor": "~0.52.2",
         "monaco-yaml": "^5.4.1",
         "parse-diff": "^0.12.0",
@@ -2803,6 +2804,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.16.0.tgz",
+      "integrity": "sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -24,6 +24,7 @@
     "@xterm/addon-webgl": "^0.20.0-beta.219",
     "@xterm/xterm": "^6.1.0-beta.220",
     "frimousse": "^0.3.0",
+    "lucide-react": "^1.16.0",
     "monaco-editor": "~0.52.2",
     "monaco-yaml": "^5.4.1",
     "parse-diff": "^0.12.0",

--- a/desktop/frontend/src/components/PaneView.tsx
+++ b/desktop/frontend/src/components/PaneView.tsx
@@ -1,8 +1,9 @@
-import { memo, useEffect, useMemo } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 import type { ITheme } from "@xterm/xterm";
 import { InteractivePane, type InteractivePaneHandle } from "./InteractivePane";
 import { Pane, type PaneHandle } from "./Pane";
 import { HeaderTab } from "./terminal/HeaderTab";
+import { TabContextMenu } from "./terminal/TabContextMenu";
 import { IconBtn } from "./terminal/IconBtn";
 import {
   PlusIcon,
@@ -51,6 +52,7 @@ export interface PaneViewProps {
   onAddTerminal: (paneId: string) => void;
   onCloseTerminal: (paneId: string, tabIdx: number) => void;
   onRenameTerminal: (paneId: string, tabIdx: number, label: string) => void;
+  onTogglePinTab: (paneId: string, tabIdx: number) => void;
   onSplit: (paneId: string, direction: SplitDirection) => void;
   onClosePane: (paneId: string) => void;
   onClearPane: (paneId: string) => void;
@@ -90,6 +92,7 @@ function PaneViewImpl(props: PaneViewProps) {
     onAddTerminal,
     onCloseTerminal,
     onRenameTerminal,
+    onTogglePinTab,
     onSplit,
     onClosePane,
     onClearPane,
@@ -100,6 +103,13 @@ function PaneViewImpl(props: PaneViewProps) {
     onFindInPane,
     onCloseSearch,
   } = props;
+
+  const [tabMenu, setTabMenu] = useState<{
+    paneId: string;
+    tabIdx: number;
+    x: number;
+    y: number;
+  } | null>(null);
 
   const hasMultipleServices = services.length > 1;
   const isAllActive =
@@ -186,6 +196,7 @@ function PaneViewImpl(props: PaneViewProps) {
                   <HeaderTab
                     label={t.label}
                     active={isActive}
+                    pinned={t.pinned}
                     shimmer={runningPaneIDs?.has(t.id) ?? false}
                     done={!isActive && isDone}
                     waiting={isWaiting}
@@ -197,6 +208,10 @@ function PaneViewImpl(props: PaneViewProps) {
                     }}
                     onClose={() => onCloseTerminal(pane.id, i)}
                     onRename={(name) => onRenameTerminal(pane.id, i, name)}
+                    onContextMenu={(e) => {
+                      e.preventDefault();
+                      setTabMenu({ paneId: pane.id, tabIdx: i, x: e.clientX, y: e.clientY });
+                    }}
                   />
                 </SortableTab>
               );
@@ -332,6 +347,20 @@ function PaneViewImpl(props: PaneViewProps) {
           );
         })}
       </div>
+      {tabMenu && (() => {
+        const targetPane = pane.id === tabMenu.paneId ? pane : null;
+        const tab = targetPane?.tabs[tabMenu.tabIdx];
+        if (!tab) return null;
+        return (
+          <TabContextMenu
+            x={tabMenu.x}
+            y={tabMenu.y}
+            pinned={tab.pinned === true}
+            onTogglePin={() => onTogglePinTab(tabMenu.paneId, tabMenu.tabIdx)}
+            onClose={() => setTabMenu(null)}
+          />
+        );
+      })()}
     </div>
   );
 }

--- a/desktop/frontend/src/components/TerminalView.tsx
+++ b/desktop/frontend/src/components/TerminalView.tsx
@@ -4,7 +4,7 @@ import { GetServiceLogs, StartLogStreaming, StopLogStreaming, ClearStatus } from
 import type { ITheme } from "@xterm/xterm";
 import { disposePaneSession, type PaneHandle } from "./Pane";
 import { disposeInteractivePaneSession, type InteractivePaneHandle } from "./InteractivePane";
-import { collectTerminals } from "../paneTree";
+import { collectTerminals, isTabPinned } from "../paneTree";
 import { PaneLayout } from "./PaneLayout";
 import { TerminalTabDnd } from "./TerminalTabDnd";
 import type { ServiceTabInfo, StatusKind } from "./PaneView";
@@ -65,6 +65,7 @@ export function TerminalView({ projectName, projectRoot, services, terminalTheme
     focusTerminal,
     focusService,
     renameTerminal,
+    toggleTabPinned,
     reorderTerminals,
     moveTerminal,
     splitPane,
@@ -335,6 +336,7 @@ export function TerminalView({ projectName, projectRoot, services, terminalTheme
       if (matched.key === "w") {
         const pane = getFocusedPane();
         if (!pane || pane.tabs.length === 0 || pane.activeServiceName) return;
+        if (isTabPinned(pane, pane.activeTabIdx)) return;
         closeTerminal(pane.id, pane.activeTabIdx);
         return;
       }
@@ -402,6 +404,7 @@ export function TerminalView({ projectName, projectRoot, services, terminalTheme
             onAddTerminal={addTerminalToPane}
             onCloseTerminal={closeTerminal}
             onRenameTerminal={renameTerminal}
+            onTogglePinTab={toggleTabPinned}
             onSplit={splitPane}
             onClosePane={closePane}
             onClearPane={handleClearPane}

--- a/desktop/frontend/src/components/TerminalView.tsx
+++ b/desktop/frontend/src/components/TerminalView.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, useRef, useCallback, useImperativeHandle } from "react";
+import { toast } from "sonner";
 import { EventsOn } from "../../wailsjs/runtime/runtime";
 import { GetServiceLogs, StartLogStreaming, StopLogStreaming, ClearStatus } from "../../wailsjs/go/main/App";
 import type { ITheme } from "@xterm/xterm";
@@ -336,7 +337,12 @@ export function TerminalView({ projectName, projectRoot, services, terminalTheme
       if (matched.key === "w") {
         const pane = getFocusedPane();
         if (!pane || pane.tabs.length === 0 || pane.activeServiceName) return;
-        if (isTabPinned(pane, pane.activeTabIdx)) return;
+        if (isTabPinned(pane, pane.activeTabIdx)) {
+          toast.error("Can't close a pinned tab. Right-click the tab to unpin first.", {
+            id: "pinned-tab-close-blocked",
+          });
+          return;
+        }
         closeTerminal(pane.id, pane.activeTabIdx);
         return;
       }

--- a/desktop/frontend/src/components/terminal/HeaderTab.tsx
+++ b/desktop/frontend/src/components/terminal/HeaderTab.tsx
@@ -1,13 +1,28 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, type MouseEvent } from "react";
+import { Pin } from "lucide-react";
 import { XIcon } from "../icons";
 import { Tooltip } from "../ui/Tooltip";
 
-export function HeaderTab({ label, active, onClick, onClose, onRename, shimmer, done, waiting, error }: {
+export function HeaderTab({
+  label,
+  active,
+  onClick,
+  onClose,
+  onRename,
+  onContextMenu,
+  pinned,
+  shimmer,
+  done,
+  waiting,
+  error,
+}: {
   label: string;
   active: boolean;
   onClick: () => void;
   onClose?: () => void;
   onRename?: (name: string) => void;
+  onContextMenu?: (e: MouseEvent<HTMLButtonElement>) => void;
+  pinned?: boolean;
   shimmer?: boolean;
   done?: boolean;
   waiting?: boolean;
@@ -56,22 +71,51 @@ export function HeaderTab({ label, active, onClick, onClose, onRename, shimmer, 
     <button
       onClick={onClick}
       onDoubleClick={onRename ? () => setEditing(true) : undefined}
+      onContextMenu={onContextMenu}
       className={`flex items-center gap-1 rounded-md px-2.5 py-1 font-mono text-[11px] font-medium transition-colors ${
         active
           ? "bg-[var(--terminal-header-active)] text-[var(--terminal-tab-active)]"
           : "text-[var(--terminal-header-text)] hover:text-[var(--terminal-tab-active)]"
       }`}
     >
-      <span className={error ? "text-red-400" : waiting ? "sidebar-waiting" : shimmer ? "sidebar-shimmer" : ""} style={done && !shimmer && !waiting && !error ? { color: "var(--accent-blue)" } : undefined}>{label}</span>
-      {onClose && (
-        <Tooltip content="Close (Cmd+W)" side="bottom">
-          <span
-            onClick={(e) => { e.stopPropagation(); onClose(); }}
-            className="ml-0.5 rounded p-0.5 opacity-60 hover:bg-[var(--terminal-header-hover)] hover:opacity-100"
-          >
-            <XIcon />
+      <span
+        className={
+          error
+            ? "text-red-400"
+            : waiting
+            ? "sidebar-waiting"
+            : shimmer
+            ? "sidebar-shimmer"
+            : ""
+        }
+        style={
+          done && !shimmer && !waiting && !error
+            ? { color: "var(--accent-blue)" }
+            : undefined
+        }
+      >
+        {label}
+      </span>
+      {pinned ? (
+        <Tooltip content="Pinned (right-click to unpin)" side="bottom">
+          <span className="ml-0.5 p-0.5 opacity-80">
+            <Pin size={12} />
           </span>
         </Tooltip>
+      ) : (
+        onClose && (
+          <Tooltip content="Close (Cmd+W)" side="bottom">
+            <span
+              onClick={(e) => {
+                e.stopPropagation();
+                onClose();
+              }}
+              className="ml-0.5 rounded p-0.5 opacity-60 hover:bg-[var(--terminal-header-hover)] hover:opacity-100"
+            >
+              <XIcon />
+            </span>
+          </Tooltip>
+        )
       )}
     </button>
   );

--- a/desktop/frontend/src/components/terminal/TabContextMenu.tsx
+++ b/desktop/frontend/src/components/terminal/TabContextMenu.tsx
@@ -1,0 +1,26 @@
+import { Pin, PinOff } from "lucide-react";
+import { ContextMenuItem } from "../ui/ContextMenuItem";
+import { ContextMenuShell } from "../ui/ContextMenuShell";
+
+interface TabContextMenuProps {
+  x: number;
+  y: number;
+  pinned: boolean;
+  onTogglePin: () => void;
+  onClose: () => void;
+}
+
+export function TabContextMenu({ x, y, pinned, onTogglePin, onClose }: TabContextMenuProps) {
+  return (
+    <ContextMenuShell x={x} y={y} onClose={onClose}>
+      <ContextMenuItem
+        label={pinned ? "Unpin" : "Pin"}
+        icon={pinned ? <PinOff size={12} /> : <Pin size={12} />}
+        onClick={() => {
+          onTogglePin();
+          onClose();
+        }}
+      />
+    </ContextMenuShell>
+  );
+}

--- a/desktop/frontend/src/hooks/useTerminals.ts
+++ b/desktop/frontend/src/hooks/useTerminals.ts
@@ -32,6 +32,7 @@ import {
   splitAtPane,
   panePath,
   paneAtPath,
+  isTabPinned,
 } from "../paneTree";
 
 export interface TerminalStartOpts {
@@ -66,6 +67,7 @@ export interface UseTerminalsResult {
   focusTerminal: (paneId: string, tabIdx: number) => void;
   focusService: (paneId: string, serviceName: string) => void;
   renameTerminal: (paneId: string, tabIdx: number, label: string) => void;
+  toggleTabPinned: (paneId: string, tabIdx: number) => void;
   reorderTerminals: (paneId: string, order: string[]) => void;
   moveTerminal: (fromPaneId: string, termId: string, toPaneId: string, toIdx?: number) => void;
   splitPane: (paneId: string, direction: SplitDirection) => Promise<void>;
@@ -394,6 +396,7 @@ export function useTerminals(
       if (!current) return;
       const pane = findPane(current, paneId);
       if (!pane || !pane.tabs[tabIdx]) return;
+      if (isTabPinned(pane, tabIdx)) return;
       const closingTab = pane.tabs[tabIdx];
       StopTerminal(closingTab.id).catch(() => {});
       recordClosingTabs([closingTab]);
@@ -461,6 +464,23 @@ export function useTerminals(
       const next = mapPane(current, paneId, (p) => ({
         ...p,
         tabs: p.tabs.map((t, i) => (i === tabIdx ? { ...t, label } : t)),
+      }));
+      applyTree(next);
+    },
+    [applyTree],
+  );
+
+  const toggleTabPinned = useCallback(
+    (paneId: string, tabIdx: number) => {
+      const current = treeRef.current;
+      if (!current) return;
+      const pane = findPane(current, paneId);
+      if (!pane || !pane.tabs[tabIdx]) return;
+      const next = mapPane(current, paneId, (p) => ({
+        ...p,
+        tabs: p.tabs.map((t, i) =>
+          i === tabIdx ? { ...t, pinned: !t.pinned } : t,
+        ),
       }));
       applyTree(next);
     },
@@ -650,6 +670,7 @@ export function useTerminals(
     focusTerminal,
     focusService,
     renameTerminal,
+    toggleTabPinned,
     reorderTerminals,
     moveTerminal,
     splitPane,

--- a/desktop/frontend/src/hooks/useTerminals.ts
+++ b/desktop/frontend/src/hooks/useTerminals.ts
@@ -705,6 +705,7 @@ async function reifyTreeWithFreshPtys(
           startCmd: persistedTabs[i].startCmd,
           resumeCmd: persistedTabs[i].resumeCmd,
           actionName: persistedTabs[i].actionName,
+          pinned: persistedTabs[i].pinned,
         }),
       );
       const pane = makePaneLeaf(nextPaneId(), tabs, clampIdx(node.activeTabIdx, tabs.length));
@@ -745,6 +746,7 @@ function treeToPersisted(node: PaneNode): PersistedPaneNode {
         ...(t.startCmd ? { startCmd: t.startCmd } : {}),
         ...(t.resumeCmd ? { resumeCmd: t.resumeCmd } : {}),
         ...(t.actionName ? { actionName: t.actionName } : {}),
+        ...(t.pinned ? { pinned: true } : {}),
       })),
     };
   }

--- a/desktop/frontend/src/paneTree.ts
+++ b/desktop/frontend/src/paneTree.ts
@@ -191,3 +191,12 @@ export function splitAtPane(
     b: newPane,
   });
 }
+
+/**
+ * Single source of truth for "is this tab pinned?". All close paths
+ * (× icon, Cmd+W hotkey, closeTerminal guard) consult this helper so
+ * they cannot drift apart.
+ */
+export function isTabPinned(pane: PaneLeaf, idx: number): boolean {
+  return pane.tabs[idx]?.pinned === true;
+}

--- a/desktop/frontend/src/paneTree.ts
+++ b/desktop/frontend/src/paneTree.ts
@@ -11,6 +11,7 @@ export interface TerminalInstance {
   startCmd?: string;
   resumeCmd?: string;
   actionName?: string;
+  pinned?: boolean;
 }
 
 export interface PaneLeaf {
@@ -42,9 +43,16 @@ export function makePaneLeaf(id: string, tabs: TerminalInstance[], activeTabIdx 
 export function makeTerminal(
   id: string,
   label: string,
-  opts?: { startCmd?: string; resumeCmd?: string; actionName?: string },
+  opts?: { startCmd?: string; resumeCmd?: string; actionName?: string; pinned?: boolean },
 ): TerminalInstance {
-  return { id, label, ...(opts?.startCmd ? { startCmd: opts.startCmd } : {}), ...(opts?.resumeCmd ? { resumeCmd: opts.resumeCmd } : {}), ...(opts?.actionName ? { actionName: opts.actionName } : {}) };
+  return {
+    id,
+    label,
+    ...(opts?.startCmd ? { startCmd: opts.startCmd } : {}),
+    ...(opts?.resumeCmd ? { resumeCmd: opts.resumeCmd } : {}),
+    ...(opts?.actionName ? { actionName: opts.actionName } : {}),
+    ...(opts?.pinned ? { pinned: true } : {}),
+  };
 }
 
 export function walkPanes(node: PaneNode, fn: (pane: PaneLeaf) => void): void {

--- a/desktop/frontend/src/terminals.ts
+++ b/desktop/frontend/src/terminals.ts
@@ -6,6 +6,7 @@ export interface PersistedTab {
   startCmd?: string;
   resumeCmd?: string;
   actionName?: string;
+  pinned?: boolean;
 }
 
 // Mirrors the Go binding (main.PaneNode) so it round-trips through the

--- a/desktop/terminals.go
+++ b/desktop/terminals.go
@@ -16,6 +16,7 @@ type PersistedTab struct {
 	StartCmd   string `json:"startCmd,omitempty"`
 	ResumeCmd  string `json:"resumeCmd,omitempty"`
 	ActionName string `json:"actionName,omitempty"`
+	Pinned     bool   `json:"pinned,omitempty"`
 }
 
 // PaneNode is one node of a persisted pane layout tree. Leaves have


### PR DESCRIPTION
## Summary

Adds a right-click context menu on terminal tabs with a single Pin/Unpin action.

- Pinned tabs cannot be closed via the × icon or Cmd/Ctrl+W; the × is replaced by a permanent pin icon in the same slot (no tab-width shift).
- Right-click toggles between Pin and Unpin via a single-item menu using the existing `ContextMenuShell`/`ContextMenuItem` primitives.
- Pin state persists across app restarts via the existing `terminals.json` save path — `PersistedTab.Pinned bool` added with `json:"pinned,omitempty"` (forward-compatible with older files).
- A defensive guard in `closeTerminal` keeps pinned tabs alive even if the underlying shell process exits.

A single `isTabPinned` helper in `paneTree.ts` is the source of truth consulted by all three close paths (× icon, Cmd+W, `closeTerminal`).

## Files changed

- `desktop/terminals.go` — `Pinned bool` on `PersistedTab`.
- `desktop/frontend/src/paneTree.ts` — `pinned?: boolean` on `TerminalInstance`; new `isTabPinned` helper.
- `desktop/frontend/src/terminals.ts` — `pinned?: boolean` on `PersistedTab` (TS mirror).
- `desktop/frontend/src/hooks/useTerminals.ts` — `toggleTabPinned` action, `closeTerminal` guard, persist/restore round-trip.
- `desktop/frontend/src/components/terminal/HeaderTab.tsx` — pin icon swap, `onContextMenu` prop.
- `desktop/frontend/src/components/terminal/TabContextMenu.tsx` (new) — one-item Pin/Unpin menu.
- `desktop/frontend/src/components/PaneView.tsx` — owns menu position state, wires `onContextMenu`.
- `desktop/frontend/src/components/TerminalView.tsx` — Cmd+W short-circuit, threads `toggleTabPinned` down.
- `desktop/frontend/package.json` / `package-lock.json` — adds `lucide-react` for the `Pin`/`PinOff` icons.

## Test plan

- [ ] Right-click any tab → menu shows "Pin". Click → × replaced by pin icon, no tab-width shift.
- [ ] Cmd+W on a pinned tab is a no-op; non-pinned tabs still close.
- [ ] Right-click pinned tab → menu shows "Unpin". Click → × returns on hover; Cmd+W closes again.
- [ ] Pin a tab → quit and relaunch the app → tab is still pinned. `~/.lpm/terminals.json` contains `"pinned": true`.
- [ ] Type `exit` inside a pinned tab → tab stays in the strip (does not auto-remove).
- [ ] Rename + drag-reorder still work on both pinned and non-pinned tabs.
- [ ] Closing the only non-pinned tab in a pane with a pinned tab leaves the pane alive with just the pinned tab.