### PR TITLE
feat(ports): support inclusive port ranges in action/terminal ports

### DIFF
--- a/desktop/frontend/src-tauri/src/config.rs
+++ b/desktop/frontend/src-tauri/src/config.rs
@@ -265,13 +265,23 @@ enum ActionDef {
     Full(ActionFull),
 }
 
-/// An action's `port` is either a single port or a list of them. A scalar stays
-/// back-compatible with the long-standing `port: 3000` form.
+/// A single `port` entry: a bare port number, or a string holding either one
+/// port (`"3000"`) or an inclusive range (`"3002-3010"`).
+#[derive(Deserialize, Clone)]
+#[serde(untagged)]
+enum PortEntry {
+    Num(i64),
+    Text(String),
+}
+
+/// An action's `port` is either a single entry or a list of them. A scalar
+/// integer stays back-compatible with the long-standing `port: 3000` form;
+/// string entries allow inclusive ranges, e.g. `port: [3000, "3002-3010"]`.
 #[derive(Deserialize, Clone)]
 #[serde(untagged)]
 enum PortSpec {
-    One(i64),
-    Many(Vec<i64>),
+    One(PortEntry),
+    Many(Vec<PortEntry>),
 }
 
 impl Default for PortSpec {
@@ -280,20 +290,63 @@ impl Default for PortSpec {
     }
 }
 
+/// Upper bound on ports a single range may expand to, to keep a stray
+/// `"1-65535"` from ballooning the conflict set.
+const PORT_RANGE_MAX: usize = 1024;
+
+fn push_port(out: &mut Vec<i64>, p: i64) {
+    if p > 0 && p <= 65535 {
+        out.push(p);
+    }
+}
+
+/// Expands one string entry: an inclusive `lo-hi` range, or a single number.
+/// Reversed ranges (`hi-lo`) are normalized; out-of-range ends are clamped to
+/// 1..=65535; the expansion is capped at PORT_RANGE_MAX ports.
+fn expand_port_text(s: &str, out: &mut Vec<i64>) {
+    let s = s.trim();
+    if let Some((lo, hi)) = s.split_once('-') {
+        if let (Ok(lo), Ok(hi)) = (lo.trim().parse::<i64>(), hi.trim().parse::<i64>()) {
+            let (lo, hi) = if lo <= hi { (lo, hi) } else { (hi, lo) };
+            let lo = lo.max(1);
+            let hi = hi.min(65535);
+            if lo <= hi {
+                let last = (lo + PORT_RANGE_MAX as i64 - 1).min(hi);
+                for p in lo..=last {
+                    out.push(p);
+                }
+            }
+        }
+        return;
+    }
+    if let Ok(p) = s.parse::<i64>() {
+        push_port(out, p);
+    }
+}
+
+fn expand_port_entry(e: &PortEntry, out: &mut Vec<i64>) {
+    match e {
+        PortEntry::Num(p) => push_port(out, *p),
+        PortEntry::Text(s) => expand_port_text(s, out),
+    }
+}
+
 impl PortSpec {
     fn to_vec(&self) -> Vec<i64> {
+        let mut out = Vec::new();
         match self {
-            PortSpec::One(p) if *p > 0 => vec![*p],
-            PortSpec::One(_) => vec![],
-            PortSpec::Many(v) => v.iter().copied().filter(|p| *p > 0).collect(),
+            PortSpec::One(e) => expand_port_entry(e, &mut out),
+            PortSpec::Many(v) => {
+                for e in v {
+                    expand_port_entry(e, &mut out);
+                }
+            }
         }
+        out
     }
 
     fn is_empty(&self) -> bool {
-        match self {
-            PortSpec::One(p) => *p <= 0,
-            PortSpec::Many(v) => !v.iter().any(|p| *p > 0),
-        }
+        self.to_vec().is_empty()
     }
 }
 
