### PR TITLE
feat(terminal): responsive tab strip with truncation and scroll fades

### DIFF
--- a/desktop/frontend/src/components/PaneView.tsx
+++ b/desktop/frontend/src/components/PaneView.tsx
@@ -19,6 +19,7 @@ import { TerminalSearchBar } from "./terminal/TerminalSearchBar";
 import { XIcon, GlobeIcon, TerminalIcon, ZapIcon } from "./icons";
 import { Tooltip } from "./ui/Tooltip";
 import { SortableTab, TabStrip } from "./TerminalTabDnd";
+import { useScrollFade } from "../hooks/useScrollFade";
 import { ALL_SERVICES, type PaneLeaf, type SplitDirection } from "../paneTree";
 import { useBrowserUrls } from "../store/browserUrls";
 
@@ -195,6 +196,12 @@ function PaneViewImpl(props: PaneViewProps) {
 
   const tabIds = useMemo(() => pane.tabs.map((t) => t.id), [pane.tabs]);
 
+  const { ref: scrollRef, canScrollLeft, canScrollRight } = useScrollFade<HTMLDivElement>([
+    pane.tabs,
+    services,
+    activeServiceName,
+  ]);
+
   const containerClass = fullscreen
     ? "fixed inset-0 z-50 flex flex-col overflow-hidden bg-[var(--terminal-bg)]"
     : "flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden border-t border-x border-[var(--border)]";
@@ -211,7 +218,11 @@ function PaneViewImpl(props: PaneViewProps) {
       onMouseDownCapture={() => onFocusPane(pane.id)}
     >
       <div className={headerClass}>
-        <div className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto">
+        <div className="relative flex min-w-0 flex-1 items-center">
+          <div
+            ref={scrollRef}
+            className="flex w-full min-w-0 items-center gap-0.5 overflow-x-auto"
+          >
           {hasMultipleServices && (
             <HeaderTab
               label="All"
@@ -233,7 +244,7 @@ function PaneViewImpl(props: PaneViewProps) {
             );
           })}
           {services.length > 0 && pane.tabs.length > 0 && (
-            <div className="mx-1 h-3.5 w-px bg-[var(--terminal-header-hover)]" />
+            <div className="mx-1 h-3.5 w-px shrink-0 bg-[var(--terminal-header-hover)]" />
           )}
           <TabStrip paneId={pane.id} tabIds={tabIds}>
             {pane.tabs.map((t, i) => {
@@ -283,6 +294,13 @@ function PaneViewImpl(props: PaneViewProps) {
             onAddTerminal={() => onAddTerminal(pane.id)}
             onAddBrowser={() => onAddBrowser(pane.id)}
           />
+          </div>
+          {canScrollLeft && (
+            <div className="pointer-events-none absolute inset-y-0 left-0 z-10 w-6 bg-gradient-to-r from-[var(--terminal-header)] to-transparent" />
+          )}
+          {canScrollRight && (
+            <div className="pointer-events-none absolute inset-y-0 right-0 z-10 w-6 bg-gradient-to-l from-[var(--terminal-header)] to-transparent" />
+          )}
         </div>
         <div className="flex shrink-0 items-center gap-0.5">
           <Tooltip

--- a/desktop/frontend/src/components/terminal/HeaderTab.tsx
+++ b/desktop/frontend/src/components/terminal/HeaderTab.tsx
@@ -2,6 +2,7 @@ import { type MouseEvent, type ReactNode } from "react";
 import { Pin } from "lucide-react";
 import { XIcon } from "../icons";
 import { Tooltip } from "../ui/Tooltip";
+import { useIsTruncated } from "../../hooks/useIsTruncated";
 
 export function HeaderTab({
   label,
@@ -30,11 +31,29 @@ export function HeaderTab({
 }) {
   const closable = !!onClose && !pinned;
   const hasHoverIcon = closable || !!pinned;
+  const { ref: labelRef, truncated } = useIsTruncated(label);
+
+  const statusClassName = error
+    ? "text-red-400"
+    : waiting
+    ? "sidebar-waiting"
+    : shimmer
+    ? "sidebar-shimmer"
+    : "";
+  const statusStyle =
+    done && !shimmer && !waiting && !error ? { color: "var(--accent-blue)" } : undefined;
+
+  const labelNode = (
+    <span ref={labelRef} className={`min-w-0 truncate ${statusClassName}`} style={statusStyle}>
+      {label}
+    </span>
+  );
+
   return (
     <button
       onClick={onClick}
       onContextMenu={onContextMenu}
-      className={`group flex select-none items-center gap-1 rounded-md px-2.5 py-1 font-mono text-[11px] font-medium transition-colors ${
+      className={`group flex max-w-[200px] select-none items-center gap-1 overflow-hidden rounded-md px-2.5 py-1 font-mono text-[11px] font-medium transition-colors ${
         active
           ? "bg-[var(--terminal-header-active)] text-[var(--terminal-tab-active)]"
           : "text-[var(--terminal-header-text)] hover:text-[var(--terminal-tab-active)]"
@@ -68,24 +87,13 @@ export function HeaderTab({
           ) : null}
         </span>
       )}
-      <span
-        className={
-          error
-            ? "text-red-400"
-            : waiting
-            ? "sidebar-waiting"
-            : shimmer
-            ? "sidebar-shimmer"
-            : ""
-        }
-        style={
-          done && !shimmer && !waiting && !error
-            ? { color: "var(--accent-blue)" }
-            : undefined
-        }
-      >
-        {label}
-      </span>
+      {truncated ? (
+        <Tooltip content={label} side="bottom" triggerClassName="flex min-w-0">
+          {labelNode}
+        </Tooltip>
+      ) : (
+        labelNode
+      )}
     </button>
   );
 }

--- a/desktop/frontend/src/hooks/scrollFade.test.ts
+++ b/desktop/frontend/src/hooks/scrollFade.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { computeScrollFade } from "./scrollFade";
+
+describe("computeScrollFade", () => {
+  it("shows no fades when content fits", () => {
+    expect(computeScrollFade({ scrollLeft: 0, scrollWidth: 200, clientWidth: 200 })).toEqual({
+      canScrollLeft: false,
+      canScrollRight: false,
+    });
+  });
+
+  it("shows only the right fade at the start of an overflowing strip", () => {
+    expect(computeScrollFade({ scrollLeft: 0, scrollWidth: 400, clientWidth: 200 })).toEqual({
+      canScrollLeft: false,
+      canScrollRight: true,
+    });
+  });
+
+  it("shows both fades in the middle", () => {
+    expect(computeScrollFade({ scrollLeft: 100, scrollWidth: 400, clientWidth: 200 })).toEqual({
+      canScrollLeft: true,
+      canScrollRight: true,
+    });
+  });
+
+  it("shows only the left fade at the end", () => {
+    expect(computeScrollFade({ scrollLeft: 200, scrollWidth: 400, clientWidth: 200 })).toEqual({
+      canScrollLeft: true,
+      canScrollRight: false,
+    });
+  });
+
+  it("ignores sub-pixel rounding via an epsilon", () => {
+    expect(computeScrollFade({ scrollLeft: 0.5, scrollWidth: 400.4, clientWidth: 200 })).toEqual({
+      canScrollLeft: false,
+      canScrollRight: true,
+    });
+    expect(computeScrollFade({ scrollLeft: 199.6, scrollWidth: 400, clientWidth: 200 })).toEqual({
+      canScrollLeft: true,
+      canScrollRight: false,
+    });
+  });
+});

--- a/desktop/frontend/src/hooks/scrollFade.ts
+++ b/desktop/frontend/src/hooks/scrollFade.ts
@@ -1,0 +1,20 @@
+export interface ScrollMetrics {
+  scrollLeft: number;
+  scrollWidth: number;
+  clientWidth: number;
+}
+
+export interface ScrollFade {
+  canScrollLeft: boolean;
+  canScrollRight: boolean;
+}
+
+const EPSILON = 1;
+
+export function computeScrollFade({ scrollLeft, scrollWidth, clientWidth }: ScrollMetrics): ScrollFade {
+  const maxScroll = scrollWidth - clientWidth;
+  return {
+    canScrollLeft: scrollLeft > EPSILON,
+    canScrollRight: scrollLeft < maxScroll - EPSILON,
+  };
+}

--- a/desktop/frontend/src/hooks/useIsTruncated.ts
+++ b/desktop/frontend/src/hooks/useIsTruncated.ts
@@ -1,0 +1,26 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+export function useIsTruncated(text: string) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const [truncated, setTruncated] = useState(false);
+
+  const measure = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    setTruncated(el.scrollWidth > el.clientWidth);
+  }, []);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [measure]);
+
+  useLayoutEffect(() => {
+    measure();
+  }, [text, measure]);
+
+  return { ref, truncated };
+}

--- a/desktop/frontend/src/hooks/useScrollFade.ts
+++ b/desktop/frontend/src/hooks/useScrollFade.ts
@@ -1,0 +1,41 @@
+import { type DependencyList, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { computeScrollFade, type ScrollFade } from "./scrollFade";
+
+export function useScrollFade<T extends HTMLElement>(deps: DependencyList) {
+  const ref = useRef<T>(null);
+  const [fade, setFade] = useState<ScrollFade>({ canScrollLeft: false, canScrollRight: false });
+
+  const measure = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    const next = computeScrollFade({
+      scrollLeft: el.scrollLeft,
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+    });
+    setFade((prev) =>
+      prev.canScrollLeft === next.canScrollLeft && prev.canScrollRight === next.canScrollRight
+        ? prev
+        : next,
+    );
+  }, []);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.addEventListener("scroll", measure, { passive: true });
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => {
+      el.removeEventListener("scroll", measure);
+      observer.disconnect();
+    };
+  }, [measure]);
+
+  useLayoutEffect(() => {
+    measure();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  return { ref, canScrollLeft: fade.canScrollLeft, canScrollRight: fade.canScrollRight };
+}


### PR DESCRIPTION
## Summary

Long terminal tab names previously wrapped to a second line and broke the header row layout. This makes the tab strip responsive:

- Tabs shrink **uniformly** when space is tight (no special-cased active-tab width).
- Labels **truncate with an ellipsis** instead of wrapping.
- A **tooltip with the full name** appears on hover **only when the label is actually clipped**.
- Once tabs hit their natural minimum size, the strip **scrolls horizontally**, with **edge-fade gradients** signalling more tabs off-screen.

## Changes

- `hooks/scrollFade.ts` — pure `computeScrollFade` helper (unit-tested, 5 cases).
- `hooks/useScrollFade.ts` — ref hook tracking scroll position via `scroll` + `ResizeObserver`; bails out of state updates when fade values are unchanged (avoids a render loop).
- `hooks/useIsTruncated.ts` — ref hook returning whether a label overflows, driving the conditional tooltip.
- `components/terminal/HeaderTab.tsx` — truncating label + uniform sizing (`max-w-[200px]`, natural min-content floor); active tab keeps only its highlight, not a different width.
- `components/PaneView.tsx` — wraps the scroll container and adds left/right edge-fade overlays.

## Notes

- The natural per-tab floor comes from each tab's own content (icon + padding) rather than a hard-coded `min-w`, which is what prevents buttons from overflowing their wrappers and overlapping.
- Test env is node-only, so DOM-measurement hooks are verified manually; the pure fade computation is unit-tested.

## Test plan

- [x] `npx vitest run` — 46/46 pass
- [x] `npm run build` — clean
- [x] Manual: long names truncate, no overlap, tooltip only when clipped, edge fades on scroll, drag-reorder still works