### PR TITLE
Add per-copy run overrides for duplicated projects

### DIFF
--- a/desktop/frontend/src/components/BulkDuplicateDialog.tsx
+++ b/desktop/frontend/src/components/BulkDuplicateDialog.tsx
@@ -1,12 +1,23 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useState } from "react";
 import { Folder, GitBranch, Package } from "lucide-react";
 import { useEventListener } from "../hooks/useEventListener";
 import { Modal } from "./ui/Modal";
 import { ActionPicker } from "./ActionPicker";
 import { PromptComposer, type PromptImage } from "./PromptComposer";
+import { CopyRow } from "./CopyRow";
+import { ShellCommandInput } from "./ShellCommandInput";
+import { SwitchRow } from "./SwitchRow";
+import { SegmentedControl } from "./ui/SegmentedControl";
+import { CARD_CLASS, FIELD_CLASS, HELPER_TEXT, SECTION_LABEL } from "./ui/fields";
 import { getSettings, saveSettings } from "../store/settings";
 import { shellQuote } from "../terminal-io";
-import type { ProjectInfo, SpawnTask } from "../types";
+import type {
+  CopyOverride,
+  CopyRunMode,
+  ProjectInfo,
+  RunMode,
+  SpawnTask,
+} from "../types";
 
 const MIN_COUNT = 1;
 const MAX_COUNT = 50;
@@ -25,16 +36,20 @@ function randomId6(): string {
   return out;
 }
 
-const FIELD_CLASS =
-  "w-full rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)] text-[13px] text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)] focus:border-[var(--accent-cyan)]";
-
-type RunMode = "none" | "action" | "command";
+// One draft copy: its display label plus an optional per-copy run override.
+// `override === null` means the copy runs the shared default below.
+interface CopyDraft {
+  label: string;
+  override: CopyOverride | null;
+}
 
 export interface BulkDuplicateOptions {
   excludeUncommitted: boolean;
   reinstallDeps: boolean;
   labels: string[];
-  tasks: SpawnTask[];
+  // One entry per copy (index-aligned with `labels`): the tasks to run on that
+  // copy, resolved from either its override or the shared default.
+  tasksPerCopy: SpawnTask[][];
   groupName: string;
 }
 