@@ -1544,6 +1597,54 @@ pub fn resolve_action_full(file_name: &str, action_name: &str) -> Option<ActionR
 pub fn resolve_running_services(info: &SpawnInfo, state: &RunState) -> Vec<String> {
     let all: Vec<String> = info.services.keys().cloned().collect();
     running_service_names(&info.profiles, &all, state)
+}
+
+#[cfg(test)]
+mod port_spec_tests {
+    use super::*;
+
+    fn ports(yaml: &str) -> Vec<i64> {
+        serde_yaml::from_str::<PortSpec>(yaml).unwrap().to_vec()
+    }
+
+    #[test]
+    fn scalar_and_list_stay_backcompat() {
+        assert_eq!(ports("3000"), vec![3000]);
+        assert_eq!(ports("[3000, 3001, 3002]"), vec![3000, 3001, 3002]);
+    }
+
+    #[test]
+    fn string_range_expands_inclusive() {
+        assert_eq!(ports("\"3002-3005\""), vec![3002, 3003, 3004, 3005]);
+    }
+
+    #[test]
+    fn list_mixes_numbers_and_ranges() {
+        assert_eq!(
+            ports("[3000, '3002-3004', 4000, '5001-5003']"),
+            vec![3000, 3002, 3003, 3004, 4000, 5001, 5002, 5003],
+        );
+    }
+
+    #[test]
+    fn range_is_normalized_and_clamped() {
+        assert_eq!(ports("\"3005-3002\""), vec![3002, 3003, 3004, 3005]);
+        assert_eq!(ports("\"0-3\""), vec![1, 2, 3]);
+        assert!(ports("\"70000-70010\"").is_empty());
+    }
+
+    #[test]
+    fn oversized_range_is_capped() {
+        assert_eq!(ports("\"1-65535\"").len(), PORT_RANGE_MAX);
+    }
+
+    #[test]
+    fn invalid_or_empty_entries_are_dropped() {
+        assert!(ports("0").is_empty());
+        assert!(ports("\"\"").is_empty());
+        assert!(ports("\"abc\"").is_empty());
+        assert_eq!(ports("[3000, 'nope', 3001]"), vec![3000, 3001]);
+    }
 }
 
 #[cfg(test)]

--- a/desktop/frontend/src/schemas/global-config.schema.json
+++ b/desktop/frontend/src/schemas/global-config.schema.json
@@ -73,9 +73,18 @@
             "port": {
               "oneOf": [
                 { "type": "integer", "minimum": 0, "maximum": 65535 },
-                { "type": "array", "items": { "type": "integer", "minimum": 0, "maximum": 65535 } }
+                { "type": "string", "pattern": "^\\s*\\d{1,5}\\s*(-\\s*\\d{1,5}\\s*)?$" },
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      { "type": "integer", "minimum": 0, "maximum": 65535 },
+                      { "type": "string", "pattern": "^\\s*\\d{1,5}\\s*(-\\s*\\d{1,5}\\s*)?$" }
+                    ]
+                  }
+                }
               ],
-              "description": "Port(s) the action wants free before it runs. Accepts a single port or a list. Busy ports are handled per \"portConflict\"."
+              "description": "Port(s) the action wants free before it runs. Accepts a single port, an inclusive range string like \"3002-3010\", or a list mixing both. Busy ports are handled per \"portConflict\"."
             },
             "portConflict": {
               "type": "string",
@@ -155,9 +164,18 @@
             "port": {
               "oneOf": [
                 { "type": "integer", "minimum": 0, "maximum": 65535 },
-                { "type": "array", "items": { "type": "integer", "minimum": 0, "maximum": 65535 } }
+                { "type": "string", "pattern": "^\\s*\\d{1,5}\\s*(-\\s*\\d{1,5}\\s*)?$" },
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      { "type": "integer", "minimum": 0, "maximum": 65535 },
+                      { "type": "string", "pattern": "^\\s*\\d{1,5}\\s*(-\\s*\\d{1,5}\\s*)?$" }
+                    ]
+                  }
+                }
               ],
-              "description": "Port(s) the terminal wants free before it launches. Accepts a single port or a list. Busy ports are handled per \"portConflict\"."
+              "description": "Port(s) the terminal wants free before it launches. Accepts a single port, an inclusive range string like \"3002-3010\", or a list mixing both. Busy ports are handled per \"portConflict\"."
             },
             "portConflict": {
               "type": "string",

--- a/desktop/frontend/src/schemas/project-config.schema.json
+++ b/desktop/frontend/src/schemas/project-config.schema.json
@@ -182,9 +182,18 @@
             "port": {
               "oneOf": [
                 { "type": "integer", "minimum": 0, "maximum": 65535 },
-                { "type": "array", "items": { "type": "integer", "minimum": 0, "maximum": 65535 } }
+                { "type": "string", "pattern": "^\\s*\\d{1,5}\\s*(-\\s*\\d{1,5}\\s*)?$" },
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      { "type": "integer", "minimum": 0, "maximum": 65535 },
+                      { "type": "string", "pattern": "^\\s*\\d{1,5}\\s*(-\\s*\\d{1,5}\\s*)?$" }
+                    ]
+                  }
+                }
               ],
