### PR TITLE
fix(terminal): keep active tab in view and free tabs from scrollbar

### DIFF
--- a/desktop/frontend/src/components/PaneView.tsx
+++ b/desktop/frontend/src/components/PaneView.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import type { ITheme } from "@xterm/xterm";
 import { InteractivePane, type InteractivePaneHandle } from "./InteractivePane";
 import { BrowserPane } from "./BrowserPane";
@@ -20,6 +20,8 @@ import { XIcon, GlobeIcon, TerminalIcon, ZapIcon } from "./icons";
 import { Tooltip } from "./ui/Tooltip";
 import { SortableTab, TabStrip } from "./TerminalTabDnd";
 import { useScrollFade } from "../hooks/useScrollFade";
+import { computeScrollIntoViewLeft } from "../hooks/scrollIntoViewX";
+import { useTabScroll } from "../store/tabScroll";
 import { ALL_SERVICES, type PaneLeaf, type SplitDirection } from "../paneTree";
 import { useBrowserUrls } from "../store/browserUrls";
 
@@ -202,6 +204,37 @@ function PaneViewImpl(props: PaneViewProps) {
     activeServiceName,
   ]);
 
+  // Keep the focused tab on screen. The margin clears the w-6 fade gradient at
+  // each edge so the tab isn't left half-hidden under it.
+  const scrollTabIntoView = useCallback(
+    (tab: HTMLElement | null) => {
+      const container = scrollRef.current;
+      if (!container || !tab) return;
+      const containerRect = container.getBoundingClientRect();
+      const tabRect = tab.getBoundingClientRect();
+      const next = computeScrollIntoViewLeft({
+        scrollLeft: container.scrollLeft,
+        clientWidth: container.clientWidth,
+        elementLeft: tabRect.left - containerRect.left + container.scrollLeft,
+        elementWidth: tabRect.width,
+        margin: 28,
+      });
+      if (next !== null) container.scrollTo({ left: next, behavior: "smooth" });
+    },
+    [scrollRef],
+  );
+
+  // Covers activation that changes state (reuse landing on a different tab,
+  // keyboard switches) and explicit reuse requests for the already-active tab
+  // (scrollNonce), which change no pane state. Clicks scroll imperatively
+  // below, since re-clicking the active tab also wouldn't re-run this effect.
+  const scrollNonce = useTabScroll((s) => s.nonce[pane.id] ?? 0);
+  useEffect(() => {
+    scrollTabIntoView(
+      scrollRef.current?.querySelector<HTMLElement>("[data-active-tab]") ?? null,
+    );
+  }, [scrollTabIntoView, terminalIdx, activeServiceName, pane.tabs.length, scrollNonce]);
+
   const containerClass = fullscreen
     ? "fixed inset-0 z-50 flex flex-col overflow-hidden bg-[var(--terminal-bg)]"
     : "flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden border-t border-x border-[var(--border)]";
