### PR TITLE
feat(settings): add default project directory

### DIFF
--- a/desktop/frontend/bridge/commands.js
+++ b/desktop/frontend/bridge/commands.js
@@ -16,8 +16,8 @@ export function AddPortForward(project, remotePort, localPort) {
 export function AttachProject(projectName) {
   return invoke("attach_project", { projectName });
 }
-export function BrowseFolder() {
-  return invoke("browse_folder");
+export function BrowseFolder(defaultDir) {
+  return invoke("browse_folder", { defaultDir });
 }
 export function CheckActionPortConflict(projectName, actionName) {
   return invoke("check_action_port_conflict", { projectName, actionName });

--- a/desktop/frontend/src-tauri/src/config.rs
+++ b/desktop/frontend/src-tauri/src/config.rs
@@ -1496,7 +1496,14 @@ pub fn get_project(name: &str, run: &HashMap<String, RunState>) -> Result<Option
 /// reading from disk (a disk read would fail and break new-terminal + the
 /// Global Actions row in the Terminals view).
 fn global_root() -> String {
-    dirs::home_dir().unwrap_or_default().to_string_lossy().into_owned()
+    let home = dirs::home_dir().unwrap_or_default().to_string_lossy().into_owned();
+    if let Some(dir) = load_settings().get("defaultProjectDirectory").and_then(Value::as_str) {
+        let expanded = expand_home(dir);
+        if !expanded.is_empty() && std::path::Path::new(&expanded).is_dir() {
+            return expanded;
+        }
+    }
+    home
 }
 
 fn global_project_info() -> Value {

--- a/desktop/frontend/src-tauri/src/files.rs
+++ b/desktop/frontend/src-tauri/src/files.rs
@@ -35,12 +35,19 @@ fn resolve_existing(abs: &str) -> Result<String, String> {
 }
 
 #[tauri::command]
-pub async fn browse_folder(app: AppHandle) -> Result<String, String> {
-    let picked = pick_path(app, |app| {
-        app.dialog()
-            .file()
-            .set_title("Select project folder")
-            .blocking_pick_folder()
+pub async fn browse_folder(
+    app: AppHandle,
+    default_dir: Option<String>,
+) -> Result<String, String> {
+    let start = default_dir
+        .map(|d| expand_home(&d))
+        .filter(|d| !d.is_empty() && std::path::Path::new(d).is_dir());
+    let picked = pick_path(app, move |app| {
+        let mut builder = app.dialog().file().set_title("Select project folder");
+        if let Some(dir) = start {
+            builder = builder.set_directory(dir);
+        }
+        builder.blocking_pick_folder()
     })
     .await?;
     match picked {

--- a/desktop/frontend/src/components/AddCloneRepoModal.tsx
+++ b/desktop/frontend/src/components/AddCloneRepoModal.tsx
@@ -7,6 +7,7 @@ import { XIcon } from "./icons";
 import { slugify } from "../slugify";
 import { useAppStore } from "../store/app";
 import { BrowseFolder } from "../../bridge/commands";
+import { getSettings } from "../store/settings";
 import { gitUrlSchema, projectNameSchema } from "../forms/schemas";
 import {
   modalErrorInputClass,
@@ -67,6 +68,12 @@ export function AddCloneRepoModal() {
     setSubmitError("");
   }, [open, reset]);
 
+  useEffect(() => {
+    if (!open) return;
+    const dir = getSettings().defaultProjectDirectory;
+    if (dir) setValue("destParent", dir, { shouldDirty: false, shouldValidate: true });
+  }, [open, setValue]);
+
   const url = watch("url");
   const nameDirty = !!dirtyFields.name;
   useEffect(() => {
@@ -77,7 +84,7 @@ export function AddCloneRepoModal() {
   const pickDest = async () => {
     if (busy) return;
     try {
-      const dir = await BrowseFolder();
+      const dir = await BrowseFolder(getSettings().defaultProjectDirectory);
       if (dir) {
         setValue("destParent", dir, {
           shouldDirty: true,

--- a/desktop/frontend/src/components/Settings.tsx
+++ b/desktop/frontend/src/components/Settings.tsx
@@ -31,6 +31,7 @@ import {
   VaultExportKey,
   VaultImportKey,
   ListSystemSounds,
+  BrowseFolder,
 } from "../../bridge/commands";
 import { SoundPicker } from "./SoundPicker";
 import type { main } from "../../bridge/models";
@@ -94,6 +95,7 @@ export function Settings({
 }: SettingsProps) {
   const theme = useSettingsStore((s) => s.theme);
   const dblClick = useSettingsStore((s) => s.doubleClickToToggle);
+  const defaultProjectDirectory = useSettingsStore((s) => s.defaultProjectDirectory);
   const soundEnabled = useSettingsStore((s) => s.soundNotifications ?? false);
   const doneSound = useSettingsStore((s) => s.doneSound ?? "chime");
   const waitingSound = useSettingsStore((s) => s.waitingSound ?? "chime");
@@ -110,6 +112,15 @@ export function Settings({
   const setTheme = (next: Theme) => {
     applyTheme(next);
     void updateSettings({ theme: next });
+  };
+
+  const chooseDefaultProjectDir = async () => {
+    try {
+      const dir = await BrowseFolder(defaultProjectDirectory);
+      if (dir) void updateSettings({ defaultProjectDirectory: dir });
+    } catch {
+      // User's own picker; cancellations are normal.
+    }
   };
 
   const [kokoroStatus, setKokoroStatus] = useState<KokoroStatus>("idle");
@@ -355,6 +366,27 @@ export function Settings({
               </SettingsRow>
               <SettingsRow label="Double-click to start/stop" description="Double-click a project in sidebar to toggle it">
                 <Toggle enabled={dblClick} onChange={(v) => updateSettings({ doubleClickToToggle: v })} />
+              </SettingsRow>
+              <SettingsRow label="Default project directory" description="Add project, clone destination, and global terminals open here">
+                <div className="flex items-center gap-2">
+                  <span
+                    className="max-w-[180px] truncate font-mono text-xs text-[var(--text-muted)]"
+                    title={defaultProjectDirectory || undefined}
+                  >
+                    {defaultProjectDirectory || "Not set"}
+                  </span>
+                  {defaultProjectDirectory && (
+                    <button
+                      onClick={() => void updateSettings({ defaultProjectDirectory: undefined })}
+                      className={BTN_SECONDARY}
+                    >
+                      Clear
+                    </button>
+                  )}
+                  <button onClick={chooseDefaultProjectDir} className={BTN_SECONDARY}>
+                    Choose
+                  </button>
+                </div>
               </SettingsRow>
             </SettingsSection>
 

--- a/desktop/frontend/src/store/app.ts
+++ b/desktop/frontend/src/store/app.ts
@@ -767,7 +767,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       return;
     }
     try {
-      const dir = await BrowseFolder();
+      const dir = await BrowseFolder(getSettings().defaultProjectDirectory);
       if (!dir) return;
       const name = dir.split("/").pop() || "new-project";
       await CreateProject(name, dir);

--- a/desktop/frontend/src/store/settings.ts
+++ b/desktop/frontend/src/store/settings.ts
@@ -26,6 +26,7 @@ export interface Settings {
   browserTheme?: "light" | "dark"; // unset = follow the app theme
 
   doubleClickToToggle: boolean;
+  defaultProjectDirectory?: string;
   soundNotifications?: boolean;
   doneSound?: string;
   waitingSound?: string;
@@ -81,6 +82,7 @@ function normalize(s: main.Settings): Settings {
     browserTheme:
       s.browserTheme === "light" || s.browserTheme === "dark" ? s.browserTheme : undefined,
     doubleClickToToggle: s.doubleClickToToggle ?? defaults.doubleClickToToggle,
+    defaultProjectDirectory: s.defaultProjectDirectory || undefined,
     soundNotifications: s.soundNotifications,
     doneSound: s.doneSound || undefined,
     waitingSound: s.waitingSound || undefined,


### PR DESCRIPTION
## Summary

Adds a **Default project directory** option in **General settings** (folder picker). When set, that folder becomes the default/starting location across the app instead of the last-used folder.

## What it affects

- **Add project → Local folder**: picker opens at the default directory.
- **Clone repository → Destination folder**: field is pre-filled with the default directory and the **Choose** picker opens there.
- **Global terminals**: new tabs open in the default directory (instead of `~`). Per-project terminals keep their own project root.

When the setting is unset — or the folder no longer exists — everything falls back to the previous behavior (`~` for terminals, last-used for pickers).

## Implementation

- `store/settings.ts`: new `defaultProjectDirectory?: string` field.
- `components/Settings.tsx`: General-section row with path display, **Choose**, and **Clear**.
- `src-tauri/src/files.rs`: `browse_folder` takes an optional `default_dir` and calls `set_directory` when the path exists.
- `bridge/commands.js`: `BrowseFolder(defaultDir)` forwards the arg.
- `store/app.ts` + `components/AddCloneRepoModal.tsx`: pass the setting into the pickers; clone destination is also pre-filled on open.
- `src-tauri/src/config.rs`: `global_root()` reads the setting (existence-checked) with home fallback.

## Notes

- The relocate-project picker is intentionally left unchanged.
- `cargo check` passes; `tsc --noEmit` is clean for the touched files.