-              "description": "Port(s) the action wants free before it runs. Accepts a single port or a list. Busy ports are handled per \"portConflict\"."
+              "description": "Port(s) the action wants free before it runs. Accepts a single port, an inclusive range string like \"3002-3010\", or a list mixing both. Busy ports are handled per \"portConflict\"."
             },
             "portConflict": {
               "type": "string",
@@ -270,9 +279,18 @@
             "port": {
               "oneOf": [
                 { "type": "integer", "minimum": 0, "maximum": 65535 },
-                { "type": "array", "items": { "type": "integer", "minimum": 0, "maximum": 65535 } }
+                { "type": "string", "pattern": "^\\s*\\d{1,5}\\s*(-\\s*\\d{1,5}\\s*)?$" },
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      { "type": "integer", "minimum": 0, "maximum": 65535 },
+                      { "type": "string", "pattern": "^\\s*\\d{1,5}\\s*(-\\s*\\d{1,5}\\s*)?$" }
+                    ]
+                  }
+                }
               ],
-              "description": "Port(s) the terminal wants free before it launches. Accepts a single port or a list. Busy ports are handled per \"portConflict\"."
+              "description": "Port(s) the terminal wants free before it launches. Accepts a single port, an inclusive range string like \"3002-3010\", or a list mixing both. Busy ports are handled per \"portConflict\"."
             },
             "portConflict": {
               "type": "string",

--- a/desktop/frontend/src/schemas/repo-config.schema.json
+++ b/desktop/frontend/src/schemas/repo-config.schema.json
@@ -133,9 +133,18 @@
             "port": {
               "oneOf": [
                 { "type": "integer", "minimum": 0, "maximum": 65535 },
-                { "type": "array", "items": { "type": "integer", "minimum": 0, "maximum": 65535 } }
+                { "type": "string", "pattern": "^\\s*\\d{1,5}\\s*(-\\s*\\d{1,5}\\s*)?$" },
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      { "type": "integer", "minimum": 0, "maximum": 65535 },
+                      { "type": "string", "pattern": "^\\s*\\d{1,5}\\s*(-\\s*\\d{1,5}\\s*)?$" }
+                    ]
+                  }
+                }
               ],
-              "description": "Port(s) the action wants free before it runs. Accepts a single port or a list. Busy ports are handled per \"portConflict\"."
+              "description": "Port(s) the action wants free before it runs. Accepts a single port, an inclusive range string like \"3002-3010\", or a list mixing both. Busy ports are handled per \"portConflict\"."
             },
             "portConflict": {
               "type": "string",
@@ -221,9 +230,18 @@
             "port": {
               "oneOf": [
                 { "type": "integer", "minimum": 0, "maximum": 65535 },
-                { "type": "array", "items": { "type": "integer", "minimum": 0, "maximum": 65535 } }
+                { "type": "string", "pattern": "^\\s*\\d{1,5}\\s*(-\\s*\\d{1,5}\\s*)?$" },
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      { "type": "integer", "minimum": 0, "maximum": 65535 },
+                      { "type": "string", "pattern": "^\\s*\\d{1,5}\\s*(-\\s*\\d{1,5}\\s*)?$" }
+                    ]
+                  }
+                }
               ],