@@ -53,13 +68,18 @@ export function BulkDuplicateDialog({
   onCancel,
   onConfirm,
 }: BulkDuplicateDialogProps) {
-  const [labels, setLabels] = useState<string[]>([""]);
-  const count = labels.length;
+  const [copies, setCopies] = useState<CopyDraft[]>([
+    { label: "", override: null },
+  ]);
+  const count = copies.length;
+  // The shared default applied to every copy that doesn't override it.
   const [mode, setMode] = useState<RunMode>("none");
   const [actionName, setActionName] = useState("");
   const [command, setCommand] = useState("");
   const [prompt, setPrompt] = useState("");
   const [promptImages, setPromptImages] = useState<PromptImage[]>([]);
+  // Which copy's override editor is expanded (`null` = none).
+  const [editing, setEditing] = useState<number | null>(null);
   const [excludeUncommitted, setExcludeUncommitted] = useState(false);
   const [reinstallDeps, setReinstallDeps] = useState(false);
   const [groupName, setGroupName] = useState("");
@@ -72,12 +92,13 @@ export function BulkDuplicateDialog({
 
   useEffect(() => {
     if (!open) return;
-    setLabels([genLabel()]);
+    setCopies([{ label: genLabel(), override: null }]);
     setMode("none");
     setActionName("");
     setCommand("");
     setPrompt("");
     setPromptImages([]);
+    setEditing(null);
     setExcludeUncommitted(getSettings().duplicateExcludeUncommitted ?? false);
     setReinstallDeps(getSettings().duplicateReinstallDeps ?? false);
     setGroupName("");
@@ -91,24 +112,64 @@ export function BulkDuplicateDialog({
 
   const clamp = (n: number) => Math.min(MAX_COUNT, Math.max(MIN_COUNT, n));
 
-  // Keep one label field per copy: grow with fresh default labels, shrink by
-  // trimming, and preserve labels the user already typed.
+  // Keep one draft per copy: grow with fresh default-named, default-running
+  // copies, shrink by trimming, and preserve copies the user already tuned.
   const changeCount = (next: number) => {
     const n = clamp(next);
-    setLabels((prev) => {
-      if (n <= prev.length) return prev.slice(0, n);
+    setCopies((prev) => {
+      if (n <= prev.length) {
+        const trimmed = prev.slice(0, n);
+        // A single copy has no per-copy override UI, so drop any override left
+        // over from a higher count — otherwise it would silently still apply.
+        return n === 1 && trimmed[0]?.override
+          ? [{ ...trimmed[0], override: null }]
+          : trimmed;
+      }
       const out = prev.slice();
-      while (out.length < n) out.push(genLabel());
+      while (out.length < n) out.push({ label: genLabel(), override: null });
       return out;
     });
+    setEditing((e) => (e !== null && e >= n ? null : e));
   };
 
   const setLabelAt = (i: number, value: string) =>
-    setLabels((prev) => {
-      const next = prev.slice();
-      next[i] = value;
-      return next;
-    });
+    setCopies((prev) =>
+      prev.map((c, idx) => (idx === i ? { ...c, label: value } : c)),
+    );
+
+  const setOverrideAt = (i: number, override: CopyOverride | null) =>
+    setCopies((prev) =>
+      prev.map((c, idx) => (idx === i ? { ...c, override } : c)),
+    );
+
+  const patchOverrideAt = (i: number, patch: Partial<CopyOverride>) =>
+    setCopies((prev) =>
+      prev.map((c, idx) =>
+        idx === i && c.override
+          ? { ...c, override: { ...c.override, ...patch } }
+          : c,
+      ),
+    );
+
+  // Switch a copy between inheriting the default and an explicit override. A
+  // fresh override seeds from the default's action/command so the user starts
+  // from a sensible base, with a clean (text-only) prompt.
+  const pickCopyMode = (i: number, next: CopyRunMode) => {
+    if (next === "default") return setOverrideAt(i, null);
+    setCopies((prev) =>
+      prev.map((c, idx) => {
+        if (idx !== i) return c;
+        const seeded: CopyOverride = c.override
+          ? { ...c.override, mode: next }
+          : { mode: next, actionName, command, prompt: "" };
+        // Switching to "action" needs a concrete action — fall back to the
+        // first runnable when neither the default nor a prior override set one.
+        if (next === "action" && !seeded.actionName)
+          seeded.actionName = runnableActions[0]?.name ?? "";
+        return { ...c, override: seeded };
+      }),
+    );
+  };
 
   const single = count === 1;
   const noun = single ? "copy" : "copies";
@@ -118,7 +179,6 @@ export function BulkDuplicateDialog({
   );
   const trimmedGroup = groupName.trim();
   const hasGroup = !single && trimmedGroup.length > 0;
-  const railColor = hasGroup ? "bg-[var(--accent-cyan)]/45" : "bg-[var(--border)]";
   const imagesPending = promptImages.some((im) => !im.path && !im.error);
 
   const pickMode = (next: RunMode) => {
@@ -134,17 +194,55 @@ export function BulkDuplicateDialog({
     }
   };
 
-  const buildTasks = (): SpawnTask[] => {
-    // The seed is typed into the terminal as one line then submitted, so flatten
-    // newlines and append the saved image paths for the agent to pick up.
-    const text = prompt.replace(/\s*\n\s*/g, " ").trim();
-    const paths = promptImages.map((im) => im.path).filter(Boolean).map(shellQuote);
-    const seed = [text, ...paths].filter(Boolean).join(" ") || undefined;
-    if (mode === "action" && actionName)
-      return [{ kind: "action", actionName, prompt: seed }];
-    if (mode === "command" && command.trim())
-      return [{ kind: "command", command: command.trim(), prompt: seed }];
+  // The seed is typed into the terminal as one line then submitted, so flatten
+  // newlines and append the saved image paths for the agent to pick up.
+  const flattenSeed = (
+    text: string,
+    images: PromptImage[],
+  ): string | undefined => {
+    const t = text.replace(/\s*\n\s*/g, " ").trim();
+    const paths = images.map((im) => im.path).filter(Boolean).map(shellQuote);
+    return [t, ...paths].filter(Boolean).join(" ") || undefined;
+  };
+
+  const taskFrom = (
+    m: RunMode,
+    act: string,
+    cmd: string,
+    seed: string | undefined,
+  ): SpawnTask[] => {
+    if (m === "action" && act)
+      return [{ kind: "action", actionName: act, prompt: seed }];
+    if (m === "command" && cmd.trim())
+      return [{ kind: "command", command: cmd.trim(), prompt: seed }];
     return [];
+  };
+
+  const buildTasksPerCopy = (): SpawnTask[][] => {
+    const defaultTask = taskFrom(
+      mode,
+      actionName,
+      command,
+      flattenSeed(prompt, promptImages),
+    );
+    return copies.map((c) =>
+      c.override
+        ? taskFrom(
+            c.override.mode,
+            c.override.actionName,
+            c.override.command,
+            flattenSeed(c.override.prompt, []),
+          )
+        : defaultTask,
+    );
+  };
+
+  const overrideSummary = (override: CopyOverride | null): string => {
+    if (!override) return "Default";
+    if (override.mode === "none") return "Nothing";
+    if (override.mode === "command") return "Command";
+    const a = runnableActions.find((x) => x.name === override.actionName);
+    return `Action: ${a?.label || a?.name || override.actionName || "—"}`;
   };
 
   const handleConfirm = () => {
@@ -156,15 +254,15 @@ export function BulkDuplicateDialog({
     onConfirm(count, {
       excludeUncommitted,
       reinstallDeps,
-      labels: labels.map((l) => l.trim()),
-      tasks: buildTasks(),
+      labels: copies.map((c) => c.label.trim()),
+      tasksPerCopy: buildTasksPerCopy(),
       groupName: single ? "" : trimmedGroup,
     });
   };
 
   // Enter confirms from the count or command field; leave it to the focused
   // control when a button (segment, picker option, toggle) has focus, and let
-  // Shift+Enter add a newline while composing the prompt.
+  // Shift+Enter add a newline while composing a prompt.
   useEventListener(
     "keydown",
     (e) => {
@@ -180,300 +278,270 @@ export function BulkDuplicateDialog({
     open,
   );
 
-  const segments: { key: RunMode; label: string; disabled?: boolean }[] = [
-    { key: "none", label: "Nothing" },
-    { key: "action", label: "Action", disabled: runnableActions.length === 0 },
-    { key: "command", label: "Command" },
+  const runOptions: { value: RunMode; label: string; disabled?: boolean }[] = [
+    { value: "none", label: "Nothing" },
+    { value: "action", label: "Action", disabled: runnableActions.length === 0 },
+    { value: "command", label: "Command" },
   ];
-
-  const renderToggle = (
-    checked: boolean,
-    onChange: (v: boolean) => void,
-    icon: ReactNode,
-    title: string,
-    description: string,
-  ): ReactNode => (
-    <button
-      type="button"
-      onClick={() => onChange(!checked)}
-      className={`flex w-full items-start gap-3 rounded-xl border px-3.5 py-3 text-left transition-colors ${
-        checked
-          ? "border-[var(--accent-cyan)]/60 bg-[var(--accent-cyan)]/5"
-          : "border-[var(--border)] hover:bg-[var(--bg-hover)]"
-      }`}
-    >
-      <span
-        className={`mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors ${
-          checked
-            ? "bg-[var(--accent-cyan)] text-[var(--bg-primary)]"
-            : "bg-[var(--bg-secondary)] text-[var(--text-muted)]"
-        }`}
-      >
-        {icon}
-      </span>
-      <span className="min-w-0">
-        <span className="block text-sm font-medium text-[var(--text-primary)]">{title}</span>
-        <span className="mt-0.5 block text-[11px] leading-snug text-[var(--text-muted)]">{description}</span>
-      </span>
-    </button>
-  );
 
   return (
     <Modal
       open={open}
       onClose={onCancel}
       zIndexClassName="z-[60]"
-      contentClassName="max-h-[85vh] w-[min(560px,92vw)] overflow-y-auto rounded-2xl border border-[var(--border)] bg-[var(--bg-primary)] p-6 shadow-2xl"
+      contentClassName="max-h-[85vh] w-[min(540px,92vw)] overflow-y-auto rounded-2xl border border-[var(--border)] bg-[var(--bg-primary)] p-6 shadow-2xl"
     >
       <div className="flex items-start gap-3">
-        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-[var(--bg-secondary)] text-[var(--accent-cyan)]">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[var(--accent-cyan)]/10 text-[var(--accent-cyan)] ring-1 ring-inset ring-[var(--accent-cyan)]/20">
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
             <rect x="8" y="8" width="12" height="12" rx="2" />
             <path d="M4 16V6a2 2 0 0 1 2-2h10" />
           </svg>
-        </span>
+        </div>
         <div className="min-w-0">
-          <h3 className="text-base font-semibold text-[var(--text-primary)]">Duplicate</h3>
-          <p className="mt-0.5 text-[13px] leading-snug text-[var(--text-secondary)]">
-            Create {single ? "a copy" : `${count} copies`} of{" "}
-            <span className="font-medium text-[var(--text-primary)]">
+          <h3 className="text-[15px] font-semibold leading-tight text-[var(--text-primary)]">
+            Duplicate
+          </h3>
+          <p className="mt-1 text-[12px] leading-snug text-[var(--text-muted)]">
+            Create independent copies of{" "}
+            <span className="font-mono text-[var(--text-secondary)]">
               {project?.label || project?.name}
-            </span>
-            {single
-              ? ", ready to work in on its own."
-              : ", each ready to work in on its own."}
+            </span>{" "}
+            to run agents or services in parallel.
           </p>
         </div>
       </div>
 
-      <div className="mt-6 flex items-center justify-between">
-        <p className="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
-          How many copies
-        </p>
-        <div className="inline-flex items-center overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)]">
-          <button
-            onClick={() => changeCount(count - 1)}
-            disabled={count <= MIN_COUNT}
-            className="flex h-9 w-9 items-center justify-center text-lg text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-30"
-            aria-label="Fewer copies"
-          >
-            −
-          </button>
-          <input
-            value={count}
-            onChange={(e) => {
-              const n = parseInt(e.target.value.replace(/\D/g, ""), 10);
-              if (!Number.isNaN(n)) changeCount(n);
-            }}
-            inputMode="numeric"
-            className="h-9 w-11 border-x border-[var(--border)] bg-transparent text-center text-sm font-semibold text-[var(--text-primary)] outline-none"
-          />
-          <button
-            onClick={() => changeCount(count + 1)}
-            disabled={count >= MAX_COUNT}
-            className="flex h-9 w-9 items-center justify-center text-lg text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-30"
-            aria-label="More copies"
-          >
-            +
-          </button>
-        </div>
-      </div>
-
-      <div className="mt-5">
-        <p className="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
-          {single ? "Label" : "Folder & labels"}
-        </p>
-
-        {!single && (
-          <>
-            <div className="relative mt-2">
-              <Folder
-                size={15}
-                className={`pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 transition-colors ${
-                  hasGroup ? "text-[var(--accent-cyan)]" : "text-[var(--text-muted)]"
-                }`}
-              />
+      <div className="mt-5 space-y-3">
+        <div className={CARD_CLASS}>
+          <div className="flex items-center justify-between gap-3 px-4 py-3">
+            <span className={SECTION_LABEL}>Copies</span>
+            <div className="inline-flex items-center overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)]">
+              <button
+                type="button"
+                onClick={() => changeCount(count - 1)}
+                disabled={count <= MIN_COUNT}
+                className="flex h-8 w-8 items-center justify-center text-lg text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-30"
+                aria-label="Fewer copies"
+              >
+                −
+              </button>
               <input
-                value={groupName}
-                onChange={(e) => setGroupName(e.target.value)}
-                spellCheck={false}
-                autoCapitalize="off"
-                autoCorrect="off"
-                placeholder="Folder name (optional)"
-                className={`${FIELD_CLASS} transition-colors py-2 pl-9 pr-3`}
+                value={count}
+                onChange={(e) => {
+                  const n = parseInt(e.target.value.replace(/\D/g, ""), 10);
+                  if (!Number.isNaN(n)) changeCount(n);
+                }}
+                inputMode="numeric"
+                className="h-8 w-11 border-x border-[var(--border)] bg-transparent text-center text-[13px] font-semibold tabular-nums text-[var(--text-primary)] outline-none"
               />
+              <button
+                type="button"
+                onClick={() => changeCount(count + 1)}
+                disabled={count >= MAX_COUNT}
+                className="flex h-8 w-8 items-center justify-center text-lg text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-30"
+                aria-label="More copies"
+              >
+                +
+              </button>
             </div>
-            {folderOptions.length > 0 && (
-              <div className="mt-2 flex flex-wrap gap-1.5">
-                {folderOptions.map((n) => {
-                  const active = trimmedGroup.toLowerCase() === n.toLowerCase();
-                  return (
-                    <button
-                      key={n}
-                      type="button"
-                      onClick={() => setGroupName(active ? "" : n)}
-                      title={n}
-                      className={`flex max-w-[160px] items-center gap-1 rounded-lg border px-2.5 py-1 text-[11px] font-medium transition-colors ${
-                        active
-                          ? "border-[var(--accent-cyan)]/60 bg-[var(--accent-cyan)]/10 text-[var(--text-primary)]"
-                          : "border-[var(--border)] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
-                      }`}
-                    >
-                      <Folder size={11} className="shrink-0 opacity-70" />
-                      <span className="min-w-0 truncate">{n}</span>
-                    </button>
-                  );
-                })}
-              </div>
-            )}
-          </>
-        )}
+          </div>
 
-        <div
-          className={`${single ? "mt-2" : "mt-2.5"} max-h-[180px] overflow-y-auto pr-0.5`}
-        >
-          <div className={`relative ${single ? "" : "pl-6"}`}>
-            <div className="space-y-1.5">
-              {labels.map((value, i) => (
-                <div key={i} className="relative">
-                  {!single && (
-                    <>
-                      <span
-                        className={`pointer-events-none absolute left-[-13px] top-1/2 h-px w-[13px] -translate-y-1/2 transition-colors ${railColor}`}
-                      />
-                      <span className="pointer-events-none absolute left-2 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-lg bg-[var(--bg-primary)] text-[11px] font-semibold tabular-nums text-[var(--text-muted)]">
-                        {i + 1}
-                      </span>
-                    </>
-                  )}
+          <div className="border-t border-[var(--border)] px-4 py-3">
+            {single ? (
+              <div>
+                <div className="flex items-center gap-3">
+                  <span className={SECTION_LABEL}>Label</span>
                   <input
-                    value={value}
-                    onChange={(e) => setLabelAt(i, e.target.value)}
-                    autoFocus={i === 0}
+                    value={copies[0]?.label ?? ""}
+                    onChange={(e) => setLabelAt(0, e.target.value)}
+                    autoFocus
                     spellCheck={false}
                     autoCapitalize="off"
                     autoCorrect="off"
                     placeholder="Auto-named"
-                    className={`${FIELD_CLASS} transition-colors py-2 pr-3 ${single ? "pl-3" : "pl-10"}`}
+                    className={`${FIELD_CLASS} h-9 flex-1 px-3`}
                   />
                 </div>
-              ))}
-            </div>
-            {!single && (
-              <span
-                className={`pointer-events-none absolute bottom-4 left-[11px] top-0 w-px transition-colors ${railColor}`}
-              />
+                <p className={`mt-2 ${HELPER_TEXT}`}>
+                  A label to recognize the copy by. Leave blank to name it
+                  automatically.
+                </p>
+              </div>
+            ) : (
+              <div>
+                <div className="relative">
+                  <Folder
+                    size={14}
+                    className={`pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 transition-colors ${
+                      hasGroup
+                        ? "text-[var(--accent-cyan)]"
+                        : "text-[var(--text-muted)]"
+                    }`}
+                  />
+                  <input
+                    value={groupName}
+                    onChange={(e) => setGroupName(e.target.value)}
+                    spellCheck={false}
+                    autoCapitalize="off"
+                    autoCorrect="off"
+                    placeholder="Folder name (optional)"
+                    className={`${FIELD_CLASS} h-9 pl-9 pr-3`}
+                  />
+                </div>
+
+                {folderOptions.length > 0 && (
+                  <div className="mt-2 flex flex-wrap gap-1.5">
+                    {folderOptions.map((n) => {
+                      const active =
+                        trimmedGroup.toLowerCase() === n.toLowerCase();
+                      return (
+                        <button
+                          key={n}
+                          type="button"
+                          onClick={() => setGroupName(active ? "" : n)}
+                          title={n}
+                          className={`max-w-[160px] truncate rounded-md bg-[var(--bg-secondary)] px-2 py-1 text-[12px] transition-colors ${
+                            active
+                              ? "font-medium text-[var(--accent-cyan)]"
+                              : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+                          }`}
+                        >
+                          {n}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+
+                <div className="mt-3 space-y-1.5">
+                  {copies.map((copy, i) => (
+                    <CopyRow
+                      key={i}
+                      index={i}
+                      label={copy.label}
+                      onLabelChange={(value) => setLabelAt(i, value)}
+                      override={copy.override}
+                      summary={overrideSummary(copy.override)}
+                      expanded={editing === i}
+                      onToggleExpand={() => setEditing(editing === i ? null : i)}
+                      actions={runnableActions}
+                      onChangeMode={(m) => pickCopyMode(i, m)}
+                      onPatchOverride={(patch) => patchOverrideAt(i, patch)}
+                      autoFocus={i === 0}
+                    />
+                  ))}
+                </div>
+
+                <p className={`mt-2 ${HELPER_TEXT}`}>
+                  {hasGroup
+                    ? `The copies are grouped under “${trimmedGroup}” in the sidebar.`
+                    : "Name a folder above to keep the copies together in the sidebar, or leave it blank."}{" "}
+                  Use the menu beside a copy to run a different action or command
+                  on it.
+                </p>
+              </div>
             )}
           </div>
         </div>
 
-        <p className="mt-2 text-[11px] leading-snug text-[var(--text-muted)]">
-          {single
-            ? "A label to recognize the copy by. Leave blank to name it automatically."
-            : hasGroup
-              ? `The copies are grouped under “${trimmedGroup}” in the sidebar. Leave a label blank to name it automatically.`
-              : "Name a folder above to keep the copies together in the sidebar, or leave it blank to add them on their own. Leave a label blank to name it automatically."}
-        </p>
-      </div>
+        <div className={`${CARD_CLASS} px-4 py-3`}>
+          <div className="flex items-center justify-between gap-3">
+            <span className={SECTION_LABEL}>
+              {single ? "Run on the copy" : "Run on each copy"}
+            </span>
+            <SegmentedControl
+              value={mode}
+              options={runOptions}
+              onChange={pickMode}
+            />
+          </div>
 
-      <div className="mt-5">
-        <p className="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
-          Run on {copyRef}
-        </p>
-        <div className="mt-2 flex gap-1 rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)] p-1">
-          {segments.map((s) => (
-            <button
-              key={s.key}
-              onClick={() => pickMode(s.key)}
-              disabled={s.disabled}
-              className={`flex-1 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
-                mode === s.key
-                  ? "bg-[var(--bg-primary)] text-[var(--text-primary)] shadow-sm"
-                  : "text-[var(--text-secondary)] hover:text-[var(--text-primary)] disabled:opacity-40 disabled:hover:text-[var(--text-secondary)]"
-              }`}
-            >
-              {s.label}
-            </button>
-          ))}
+          {mode === "action" && (
+            <div className="field-reveal">
+              <ActionPicker
+                actions={runnableActions}
+                value={actionName}
+                onChange={setActionName}
+              />
+            </div>
+          )}
+
+          {mode === "command" && (
+            <div className="mt-2 field-reveal">
+              <ShellCommandInput value={command} onChange={setCommand} autoFocus />
+            </div>
+          )}
+
+          {mode !== "none" && (
+            <>
+              <p className={`mt-1.5 ${HELPER_TEXT}`}>
+                {mode === "command"
+                  ? `Runs in a terminal on ${copyRef} as soon as it's created.`
+                  : `Starts on ${copyRef} in the background as soon as it's created.`}
+              </p>
+
+              <div className="mt-3 field-reveal">
+                <span className={SECTION_LABEL}>Prompt</span>
+                <PromptComposer
+                  value={prompt}
+                  onChange={setPrompt}
+                  images={promptImages}
+                  onImagesChange={setPromptImages}
+                  placeholder="Type a task for an AI agent, and paste or attach images…"
+                />
+                <p className={`mt-1.5 ${HELPER_TEXT}`}>
+                  Sent to {copyRef}'s terminal once it's ready — e.g. a task for
+                  the agent, with any attached images. Leave blank to send
+                  nothing.
+                </p>
+              </div>
+            </>
+          )}
         </div>
 
-        {mode === "action" && (
-          <ActionPicker
-            actions={runnableActions}
-            value={actionName}
-            onChange={setActionName}
+        <div
+          className={`${CARD_CLASS} divide-y divide-[var(--border)] overflow-hidden`}
+        >
+          <SwitchRow
+            checked={excludeUncommitted}
+            onChange={setExcludeUncommitted}
+            icon={<GitBranch size={18} />}
+            title="Committed work only"
+            description={`Reset ${copyRef} to the last commit, dropping uncommitted changes.`}
           />
-        )}
-
-        {mode === "command" && (
-          <input
-            value={command}
-            onChange={(e) => setCommand(e.target.value)}
-            autoFocus
-            spellCheck={false}
-            autoCapitalize="off"
-            autoCorrect="off"
-            placeholder="Enter a command…"
-            className={`mt-2 ${FIELD_CLASS} px-3 py-2.5 font-mono`}
+          <SwitchRow
+            checked={reinstallDeps}
+            onChange={setReinstallDeps}
+            icon={<Package size={18} />}
+            title="Reinstall dependencies"
+            description={`Copy without dependencies, then install them fresh in ${copyRef}.`}
           />
-        )}
-
-        {mode !== "none" && (
-          <p className="mt-1.5 text-[11px] text-[var(--text-muted)]">
-            {mode === "command"
-              ? `Runs in a terminal on ${copyRef} as soon as it's created.`
-              : `Starts on ${copyRef} in the background as soon as it's created.`}
-          </p>
-        )}
-
-        {mode !== "none" && (
-          <div className="mt-3">
-            <p className="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
-              Prompt
-            </p>
-            <PromptComposer
-              value={prompt}
-              onChange={setPrompt}
-              images={promptImages}
-              onImagesChange={setPromptImages}
-              placeholder="Type a task for an AI agent, and paste or attach images…"
-            />
-            <p className="mt-1.5 text-[11px] text-[var(--text-muted)]">
-              Sent to {copyRef}'s terminal once it's ready — e.g. a task for the
-              agent, with any attached images. Leave blank to send nothing.
-            </p>
-          </div>
-        )}
+        </div>
       </div>
 
-      <div className="mt-5 space-y-2">
-        {renderToggle(
-          excludeUncommitted,
-          setExcludeUncommitted,
-          <GitBranch size={16} />,
-          "Committed work only",
-          `Reset ${copyRef} to the last commit, dropping uncommitted changes.`,
-        )}
-        {renderToggle(
-          reinstallDeps,
-          setReinstallDeps,
-          <Package size={16} />,
-          "Reinstall dependencies",
-          `Copy without dependencies, then install them fresh in ${copyRef}.`,
-        )}
-      </div>
-
-      <div className="mt-6 flex justify-end gap-2">
+      <div className="mt-6 flex justify-end gap-2 border-t border-[var(--border)] pt-4">
         <button
+          type="button"
           onClick={onCancel}
-          className="rounded-lg border border-[var(--border)] px-4 py-2 text-sm font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)]"
+          className="rounded-lg px-4 py-2 text-[13px] font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)]"
         >
           Cancel
         </button>
         <button
+          type="button"
           onClick={handleConfirm}
           disabled={!project || imagesPending}
-          className="rounded-lg bg-[var(--text-primary)] px-4 py-2 text-sm font-medium text-[var(--bg-primary)] transition-all hover:opacity-90 disabled:opacity-40"
+          className="rounded-lg bg-[var(--text-primary)] px-4 py-2 text-[13px] font-medium text-[var(--bg-primary)] shadow-sm transition-opacity hover:opacity-90 disabled:opacity-40"
         >
           {imagesPending ? "Attaching images…" : `Create ${count} ${noun}`}
         </button>

--- a/desktop/frontend/src/components/CopyRow.tsx
+++ b/desktop/frontend/src/components/CopyRow.tsx
@@ -1,0 +1,77 @@
+import { ChevronDown } from "lucide-react";
+import { CopyRunConfig } from "./CopyRunConfig";
+import { FIELD_CLASS } from "./ui/fields";
+import type { ActionInfo, CopyOverride, CopyRunMode } from "../types";
+
+interface CopyRowProps {
+  index: number;
+  label: string;
+  onLabelChange: (value: string) => void;
+  override: CopyOverride | null;
+  summary: string;
+  expanded: boolean;
+  onToggleExpand: () => void;
+  actions: ActionInfo[];
+  onChangeMode: (mode: CopyRunMode) => void;
+  onPatchOverride: (patch: Partial<CopyOverride>) => void;
+  autoFocus?: boolean;
+}
+
+export function CopyRow({
+  index,
+  label,
+  onLabelChange,
+  override,
+  summary,
+  expanded,
+  onToggleExpand,
+  actions,
+  onChangeMode,
+  onPatchOverride,
+  autoFocus,
+}: CopyRowProps) {
+  return (
+    <div className="grid grid-cols-[1rem_1fr_6.5rem] items-center gap-2.5">
+      <span className="text-right text-[12px] tabular-nums text-[var(--text-muted)]">
+        {index + 1}
+      </span>
+      <input
+        value={label}
+        onChange={(e) => onLabelChange(e.target.value)}
+        autoFocus={autoFocus}
+        spellCheck={false}
+        autoCapitalize="off"
+        autoCorrect="off"
+        placeholder="Auto-named"
+        className={`${FIELD_CLASS} h-9 px-3`}
+      />
+      <button
+        type="button"
+        onClick={onToggleExpand}
+        title={`Run on this copy — ${summary}`}
+        className={`flex w-full items-center justify-end gap-1 text-[12px] font-medium transition-colors ${
+          override
+            ? "text-[var(--accent-cyan)]"
+            : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+        }`}
+      >
+        <span className="truncate">{summary}</span>
+        <ChevronDown
+          size={13}
+          className={`shrink-0 transition-transform ${expanded ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {expanded && (
+        <div className="col-span-3 ml-[1.625rem] mb-1 mt-2">
+          <CopyRunConfig
+            actions={actions}
+            override={override}
+            onChangeMode={onChangeMode}
+            onPatchOverride={onPatchOverride}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/frontend/src/components/CopyRunConfig.tsx
+++ b/desktop/frontend/src/components/CopyRunConfig.tsx
@@ -1,0 +1,75 @@
+import { ActionPicker } from "./ActionPicker";
+import { ShellCommandInput } from "./ShellCommandInput";
+import { SegmentedControl } from "./ui/SegmentedControl";
+import { FIELD_CLASS, HELPER_TEXT } from "./ui/fields";
+import type { ActionInfo, CopyOverride, CopyRunMode } from "../types";
+
+const OPTIONS: { value: CopyRunMode; label: string }[] = [
+  { value: "default", label: "Default" },
+  { value: "none", label: "Nothing" },
+  { value: "action", label: "Action" },
+  { value: "command", label: "Command" },
+];
+
+interface CopyRunConfigProps {
+  actions: ActionInfo[];
+  override: CopyOverride | null;
+  onChangeMode: (mode: CopyRunMode) => void;
+  onPatchOverride: (patch: Partial<CopyOverride>) => void;
+}
+
+export function CopyRunConfig({
+  actions,
+  override,
+  onChangeMode,
+  onPatchOverride,
+}: CopyRunConfigProps) {
+  const active: CopyRunMode = override ? override.mode : "default";
+  const noActions = actions.length === 0;
+  const options = OPTIONS.map((o) =>
+    o.value === "action" ? { ...o, disabled: noActions } : o,
+  );
+
+  return (
+    <div className="border-l border-[var(--border)] pl-3">
+      <SegmentedControl
+        value={active}
+        options={options}
+        onChange={onChangeMode}
+        fullWidth
+      />
+
+      {override?.mode === "action" && (
+        <ActionPicker
+          actions={actions}
+          value={override.actionName}
+          onChange={(name) => onPatchOverride({ actionName: name })}
+        />
+      )}
+
+      {override?.mode === "command" && (
+        <div className="mt-2">
+          <ShellCommandInput
+            value={override.command}
+            onChange={(value) => onPatchOverride({ command: value })}
+            autoFocus
+          />
+        </div>
+      )}
+
+      {!override ? (
+        <p className={`mt-2 ${HELPER_TEXT}`}>Inherits the shared default above.</p>
+      ) : override.mode === "none" ? (
+        <p className={`mt-2 ${HELPER_TEXT}`}>Nothing runs on this copy.</p>
+      ) : (
+        <textarea
+          value={override.prompt}
+          onChange={(e) => onPatchOverride({ prompt: e.target.value })}
+          spellCheck={false}
+          placeholder="Prompt for an AI agent (optional)…"
+          className={`mt-2 ${FIELD_CLASS} block max-h-[160px] min-h-[52px] resize-none px-3 py-2 leading-snug`}
+        />
+      )}
+    </div>
+  );
+}

--- a/desktop/frontend/src/components/ShellCommandInput.tsx
+++ b/desktop/frontend/src/components/ShellCommandInput.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from "react";
+import { FIELD_CLASS } from "./ui/fields";
+
+const MAX_HEIGHT = 160;
+
+interface ShellCommandInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  autoFocus?: boolean;
+  placeholder?: string;
+}
+
+// A command field that reads like a shell line: a leading "$" prompt glyph with
+// the text starting just past it. Grows with its content like the prompt field,
+// so multi-line commands stay readable (Shift+Enter adds a line, Enter submits).
+export function ShellCommandInput({
+  value,
+  onChange,
+  autoFocus,
+  placeholder = "Enter a command…",
+}: ShellCommandInputProps) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, MAX_HEIGHT)}px`;
+  }, [value]);
+
+  return (
+    <div className="relative">
+      <span className="pointer-events-none absolute left-3 top-2 font-mono text-[13px] leading-snug text-[var(--text-muted)]">
+        $
+      </span>
+      <textarea
+        ref={ref}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        autoFocus={autoFocus}
+        spellCheck={false}
+        autoCapitalize="off"
+        autoCorrect="off"
+        rows={1}
+        placeholder={placeholder}
+        className={`${FIELD_CLASS} block max-h-[160px] min-h-[36px] resize-none py-2 pl-7 pr-3 font-mono leading-snug`}
+      />
+    </div>
+  );
+}

--- a/desktop/frontend/src/components/SwitchRow.tsx
+++ b/desktop/frontend/src/components/SwitchRow.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+import { Switch } from "./ui/Switch";
+
+interface SwitchRowProps {
+  checked: boolean;
+  onChange: (value: boolean) => void;
+  icon: ReactNode;
+  title: string;
+  description: string;
+}
+
+export function SwitchRow({
+  checked,
+  onChange,
+  icon,
+  title,
+  description,
+}: SwitchRowProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+      className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-[var(--bg-hover)]"
+    >
+      <span
+        className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors ${
+          checked
+            ? "bg-[var(--accent-cyan)]/15 text-[var(--accent-cyan)]"
+            : "bg-[var(--bg-active)] text-[var(--text-muted)]"
+        }`}
+      >
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-[13px] font-medium text-[var(--text-primary)]">
+          {title}
+        </span>
+        <span className="block text-[12px] leading-snug text-[var(--text-muted)]">
+          {description}
+        </span>
+      </span>
+      <Switch checked={checked} />
+    </button>
+  );
+}

--- a/desktop/frontend/src/components/ui/SegmentedControl.tsx
+++ b/desktop/frontend/src/components/ui/SegmentedControl.tsx
@@ -5,40 +5,54 @@ interface SegmentedOption<T extends string> {
   value: T;
   label: string;
   tooltip?: ReactNode;
+  disabled?: boolean;
 }
 
 interface SegmentedControlProps<T extends string> {
   value: T;
   options: readonly SegmentedOption<T>[];
   onChange: (value: T) => void;
+  fullWidth?: boolean;
+  className?: string;
 }
 
 export function SegmentedControl<T extends string>({
   value,
   options,
   onChange,
+  fullWidth = false,
+  className = "",
 }: SegmentedControlProps<T>) {
+  const fullWidthClass = fullWidth ? "w-full" : "";
   return (
-    <div className="flex rounded-md border border-[var(--border)] p-0.5">
+    <div
+      className={`flex rounded-md border border-[var(--border)] p-0.5 ${fullWidthClass} ${className}`}
+    >
       {options.map((opt) => {
         const button = (
           <button
+            type="button"
             onClick={() => onChange(opt.value)}
-            className={`rounded px-2.5 py-1 text-[11px] font-medium transition-colors ${
+            disabled={opt.disabled}
+            className={`rounded px-2.5 py-1 text-[11px] font-medium transition-colors ${fullWidthClass} ${
               value === opt.value
                 ? "bg-[var(--bg-active)] text-[var(--text-primary)]"
-                : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                : "text-[var(--text-muted)] hover:text-[var(--text-secondary)] disabled:opacity-40 disabled:hover:text-[var(--text-muted)]"
             }`}
           >
             {opt.label}
           </button>
         );
-        return opt.tooltip ? (
-          <Tooltip key={opt.value} content={opt.tooltip} side="bottom" wide>
-            {button}
-          </Tooltip>
-        ) : (
-          <span key={opt.value}>{button}</span>
+        return (
+          <span key={opt.value} className={fullWidth ? "flex-1" : ""}>
+            {opt.tooltip ? (
+              <Tooltip content={opt.tooltip} side="bottom" wide>
+                {button}
+              </Tooltip>
+            ) : (
+              button
+            )}
+          </span>
         );
       })}
     </div>

--- a/desktop/frontend/src/components/ui/Switch.tsx
+++ b/desktop/frontend/src/components/ui/Switch.tsx
@@ -1,0 +1,19 @@
+// Presentational toggle track. The on-state is the modal's single accent moment
+// for this control, so cyan reads as "this is on". The parent button owns the
+// click and the switch role/state, so this stays purely visual.
+export function Switch({ checked }: { checked: boolean }) {
+  return (
+    <span
+      aria-hidden
+      className={`relative h-[18px] w-8 shrink-0 rounded-full transition-colors ${
+        checked ? "bg-[var(--accent-cyan)]" : "bg-[var(--bg-active)]"
+      }`}
+    >
+      <span
+        className={`absolute left-[3px] top-[3px] h-3 w-3 rounded-full bg-white transition-transform ${
+          checked ? "translate-x-3.5" : ""
+        }`}
+      />
+    </span>
+  );
+}

--- a/desktop/frontend/src/components/ui/fields.ts
+++ b/desktop/frontend/src/components/ui/fields.ts
@@ -1,0 +1,18 @@
+// Shared input/textarea field styling so dialogs that compose their own fields
+// (e.g. BulkDuplicateDialog, CopyRunConfig) stay visually consistent.
+export const FIELD_CLASS =
+  "w-full rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)] text-[13px] text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)] focus:border-[var(--accent-cyan)]";
+
+// A quiet, sentence-case label sitting to the left of a settings row's control.
+export const SECTION_LABEL =
+  "text-[13px] font-medium text-[var(--text-secondary)]";
+
+// The single muted helper voice used under fields across the duplicate dialog.
+export const HELPER_TEXT = "text-[12px] leading-snug text-[var(--text-muted)]";
+
+// A grouped settings card: a soft, subtly-tinted panel that replaces the older
+// full-bleed divider rules so related controls read as one unit. No
+// `overflow-hidden` here — cards host popover menus (ActionPicker) that must be
+// free to spill past the card edge.
+export const CARD_CLASS =
+  "rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)]/40";

--- a/desktop/frontend/src/store/app.ts
+++ b/desktop/frontend/src/store/app.ts
@@ -186,7 +186,7 @@ interface AppState {
       excludeUncommitted?: boolean;
       reinstallDeps?: boolean;
       labels?: string[];
-      tasks?: SpawnTask[];
+      tasksPerCopy?: SpawnTask[][];
       groupName?: string;
     },
   ) => Promise<void>;
@@ -836,7 +836,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   bulkDuplicate: async (name, count, opts = {}) => {
     if (count < 1) return;
-    const tasks = opts.tasks ?? [];
+    const tasksPerCopy = opts.tasksPerCopy ?? [];
     set((s) => ({ duplicatingNames: [...s.duplicatingNames, name] }));
     const noun = (n: number) => (n === 1 ? "copy" : "copies");
     const toastId = toast.loading(`Creating ${count} ${noun(count)} of ${name}…`);
@@ -862,6 +862,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         if (!newName) break;
         const copyName = newName;
         created.push(copyName);
+        const tasks = tasksPerCopy[i] ?? [];
         if (tasks.length > 0) {
           set((s) => ({ spawnTasks: { ...s.spawnTasks, [copyName]: tasks } }));
         }

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -70,6 +70,24 @@ export type SpawnTask =
   | { kind: "action"; actionName: string; prompt?: string }
   | { kind: "command"; command: string; prompt?: string };
 
+// What a duplicated copy runs once created: nothing, a project action, or an
+// ad-hoc command — the authoring side of SpawnTask in the "Bulk Duplicate" flow.
+export type RunMode = "none" | "action" | "command";
+
+// A copy's per-run override of the shared default. `null` at the call site means
+// the copy inherits the default; an override carries a text-only prompt — image
+// attachments stay a shared-default feature to keep each copy's editor light.
+export interface CopyOverride {
+  mode: RunMode;
+  actionName: string;
+  command: string;
+  prompt: string;
+}
+
+// A copy's run-mode choice in the duplicate UI, including the "default" sentinel
+// that means "inherit the shared default" rather than override it.
+export type CopyRunMode = RunMode | "default";
+
 export interface ProjectInfo {
   name: string;
   session: string;


### PR DESCRIPTION
Adds per-copy run overrides to bulk duplication so each copied project can inherit the shared run setting or run its own action/command. The duplicate dialog was also reorganized into smaller UI pieces with clearer copy, run, and option sections.

- Replaces shared `tasks` output with index-aligned `tasksPerCopy`
- Adds per-copy override state for action, command, prompt, or no run
- Seeds overrides from the shared default for faster setup
- Introduces reusable UI components for copy rows, shell command input, segmented controls, and switch rows
- Refreshes the bulk duplicate dialog layout and helper text for multi-copy workflows