@@ -221,14 +254,17 @@ function PaneViewImpl(props: PaneViewProps) {
         <div className="relative flex min-w-0 flex-1 items-center">
           <div
             ref={scrollRef}
-            className="flex w-full min-w-0 items-center gap-0.5 overflow-x-auto"
+            className="no-scrollbar flex w-full min-w-0 items-center gap-0.5 overflow-x-auto"
           >
           {hasMultipleServices && (
             <HeaderTab
               label="All"
               icon={<ZapIcon />}
               active={isAllActive}
-              onClick={() => onFocusService(pane.id, ALL_SERVICES)}
+              onClick={(e) => {
+                onFocusService(pane.id, ALL_SERVICES);
+                scrollTabIntoView(e.currentTarget);
+              }}
             />
           )}
           {services.map((svc) => {
@@ -239,7 +275,10 @@ function PaneViewImpl(props: PaneViewProps) {
                 label={svc.name}
                 icon={<ZapIcon />}
                 active={isActive}
-                onClick={() => onFocusService(pane.id, svc.name)}
+                onClick={(e) => {
+                  onFocusService(pane.id, svc.name);
+                  scrollTabIntoView(e.currentTarget);
+                }}
               />
             );
           })}
@@ -275,10 +314,11 @@ function PaneViewImpl(props: PaneViewProps) {
                     done={!isActive && isDone}
                     waiting={isWaiting}
                     error={!isActive && isError}
-                    onClick={() => {
+                    onClick={(e) => {
                       if (isDone) onClearStatus(t.id, "Done");
                       if (isError) onClearStatus(t.id, "Error");
                       onFocusTab(pane.id, i);
+                      scrollTabIntoView(e.currentTarget);
                     }}
                     onClose={() => onCloseTerminal(pane.id, i)}
                     onContextMenu={(e) => {

--- a/desktop/frontend/src/components/terminal/HeaderTab.tsx
+++ b/desktop/frontend/src/components/terminal/HeaderTab.tsx
@@ -20,7 +20,7 @@ export function HeaderTab({
   label: string;
   icon?: ReactNode;
   active: boolean;
-  onClick: () => void;
+  onClick: (e: MouseEvent<HTMLButtonElement>) => void;
   onClose?: () => void;
   onContextMenu?: (e: MouseEvent<HTMLButtonElement>) => void;
   pinned?: boolean;
@@ -53,6 +53,7 @@ export function HeaderTab({
     <button
       onClick={onClick}
       onContextMenu={onContextMenu}
+      data-active-tab={active || undefined}
       className={`group flex max-w-[200px] select-none items-center gap-1 overflow-hidden rounded-md px-2.5 py-1 font-mono text-[11px] font-medium transition-colors ${
         active
           ? "bg-[var(--terminal-header-active)] text-[var(--terminal-tab-active)]"

--- a/desktop/frontend/src/hooks/scrollIntoViewX.test.ts
+++ b/desktop/frontend/src/hooks/scrollIntoViewX.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { computeScrollIntoViewLeft } from "./scrollIntoViewX";
+
+const base = { scrollLeft: 0, clientWidth: 200, elementWidth: 40, margin: 8 };
+
+describe("computeScrollIntoViewLeft", () => {
+  it("returns null when the target is already comfortably visible", () => {
+    expect(computeScrollIntoViewLeft({ ...base, elementLeft: 80 })).toBeNull();
+  });
+
+  it("scrolls left so a target before the viewport clears the margin", () => {
+    expect(
+      computeScrollIntoViewLeft({ ...base, scrollLeft: 100, elementLeft: 90 }),
+    ).toBe(82);
+  });
+
+  it("scrolls right so a target past the viewport clears the margin", () => {
+    expect(computeScrollIntoViewLeft({ ...base, elementLeft: 300 })).toBe(148);
+  });
+
+  it("treats a target hidden under the right fade as not visible", () => {
+    expect(computeScrollIntoViewLeft({ ...base, elementLeft: 165 })).toBe(13);
+  });
+
+  it("never returns a negative scroll position", () => {
+    expect(
+      computeScrollIntoViewLeft({ ...base, scrollLeft: 5, elementLeft: 0 }),
+    ).toBe(0);
+  });
+});

--- a/desktop/frontend/src/hooks/scrollIntoViewX.ts
+++ b/desktop/frontend/src/hooks/scrollIntoViewX.ts
@@ -1,0 +1,31 @@
+export interface ScrollIntoViewMetrics {
+  scrollLeft: number;
+  clientWidth: number;
+  // Position of the target relative to the scroll content's left edge.
+  elementLeft: number;
+  elementWidth: number;
+  // Keeps the target clear of the fade gradients at each edge.
+  margin: number;
+}
+
+// Returns the scrollLeft that brings the target fully into view, or null when
+// it is already visible (clear of the margins) so callers can skip scrolling.
+export function computeScrollIntoViewLeft({
+  scrollLeft,
+  clientWidth,
+  elementLeft,
+  elementWidth,
+  margin,
+}: ScrollIntoViewMetrics): number | null {
+  const elementRight = elementLeft + elementWidth;
+  const visibleLeft = scrollLeft + margin;
+  const visibleRight = scrollLeft + clientWidth - margin;
+
+  if (elementLeft < visibleLeft) {
+    return Math.max(0, elementLeft - margin);
+  }
+  if (elementRight > visibleRight) {
+    return Math.max(0, elementRight - clientWidth + margin);
+  }
+  return null;
+}

--- a/desktop/frontend/src/hooks/useTerminals.ts
+++ b/desktop/frontend/src/hooks/useTerminals.ts
@@ -35,6 +35,7 @@ import {
   paneAtPath,
   isTabPinned,
 } from "../paneTree";
+import { useTabScroll } from "../store/tabScroll";
 
 export interface TerminalStartOpts {
   configName?: string;
@@ -306,6 +307,9 @@ export function useTerminals(
                 activeServiceName: undefined,
               })), pane.id);
             }
+            // Always bring the reused tab into view: when it's already active no
+            // pane state changes, so PaneView's activation effect wouldn't fire.
+            useTabScroll.getState().requestScroll(pane.id);
             await sendTerminalInput(pane.tabs[idx].id, cmd + "\n");
             return;
           }

--- a/desktop/frontend/src/store/tabScroll.ts
+++ b/desktop/frontend/src/store/tabScroll.ts
@@ -1,0 +1,16 @@
+import { create } from "zustand";
+
+// Bridges imperative "bring the active tab into view" requests (e.g. a reuse
+// action that re-targets the already-active tab, so no pane state changes) to
+// the PaneView that owns the strip. Each request bumps a per-pane counter the
+// PaneView watches; the value itself is meaningless, only its change matters.
+interface TabScrollState {
+  nonce: Record<string, number>;
+  requestScroll: (paneId: string) => void;
+}
+
+export const useTabScroll = create<TabScrollState>((set) => ({
+  nonce: {},
+  requestScroll: (paneId) =>
+    set((s) => ({ nonce: { ...s.nonce, [paneId]: (s.nonce[paneId] ?? 0) + 1 } })),
+}));

--- a/desktop/frontend/src/styles/globals.css
+++ b/desktop/frontend/src/styles/globals.css
@@ -214,6 +214,17 @@ body {
   will-change: transform;
 }
 
+/* The terminal tab strip scrolls horizontally but uses fade gradients as the
+   affordance; the native bar would otherwise overlap the short tab row and
+   swallow clicks on the tabs underneath it. */
+.no-scrollbar {
+  scrollbar-width: none;
+}
+
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .lpm-actions-overlay {
     will-change: auto;


### PR DESCRIPTION
## Summary

Two fixes for the responsive terminal tab strip:

1. **Active tab now scrolls into view on activation.** Previously the active tab could sit scrolled out of the strip with no way to reveal it. Now activation brings it into view, covering:
   - **`reuse` actions targeting the already-active tab** — these change no pane state, so a per-pane scroll nonce (`store/tabScroll.ts`) signals `PaneView` imperatively.
   - **`reuse` / keyboard switches landing on a different tab** — handled by the state-change effect.
   - **Clicking an already-active but clipped tab** — scrolls imperatively from the click handler.
   - A 28px margin keeps the tab clear of the fade gradients.

2. **Hid the strip's native horizontal scrollbar.** On macOS ("always show scrollbars") it rendered inside the short tab row, overlapping the tabs and swallowing clicks. The existing fade gradients remain the scroll affordance.

## Changes

- `store/tabScroll.ts` — new zustand event-bus: per-pane `requestScroll` nonce
- `hooks/scrollIntoViewX.ts` (+ test) — pure helper computing the target `scrollLeft`
- `hooks/useTerminals.ts` — reuse path calls `requestScroll` unconditionally
- `components/PaneView.tsx` — imperative `scrollTabIntoView`, activation effect, nonce subscription, per-click scroll
- `components/terminal/HeaderTab.tsx` — forward the click event; mark the active tab with `data-active-tab`
- `styles/globals.css` — `.no-scrollbar` utility applied to the strip

## Test plan

- `npx vitest run src/hooks/scrollIntoViewX.test.ts` — 5/5 pass
- `npx tsc --noEmit` — clean
- Manual (`npm run tauri dev`): trigger a `reuse` action while its tab is scrolled out → tab scrolls into view; confirm all tabs are clickable with no overlapping scrollbar