-              "description": "Port(s) the terminal wants free before it launches. Accepts a single port or a list. Busy ports are handled per \"portConflict\"."
+              "description": "Port(s) the terminal wants free before it launches. Accepts a single port, an inclusive range string like \"3002-3010\", or a list mixing both. Busy ports are handled per \"portConflict\"."
             },
             "portConflict": {
               "type": "string",

--- a/lpm-config/SKILL.md
+++ b/lpm-config/SKILL.md
@@ -252,7 +252,28 @@ Ask: "Should the button run a default command with alternatives behind a chevron
 
 **"Make sure port X is free before this runs"**
 
-→ Set `port:` on the action (or terminal). lpm probes the port before launching; if something else holds it, the user gets a confirmation dialog listing the holder process. Range 0–65535. Different from `services.<key>.port`, which announces what port the service listens on (and feeds the service-side dedup check).
+→ Set `port:` on the action (or terminal). lpm probes each port before launching and handles busy ones per `portConflict`. Range 0–65535. Different from `services.<key>.port`, which announces what port the service listens on (and feeds the service-side dedup check).
+
+`port` accepts four shapes:
+
+```yaml
+actions:
+  dev:     { cmd: npm run dev,        port: 3000 }                       # single port
+  preview: { cmd: npm run preview,    port: [3000, 3001, 4000] }         # explicit list
+  cluster: { cmd: ./run-cluster.sh,   port: "5001-5020" }               # inclusive range (quote it!)
+  stack:   { cmd: docker compose up,  port: [3000, "3002-3010", 8080] } # mix of ports and ranges
+```
+
+- **Ranges** are written as a quoted string `"<lo>-<hi>"`, dash-separated and **inclusive** on both ends (`"3002-3010"` → 3002…3010). They **must be quoted** — unquoted `3002-3010` (or `[3000, 3002-3010]`) is parsed by YAML as a string element, not a number, and is invalid.
+- Lists may freely mix single ports and ranges. Reversed ranges are normalized; ends clamp to 1–65535; a single range is capped at 1024 ports; unparseable entries are dropped.
+
+**`portConflict`** decides what happens when any declared port is busy:
+
+- **`ask`** (default) — prompt before freeing it (the picker lets the user choose which to free).
+- **`free`** — kill the holder and run.
+- **`fail`** — refuse to run while the port is busy.
+
+> Service `port:` is single-int only — it's the listen port, not a free-before-run check, so it does not take lists or ranges.
 
 **"Share these actions/terminals with the team"**
 
@@ -328,7 +349,8 @@ actions:                 # optional — one-shot commands
     cmd: <string>        # required (unless nested actions)
     label: <string>      # optional — display name in UI
     cwd: <path>          # optional (remote path on SSH projects)
-    port: <int>          # optional (0-65535) — pre-flight port-conflict probe
+    port: <int|str|list> # optional — port(s) freed before run: 3000, [3000,3001], "3002-3010", or a mix
+    portConflict: <str>  # optional — ask (default) | free | fail
     env: {}              # optional
     confirm: <bool>      # optional (default: false)
     display: <string>    # optional (header | footer, default: header). "menu" still accepted (legacy).
@@ -345,7 +367,8 @@ terminals:               # optional — interactive shells (sugar for actions wi
     cmd: <string>        # required (unless nested actions)
     label: <string>      # optional
     cwd: <path>          # optional (remote path on SSH projects)
-    port: <int>          # optional (0-65535) — pre-flight port-conflict probe
+    port: <int|str|list> # optional — port(s) freed before launch: 3000, [3000,3001], "3002-3010", or a mix
+    portConflict: <str>  # optional — ask (default) | free | fail
     env: {}              # optional
     display: <string>    # optional (header | footer, default: header). "menu" still accepted (legacy).
     confirm: <bool>      # optional
@@ -383,7 +406,7 @@ profiles: {}            # optional
 - Keys: short, lowercase, hyphen-separated (`db-migrate`, `run-tests`).
 - `~` expands to home. Relative `cwd` resolves from `root` (local projects) or from `ssh.dir` on the remote host (SSH projects). Local `cwd` paths must exist; remote `cwd` paths are not validated locally.
 - `position` is a float; lower renders first; default is alphabetical. Use floats so you can insert between existing entries (e.g. `1`, `2`, `2.5`, `3`) without renumbering.
-- `port` on an action/terminal triggers a pre-flight conflict probe — the user is shown the holding process before the action runs.
+- `port` on an action/terminal triggers a pre-flight conflict probe handled per `portConflict` (`ask`/`free`/`fail`). It accepts a single int, a list, or an **inclusive range string** like `"3002-3010"` (dash-separated, **must be quoted**); lists may mix them: `port: [3000, "3002-3010", 8080]`. (Service `port` is single-int only.)
 - `extends: [a, b]` layers templates underneath the current file; `a` wins over `b`; current file wins over all.
 - Sparse override pattern: a project YAML can hold `myAction: {position: 3}` to override only that field; the rest inherits from global / `.lpm.yml` / templates. Bool fields (`confirm`, `reuse`) cannot sparse-override `true` → `false`.
 
@@ -401,7 +424,7 @@ profiles: {}            # optional
 - Nested sub-actions are validated recursively.
 - `parent_name` references an existing project.
 - `extends` entries must resolve to readable YAML files. Cycles are rejected at load time.
-- `port` on actions/terminals is in range 0–65535 (or omitted).
+- `port` on actions/terminals is in range 0–65535 (or omitted). Range entries use the quoted `"lo-hi"` form (inclusive) — never an unquoted dash range; `port: 3002-3010` or `port: [3000, 3002-3010]` is invalid, quote it as `"3002-3010"`. `portConflict` is only `ask`, `free`, or `fail`.
 - `position` is a number (integer or float).
 - `.lpm.yml` and templates must not contain identity fields (`name`, `root`, `parent_name`, `ssh`). Identity stays in personal project files.
 
@@ -675,6 +698,13 @@ actions:
     cmd: npm run preview -- --port 4173
     label: Preview
     port: 4173        # warn if 4173 is already taken before running
+    display: header
+
+  cluster:
+    cmd: ./run-cluster.sh
+    label: Cluster
+    port: [3000, "3002-3010", 8080]   # single ports + an inclusive range (quote ranges!)
+    portConflict: free                # auto-free any busy port instead of asking
     display: header
 ```
 

--- a/lpm-config/references/yaml-schema.md
+++ b/lpm-config/references/yaml-schema.md
@@ -246,7 +246,8 @@ Sub-actions inherit `cwd` and `env` from the parent; child values win on conflic
 | `type` | string | no | — | Action type. `terminal` runs in a terminal pane; `background` runs hidden and shows a toast on completion. Omit for the default inline runner (modal with streaming output). |
 | `reuse` | bool | no | false | When `type: terminal`, reuse the same terminal pane across runs instead of opening a new one. |
 | `mode` | string | no | — | SSH-only execution mode. `remote` (default on SSH projects) runs the command on the host. `sync` rsyncs `ssh.dir` into a local mirror, runs the action locally, then rsyncs changes back. `sync` is rejected on local projects. See [SSH Action Modes](#ssh-action-modes). |
-| `port` | int | no | — | Port the action wants free. lpm probes it before launching; if held, the user gets a confirmation dialog listing the holder. 0–65535. Different from `services.<key>.port` (which is "this is the port I will listen on"). |
+| `port` | int \| string \| list | no | — | Port(s) that must be free before the action runs. Single port, inclusive range string (`"3002-3010"`), or a list mixing both. Busy ports are handled per `portConflict`. See [Ports & Conflicts](#ports--conflicts). Different from `services.<key>.port` (which is "this is the port I will listen on"). |
+| `portConflict` | string | no | `ask` | What to do when a declared port is busy: `ask` (prompt before freeing), `free` (free automatically), `fail` (refuse to run). |
 | `position` | number | no | — | Sort key in the UI. Lower renders first. Floats allowed for easy insertion between existing entries. Default is alphabetical order. |
 | `inputs` | map[string]InputField | no | — | Named inputs prompted before running. Values substitute `{{key}}` in `cmd`. |
 | `actions` | map[string]Action | no | — | Nested sub-actions. Makes this an action group. See [Action Groups](#action-groups-nested-actions). Children inherit `cwd`, `env`, and `mode` from the parent. |
@@ -257,6 +258,43 @@ Sub-actions inherit `cwd` and `env` from the parent; child values win on conflic
 - **`footer`** — action appears as a compact button in the terminal footer (right next to the branch switcher). Use for tight, always-one-click controls. Footer also accepts split-button groups (parent `cmd` + nested `actions`).
 - **`menu`** *(legacy)* — action appears in the overflow menu. Still accepted but no longer suggested by autocomplete; may be deprecated in a future version.
 - **`button`** *(deprecated alias for `header`)* — flagged as an error in the editor; runtime still treats it like `header`.
+
+### Ports & Conflicts
+
+`port` declares the TCP port(s) an action (or terminal) needs free before it runs. Before launching, lpm checks each port; busy ones are handled per `portConflict`. It accepts four shapes:
+
+```yaml
+actions:
+  dev:
+    cmd: npm run dev
+    port: 3000                      # single port
+
+  preview:
+    cmd: npm run preview
+    port: [3000, 3001, 4000]        # explicit list
+
+  cluster:
+    cmd: ./run-cluster.sh
+    port: "5001-5020"               # inclusive range (quote it!)
+
+  stack:
+    cmd: docker compose up
+    port: [3000, "3002-3010", 8080] # list mixing single ports and ranges
+```
+
+**Ranges:**
+- Write a range as `"<lo>-<hi>"` — a string with a dash. It is **inclusive** on both ends: `"3002-3010"` expands to 3002, 3003, … 3010.
+- Quote it. In YAML an unquoted `3002-3010` (or `[3000, 3002-3010]`) is parsed as a string element, not a number, so always wrap range entries in quotes.
+- You can mix explicit ports and ranges freely inside one list.
+- A reversed range (`"3010-3002"`) is normalized; ends are clamped to 1–65535; a single range is capped at 1024 ports to keep a stray `"1-65535"` from exploding the set. Unparseable entries (e.g. `"abc"`) are silently dropped.
+
+**`portConflict`** controls what happens when any declared port is already in use:
+
+- **`ask`** (default) — prompt before freeing the port (the port-conflict picker lets you choose which to free).
+- **`free`** — kill whatever holds the port and run.
+- **`fail`** — refuse to run while the port is busy.
+
+> Service `port:` is different — a service declares the **single** port it listens on (used for forwarding and uniqueness checks), so it takes one integer only, not lists or ranges.
 
 ### Input Fields
 
@@ -321,7 +359,8 @@ terminals:
 | `display` | string | no | `header` | UI placement: `header` (main button row, default) or `footer` (terminal footer strip). `menu` is still accepted (legacy) but no longer suggested. `button` is a deprecated alias for `header`. |
 | `confirm` | bool | no | false | Prompt before opening. |
 | `reuse` | bool | no | false | Reuse the existing pane on next launch. |
-| `port` | int | no | — | Port the terminal wants free. lpm probes it before launching; if held, the user gets a confirmation dialog listing the holder. 0–65535. |
+| `port` | int \| string \| list | no | — | Port(s) that must be free before the terminal launches. Single port, inclusive range string (`"3002-3010"`), or a list mixing both. Busy ports are handled per `portConflict`. See [Ports & Conflicts](#ports--conflicts). |
+| `portConflict` | string | no | `ask` | What to do when a declared port is busy: `ask`, `free`, or `fail`. |
 | `position` | number | no | — | Sort key in the UI. Lower renders first. Floats allowed for easy insertion between existing entries. Default is alphabetical order. |
 | `inputs` | map[string]InputField | no | — | Named inputs prompted before opening. Values substitute `{{key}}` in `cmd`. |
 | `actions` | map[string]Action | no | — | Nested sub-actions. Makes this a split-button or dropdown — see Action Groups. |
@@ -671,7 +710,7 @@ lpm validates config on load:
 9. Nested sub-actions are validated recursively (cmd required if no children, cwd must exist on local projects, mode validated the same way).
 10. `parent_name` must reference an existing, loadable project.
 11. `extends` entries must resolve to readable YAML files. Cycles are rejected at load time.
-12. `port` on actions/terminals is in range 0–65535 (or omitted).
+12. `port` on actions/terminals is in range 0–65535 (or omitted). Range entries use the quoted `"lo-hi"` form (inclusive) — never an unquoted dash range (`port: 3002-3010` / `[3000, 3002-3010]` is invalid; quote as `"3002-3010"`). `portConflict` is only `ask`, `free`, or `fail`.
 13. `position` is a number (integer or float).
 14. `.lpm.yml` and templates must NOT contain `name`, `root`, `parent_name`, or `ssh` — identity stays in personal project files.
 


### PR DESCRIPTION
## Summary
- Action and terminal `port` now accepts **inclusive range strings** like `"3002-3010"` in addition to a single port or a list.
- Lists may mix single ports and ranges: `port: [3000, "3002-3010", 8080]`.
- Old syntax (`port: 3000`, `port: [3000, 3001]`) is unchanged.

## Details
- **Rust** (`config.rs`): new `PortEntry` (number or string) inside `PortSpec`; `expand_port_text` expands `"lo-hi"` inclusively. Reversed ranges are normalized, ends clamped to `1–65535`, a single range capped at 1024 ports, unparseable entries dropped. Frontend is untouched — it already receives the expanded `number[]`.
- **JSON schemas** (project/repo/global): `port` now allows the string form via `pattern`, both standalone and as a list item, so schema-aware editors stop flagging valid ranges.
- Service `port` stays single-int only (it's the listen port, not a free-before-run check).

## Tests
- Added `port_spec_tests` (6 cases): back-compat, range expansion, mixed lists, normalization/clamping, oversized-range cap, garbage handling. Full Rust suite (54) passes.