### PR TITLE
feat(terminal): add Chrome-style console context menu

### DIFF
--- a/desktop/frontend/bridge/commands.d.ts
+++ b/desktop/frontend/bridge/commands.d.ts
@@ -127,6 +127,7 @@ export function SaveRepoConfig(...args: any[]): Promise<any>;
 export function SaveSettings(...args: any[]): Promise<any>;
 export function SaveTemplate(...args: any[]): Promise<any>;
 export function SaveTerminals(...args: any[]): Promise<any>;
+export function SaveTextFile(...args: any[]): Promise<any>;
 export function SaveWindowSize(...args: any[]): Promise<any>;
 export function SearchBranches(...args: any[]): Promise<any>;
 export function SetProjectLabel(...args: any[]): Promise<any>;

--- a/desktop/frontend/bridge/commands.js
+++ b/desktop/frontend/bridge/commands.js
@@ -388,6 +388,9 @@ export function SaveTemplate(name, content) {
 export function SaveTerminals(c) {
   return invoke("save_terminals", { c });
 }
+export function SaveTextFile(defaultName, content) {
+  return invoke("save_text_file", { defaultName, content });
+}
 export function SaveWindowSize(width, height) {
   return invoke("save_window_size", { width, height });
 }

--- a/desktop/frontend/src-tauri/src/files.rs
+++ b/desktop/frontend/src-tauri/src/files.rs
@@ -3,7 +3,7 @@
 use crate::config::expand_home;
 use std::path::PathBuf;
 use std::process::Command;
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 use tauri_plugin_dialog::{DialogExt, FilePath};
 
 const READ_FILE_MAX_BYTES: usize = 5 * 1024 * 1024;
@@ -47,6 +47,35 @@ pub async fn browse_folder(app: AppHandle) -> Result<String, String> {
         Some(p) => Ok(p.to_string_lossy().into_owned()),
         None => Ok(String::new()), // cancel -> "" (matches Go)
     }
+}
+
+#[tauri::command]
+pub async fn save_text_file(
+    app: AppHandle,
+    default_name: String,
+    content: String,
+) -> Result<bool, String> {
+    // Bounded by the terminal's scrollback, but a wide buffer can still be a
+    // few MB — cap generously so a real save is never rejected.
+    if content.len() > 64 * 1024 * 1024 {
+        return Err(format!("content too large ({} bytes)", content.len()));
+    }
+    let Some(path) = pick_path(app, move |app| {
+        let mut builder = app
+            .dialog()
+            .file()
+            .set_file_name(&default_name);
+        if let Ok(dir) = app.path().download_dir() {
+            builder = builder.set_directory(dir);
+        }
+        builder.blocking_save_file()
+    })
+    .await?
+    else {
+        return Ok(false);
+    };
+    std::fs::write(&path, content).map_err(|e| e.to_string())?;
+    Ok(true)
 }
 
 #[tauri::command]

