### PR TITLE
fix(actions): reachable header drop zone when buttons fit one line

### DIFF
--- a/desktop/frontend/src/components/project-detail/HeaderActions.tsx
+++ b/desktop/frontend/src/components/project-detail/HeaderActions.tsx
@@ -1,5 +1,5 @@
 import type { MouseEvent } from "react";
-import { ActionsGroup } from "../ActionsDnd";
+import { ActionsGroup, useActionsDragActive } from "../ActionsDnd";
 import { ActionView } from "../ActionView";
 import { PlusIcon } from "../icons";
 import { ActionsSortableItem } from "../ActionsSortableItem";
@@ -27,6 +27,7 @@ export function HeaderActions({
   onContextMenu,
   onAddAction,
 }: HeaderActionsProps) {
+  const dragActive = useActionsDragActive();
   return (
     <ActionsGroup
       group="header"
@@ -34,7 +35,9 @@ export function HeaderActions({
       className={
         wrapped
           ? "flex flex-wrap items-center justify-end gap-2"
-          : "flex shrink-0 items-center gap-2"
+          : dragActive
+            ? "flex grow items-center justify-end gap-2"
+            : "flex shrink-0 items-center gap-2"
       }
       style={NO_DRAG_STYLE}
     >

--- a/desktop/frontend/src/hooks/useActionsDropZone.ts
+++ b/desktop/frontend/src/hooks/useActionsDropZone.ts
@@ -2,7 +2,11 @@ import { useDroppable } from "@dnd-kit/core";
 import { ZONE_ID, type ActionGroup } from "../components/actionsDndLayout";
 
 // Same outline pair in both states so the over-state crossfades in.
-const HINT_BASE = "transition-all duration-150";
+// Transition only the hint's own paint properties — not layout. The header
+// zone toggles flex-grow while dragging, and `transition-all` would animate
+// that width change, sliding the buttons around on drop.
+const HINT_BASE =
+  "transition-[outline-color,outline-width,background-color] duration-150";
 const HINT_AVAILABLE =
   "outline-1 -outline-offset-1 outline-dashed outline-[var(--accent-blue)]/30 bg-[var(--accent-blue)]/[0.03]";
 const HINT_OVER =


### PR DESCRIPTION
## Problem

When dragging a menu item **out** of a dropdown button to drop it as a standalone top-level action, you need somewhere in the header row to drop it. That worked when the action buttons wrapped onto a second line (the wrapped row spans the full width, so there's empty space to drop into), but **not** when there were only a few buttons that fit on one line with the project title.

In that case the header actions group was sized to its content (`shrink-0`) and right-aligned, so the empty space between the title and the buttons belonged to the surrounding `flex-1` layout container — not to the droppable zone. There was no reachable drop target near the leftmost button, and no visual hint that you could drop there.

## Fix

**1. Grow the header drop zone during a drag.** While a drag is active, the header actions group switches from `shrink-0` to `grow` (keeping `justify-end`, so the buttons stay exactly where they were). The zone now fills the available space between the title and the buttons, so:

- the dashed "available" drop hint spans that area, signalling it's droppable;
- dragging a menu item into it shows the insertion placeholder at the leading position (`computeInsertion` already maps that area to index 0) and dropping extracts the item there;
- when no drag is in progress the zone stays `shrink-0`, so the empty header area remains a window-drag region.

This is the "expand into the available space" approach rather than forcing a second row.

**2. Stop the drop-zone hint transition from animating layout.** The zone carried `transition-all duration-150` to crossfade its dashed hint. Combined with the new grow/shrink toggle, `transition-all` also animated the zone's **width** on drop — the wide zone visibly narrowed and the buttons slid back into place. The hint now transitions only its own paint properties (`outline-color`, `outline-width`, `background-color`), so the width change is instant and, since the buttons are right-anchored in both states, they don't move at all.

## Scope

- `desktop/frontend/src/components/project-detail/HeaderActions.tsx` — grow the zone while dragging.
- `desktop/frontend/src/hooks/useActionsDropZone.ts` — scope the hint transition to paint properties.

The footer already spans the full terminal width, so it never had this gap and is unchanged.

## Testing

- `tsc --noEmit` clean, `npm test` (41 passing), `npm run build` green; verified the scoped transition class is emitted in the built CSS.
- Manual: with a project that has just a couple of header buttons, drag a menu item out and aim left of the buttons — the drop zone/placeholder now appears, and the drop no longer animates the buttons sliding around.

## Follow-up to

The drag-to-nest feature merged in #72 (and its two follow-up fixes on `main`).