--- a/desktop/frontend/src-tauri/src/generated_commands.rs
+++ b/desktop/frontend/src-tauri/src/generated_commands.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 
 
 
-/// All 165 commands for tauri::generate_handler!.
+/// All 167 commands for tauri::generate_handler!.
 #[macro_export]
 macro_rules! all_command_handlers {
     () => {
@@ -150,6 +150,7 @@ macro_rules! all_command_handlers {
         save_settings,
         save_template,
         save_terminals,
+        save_text_file,
         save_window_size,
         search_branches,
         set_project_label,

--- a/desktop/frontend/src/components/InteractivePane.tsx
+++ b/desktop/frontend/src/components/InteractivePane.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useImperativeHandle, type Ref } from "react";
+import { useRef, useEffect, useImperativeHandle, useState, type Ref } from "react";
 import { Terminal, type IDisposable, type ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { SearchAddon } from "@xterm/addon-search";
@@ -19,7 +19,8 @@ import {
 } from "../../bridge/commands";
 import { sendTerminalInput, shellQuote } from "../terminal-io";
 import { getTerminalTheme, openTerminalLink, TERMINAL_FONT_FAMILY } from "./terminal-utils";
-import { handleCopyShortcut } from "./terminal/copySelection";
+import { handleCopyShortcut, handleSelectAllShortcut, handleClearShortcut } from "./terminal/copySelection";
+import { ConsoleContextMenu } from "./terminal/ConsoleContextMenu";
 import { applyFilterQuery, FilterMirror } from "./terminal/FilterMirror";
 import { registerPathLinkProvider } from "./terminal/pathLinkProvider";
 import { registerFileDropHandler } from "../fileDrop";
@@ -283,6 +284,8 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
   // triggering paste/copy/other OS-level shortcuts.
   term.attachCustomKeyEventHandler((e) => {
     if (handleCopyShortcut(e, term, serialize)) return false;
+    if (handleSelectAllShortcut(e, term)) return false;
+    if (handleClearShortcut(e, term)) return false;
     if (!e.metaKey) return true;
     return false;
   });
@@ -466,6 +469,7 @@ export function InteractivePane({
   const scrollCallbackRef = useRef(onScrollStateChange);
   const themeOverrideRef = useRef(themeOverride);
   const onExitRef = useRef(onExit);
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   fontSizeRef.current = fontSize;
   scrollCallbackRef.current = onScrollStateChange;
   themeOverrideRef.current = themeOverride;
@@ -560,6 +564,7 @@ export function InteractivePane({
         session.host.parentNode.removeChild(session.host);
       }
       sessionRef.current = null;
+      setMenu(null);
     };
   }, [terminalId]);
 
@@ -612,8 +617,32 @@ export function InteractivePane({
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <div
         ref={containerRef}
+        onContextMenu={(e) => {
+          if (!sessionRef.current) return;
+          e.preventDefault();
+          setMenu({ x: e.clientX, y: e.clientY });
+        }}
         className="relative min-h-0 min-w-0 flex-1 overflow-hidden"
       />
+      {menu && sessionRef.current && (
+        <ConsoleContextMenu
+          x={menu.x}
+          y={menu.y}
+          term={sessionRef.current.term}
+          serialize={sessionRef.current.serialize}
+          canPaste
+          onClear={() => sessionRef.current?.term.clear()}
+          onPaste={() => {
+            navigator.clipboard
+              .readText()
+              .then((text) => {
+                if (text) sessionRef.current?.term.paste(text);
+              })
+              .catch(() => {});
+          }}
+          onClose={() => setMenu(null)}
+        />
+      )}
     </div>
   );
 }

--- a/desktop/frontend/src/components/Pane.tsx
+++ b/desktop/frontend/src/components/Pane.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useImperativeHandle, type Ref, type ReactNode } from "react";
+import { useRef, useEffect, useImperativeHandle, useState, type Ref, type ReactNode } from "react";
 import { Terminal, type IDisposable, type ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { SearchAddon } from "@xterm/addon-search";
@@ -6,10 +6,11 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { getTerminalTheme, openTerminalLink } from "./terminal-utils";
-import { copyTerminalSelection, handleCopyShortcut } from "./terminal/copySelection";
+import { copyTerminalSelection, handleCopyShortcut, handleSelectAllShortcut, handleClearShortcut } from "./terminal/copySelection";
 import { applyFilterQuery, FilterMirror } from "./terminal/FilterMirror";
 import { registerPathLinkProvider } from "./terminal/pathLinkProvider";
 import { ChevronRightIcon } from "./icons";
+import { ConsoleContextMenu } from "./terminal/ConsoleContextMenu";
 import "@xterm/xterm/css/xterm.css";
 
 const labelBarClass = "flex items-center justify-between gap-1 border-b border-[var(--terminal-header-hover)] bg-[var(--terminal-header)] px-3 py-0.5 font-mono text-[10px] font-medium text-[var(--terminal-header-text)]";
@@ -58,8 +59,6 @@ function createPaneSession(opts: { fontSize: number; theme: ITheme; cwd: string 
   try { term.loadAddon(new WebLinksAddon(openTerminalLink)); } catch {}
   try { const u = new Unicode11Addon(); term.loadAddon(u); term.unicode.activeVersion = "11"; } catch {}
 
-  term.attachCustomKeyEventHandler((e) => !handleCopyShortcut(e, term, serialize));
-
   term.open(host);
 
   const session: PaneSession = {
@@ -87,7 +86,19 @@ function createPaneSession(opts: { fontSize: number; theme: ITheme; cwd: string 
     session.onScrollState?.(atBottom);
   });
 
+  term.attachCustomKeyEventHandler((e) => {
+    if (handleCopyShortcut(e, term, serialize)) return false;
+    if (handleSelectAllShortcut(e, term)) return false;
+    if (handleClearShortcut(e, term, { force: true, onClear: () => clearPaneSession(session) })) return false;
+    return true;
+  });
+
   return session;
+}
+
+function clearPaneSession(session: PaneSession): void {
+  session.term.reset();
+  session.prevLines = [];
 }
 
 export function disposePaneSession(key: string): void {
@@ -133,13 +144,13 @@ export function Pane({ label, onLabelClick, labelActions, output, visible = true
     fontSizeRef.current = fontSize;
     scrollCallbackRef.current = onScrollStateChange;
     themeOverrideRef.current = themeOverride;
+    const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
 
     useImperativeHandle(ref, () => ({
       clear() {
         const session = sessionRef.current;
         if (!session) return;
-        session.term.reset();
-        session.prevLines = [];
+        clearPaneSession(session);
       },
       findNext(query: string) {
         return sessionRef.current?.search?.findNext(query) ?? false;
@@ -211,7 +222,8 @@ export function Pane({ label, onLabelClick, labelActions, output, visible = true
 
       try { session.fit.fit(); } catch {}
 
-      const handleMouseUp = () => {
+      const handleMouseUp = (e: MouseEvent) => {
+        if (e.button !== 0) return;
         copyTerminalSelection(session.term, session.serialize);
       };
       session.host.addEventListener("mouseup", handleMouseUp);
@@ -256,6 +268,7 @@ export function Pane({ label, onLabelClick, labelActions, output, visible = true
         }
 
         sessionRef.current = null;
+        setMenu(null);
       };
     }, [sessionKey]);
 
@@ -357,7 +370,29 @@ export function Pane({ label, onLabelClick, labelActions, output, visible = true
             )}
           </div>
         )}
-        <div ref={containerRef} className="relative min-h-0 min-w-0 flex-1" />
+        <div
+          ref={containerRef}
+          onContextMenu={(e) => {
+            if (!sessionRef.current) return;
+            e.preventDefault();
+            setMenu({ x: e.clientX, y: e.clientY });
+          }}
+          className="relative min-h-0 min-w-0 flex-1"
+        />
+        {menu && sessionRef.current && (
+          <ConsoleContextMenu
+            x={menu.x}
+            y={menu.y}
+            term={sessionRef.current.term}
+            serialize={sessionRef.current.serialize}
+            canPaste={false}
+            onClear={() => {
+              const s = sessionRef.current;
+              if (s) clearPaneSession(s);
+            }}
+            onClose={() => setMenu(null)}
+          />
+        )}
       </div>
     );
 }

--- a/desktop/frontend/src/components/terminal/ConsoleContextMenu.tsx
+++ b/desktop/frontend/src/components/terminal/ConsoleContextMenu.tsx
@@ -1,0 +1,67 @@
+import type { Terminal } from "@xterm/xterm";
+import type { SerializeAddon } from "@xterm/addon-serialize";
+import { ContextMenuItem } from "../ui/ContextMenuItem";
+import { ContextMenuShell } from "../ui/ContextMenuShell";
+import { copyTerminalSelection } from "./copySelection";
+import { copyConsole, saveConsole } from "./consoleActions";
+
+interface ConsoleContextMenuProps {
+  x: number;
+  y: number;
+  term: Terminal;
+  serialize: SerializeAddon | null;
+  canPaste: boolean;
+  onClear: () => void;
+  onPaste?: () => void;
+  onClose: () => void;
+}
+
+export function ConsoleContextMenu({
+  x,
+  y,
+  term,
+  serialize,
+  canPaste,
+  onClear,
+  onPaste,
+  onClose,
+}: ConsoleContextMenuProps) {
+  const hasSelection = term.hasSelection();
+  const run = (fn: () => void) => () => {
+    fn();
+    onClose();
+  };
+  return (
+    <ContextMenuShell x={x} y={y} onClose={onClose}>
+      <ContextMenuItem
+        label="Copy"
+        shortcut="⌘C"
+        disabled={!hasSelection}
+        onClick={run(() => copyTerminalSelection(term, serialize))}
+      />
+      {canPaste && onPaste && (
+        <ContextMenuItem label="Paste" shortcut="⌘V" onClick={run(onPaste)} />
+      )}
+      <ContextMenuItem
+        label="Select All"
+        shortcut="⌘A"
+        onClick={run(() => term.selectAll())}
+      />
+      <div className="my-1 h-px bg-[var(--border)]" />
+      <ContextMenuItem
+        label="Clear console"
+        shortcut="⌃L"
+        onClick={run(onClear)}
+      />
+      <div className="my-1 h-px bg-[var(--border)]" />
+      <ContextMenuItem
+        label="Copy console"
+        onClick={run(() => void copyConsole(term))}
+      />
+      <ContextMenuItem
+        label="Save as..."
+        onClick={run(() => void saveConsole(term))}
+      />
+    </ContextMenuShell>
+  );
+}

--- a/desktop/frontend/src/components/terminal/consoleActions.ts
+++ b/desktop/frontend/src/components/terminal/consoleActions.ts
@@ -1,0 +1,35 @@
+import type { Terminal } from "@xterm/xterm";
+import { toast } from "sonner";
+import { SaveTextFile } from "../../../bridge/commands";
+
+export function bufferToPlainText(term: Terminal): string {
+  const buf = term.buffer.active;
+  const lines: string[] = [];
+  for (let i = 0; i < buf.length; i++) {
+    lines.push(buf.getLine(i)?.translateToString(true) ?? "");
+  }
+  while (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+  return lines.join("\n");
+}
+
+export async function copyConsole(term: Terminal): Promise<void> {
+  const text = bufferToPlainText(term);
+  if (!text) return;
+  try {
+    await navigator.clipboard.writeText(text);
+    toast.success("Console copied");
+  } catch {
+    toast.error("Failed to copy console");
+  }
+}
+
+export async function saveConsole(term: Terminal): Promise<void> {
+  const text = bufferToPlainText(term);
+  const name = `console-${Date.now()}.log`;
+  try {
+    const saved = await SaveTextFile(name, text);
+    if (saved) toast.success("Console saved");
+  } catch {
+    toast.error("Failed to save console");
+  }
+}

--- a/desktop/frontend/src/components/terminal/copySelection.ts
+++ b/desktop/frontend/src/components/terminal/copySelection.ts
@@ -254,3 +254,43 @@ export function handleCopyShortcut(
   copyTerminalSelection(term, serialize);
   return true;
 }
+
+export function handleSelectAllShortcut(e: KeyboardEvent, term: Terminal): boolean {
+  if (
+    !(
+      e.type === "keydown" &&
+      e.metaKey &&
+      !e.ctrlKey &&
+      !e.altKey &&
+      e.key.toLowerCase() === "a"
+    )
+  ) {
+    return false;
+  }
+  e.preventDefault();
+  term.selectAll();
+  return true;
+}
+
+export function handleClearShortcut(
+  e: KeyboardEvent,
+  term: Terminal,
+  opts?: { force?: boolean; onClear?: () => void },
+): boolean {
+  if (
+    !(
+      e.type === "keydown" &&
+      e.ctrlKey &&
+      !e.metaKey &&
+      !e.altKey &&
+      e.key.toLowerCase() === "l"
+    )
+  ) {
+    return false;
+  }
+  if (!opts?.force && term.buffer.active.type === "alternate") return false;
+  e.preventDefault();
+  if (opts?.onClear) opts.onClear();
+  else term.clear();
+  return true;
+}

--- a/desktop/frontend/src/components/ui/ContextMenuItem.tsx
+++ b/desktop/frontend/src/components/ui/ContextMenuItem.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 interface ContextMenuItemProps {
   label: ReactNode;
   icon?: ReactNode;
+  shortcut?: string;
   onClick: () => void;
   disabled?: boolean;
   destructive?: boolean;
@@ -12,6 +13,7 @@ interface ContextMenuItemProps {
 export function ContextMenuItem({
   label,
   icon,
+  shortcut,
   onClick,
   disabled,
   destructive,
@@ -30,6 +32,9 @@ export function ContextMenuItem({
     >
       {icon && <span className="flex shrink-0 items-center">{icon}</span>}
       <span className="flex-1 truncate">{label}</span>
+      {shortcut && (
+        <span className="shrink-0 text-[10px] opacity-50">{shortcut}</span>
+      )}
     </button>
   );
 }


### PR DESCRIPTION
## Summary

Replaces the native macOS right-click menu on both terminal surfaces with a custom, app-themed context menu modeled on Chrome DevTools' console menu.

- **Interactive terminals:** Copy · Paste · Select All · Clear console · Copy console · Save as…
- **Service-log panes** (read-only): same, without Paste.

## Details

- **Ctrl+L** clears at a shell prompt, but passes through to full-screen TUIs (vim/less/htop) via an alternate-buffer guard so their redraw still works.
- **Cmd+A** selects all (Ctrl+A is deliberately left to readline's beginning-of-line).
- **Save as…** writes the full scrollback as plain text (`console-<timestamp>.log`, defaults to Downloads) via a new `save_text_file` Tauri command (64 MB guard).
- **Copy console** copies the whole scrollback to the clipboard.
- Service-log clear reuses the pane's existing reset (`term.reset()` + diff-state), matching the toolbar Clear button.

## Verification

- `npx tsc --noEmit` and `npm run build` pass.
- Static + code review only — needs a manual click-test:
  - Right-click both pane types → custom menu (no native menu); each item works.
  - Ctrl+L clears at a prompt; inside vim/less it redraws instead of clearing.
  - Menu "Paste" inserts text (uses `navigator.clipboard.readText()`).