### PR TITLE
feat(settings): experimental Liquid Glass transparency [DO NOT MERGE WITHOUT MANUAL TESTING]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ node_modules
 .DS_Store
 secrets
 prompts
+# Brainstorming visual-companion scratch
+.superpowers/

--- a/desktop/frontend/bridge/commands.d.ts
+++ b/desktop/frontend/bridge/commands.d.ts
@@ -147,6 +147,7 @@ export function SaveTextFile(...args: any[]): Promise<any>;
 export function SaveWindowSize(...args: any[]): Promise<any>;
 export function SearchBranches(...args: any[]): Promise<any>;
 export function SetProjectLabel(...args: any[]): Promise<any>;
+export function SetTransparency(...args: any[]): Promise<any>;
 export function StartLogStreaming(...args: any[]): Promise<any>;
 export function StartProject(...args: any[]): Promise<any>;
 export function StartProjectWithServices(...args: any[]): Promise<any>;

--- a/desktop/frontend/bridge/commands.js
+++ b/desktop/frontend/bridge/commands.js
@@ -445,6 +445,9 @@ export function SearchBranches(cwd, query) {
 export function SetProjectLabel(name, label) {
   return invoke("set_project_label", { name, label });
 }
+export function SetTransparency(enabled) {
+  return invoke("set_transparency", { enabled });
+}
 export function MoveProjectRoot(name, newRoot) {
   return invoke("move_project_root", { name, newRoot });
 }

--- a/desktop/frontend/src-tauri/Cargo.lock
+++ b/desktop/frontend/src-tauri/Cargo.lock
@@ -2377,6 +2377,7 @@ dependencies = [
  "tempfile",
  "urlencoding",
  "uuid",
+ "window-vibrancy",
  "zeroize",
 ]
 

--- a/desktop/frontend/src-tauri/Cargo.toml
+++ b/desktop/frontend/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "2", features = [] }
 cc = "1"
 
 [dependencies]
-tauri = { version = "2", features = ["unstable"] }  # unstable = multiwebview (in-pane browser)
+tauri = { version = "2", features = ["unstable", "macos-private-api"] }  # unstable = multiwebview (in-pane browser); macos-private-api = transparent window
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -65,6 +65,7 @@ reqwest = { version = "0.13", default-features = false, features = ["blocking", 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
 objc2-foundation = { version = "0.3", features = ["NSString"] }
+window-vibrancy = "0.6" # NSVisualEffectView frosted-glass backdrop for Transparency mode
 
 # thin LTO + parallel codegen roughly halves CI link time; the runtime
 # difference is imperceptible for a GUI app. opt-level = "s" keeps DMG size down.

--- a/desktop/frontend/src-tauri/src/generated_commands.rs
+++ b/desktop/frontend/src-tauri/src/generated_commands.rs
@@ -170,6 +170,7 @@ macro_rules! all_command_handlers {
         save_window_size,
         search_branches,
         set_project_label,
+        set_transparency,
         start_log_streaming,
         start_project,
         start_project_with_services,

--- a/desktop/frontend/src-tauri/src/lib.rs
+++ b/desktop/frontend/src-tauri/src/lib.rs
@@ -54,6 +54,7 @@ use files::*;
 use git::*;
 use hooks::*;
 use log_streaming::*;
+use mainwindow::set_transparency;
 use message_history::*;
 use notes_cmds::*;
 use openin::*;
@@ -122,6 +123,7 @@ pub fn run() {
             if let Some(win) = handle.get_webview_window("main") {
                 mainwindow::restore(&win);
                 mainwindow::attach(&win);
+                mainwindow::restore_transparency(&win);
             }
             // Reopen any windows that were detached when the app last closed.
             let state = app.state::<detached::DetachedState>();

--- a/desktop/frontend/src-tauri/src/mainwindow.rs
+++ b/desktop/frontend/src-tauri/src/mainwindow.rs
@@ -4,7 +4,40 @@
 // avoid two writers using different coordinate spaces for the same keys.
 use crate::bounds::{read_logical_bounds, valid_bounds};
 use crate::config;
-use tauri::{LogicalPosition, LogicalSize, WebviewWindow, WindowEvent};
+use tauri::{AppHandle, LogicalPosition, LogicalSize, Manager, WebviewWindow, WindowEvent};
+use window_vibrancy::{apply_vibrancy, clear_vibrancy, NSVisualEffectMaterial};
+
+/// Apply or remove the native frosted-glass NSVisualEffectView backdrop. The
+/// window is created `transparent: true`; the frontend keeps the body opaque
+/// until glass mode is on, so clearing vibrancy returns to the normal look.
+pub fn apply_transparency(win: &WebviewWindow, enabled: bool) {
+    if enabled {
+        let _ = apply_vibrancy(win, NSVisualEffectMaterial::Sidebar, None, None);
+    } else {
+        let _ = clear_vibrancy(win);
+    }
+}
+
+/// Re-apply the persisted Transparency setting on startup so the look survives
+/// restarts. Off by default — does nothing unless the user opted in.
+pub fn restore_transparency(win: &WebviewWindow) {
+    let on = config::load_settings()
+        .get("transparency")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if on {
+        apply_transparency(win, true);
+    }
+}
+
+#[tauri::command]
+pub fn set_transparency(app: AppHandle, enabled: bool) -> Result<(), String> {
+    let win = app
+        .get_webview_window("main")
+        .ok_or("main window not found")?;
+    apply_transparency(&win, enabled);
+    Ok(())
+}
 
 pub fn attach(win: &WebviewWindow) {
     let w = win.clone();

--- a/desktop/frontend/src-tauri/tauri.conf.json
+++ b/desktop/frontend/src-tauri/tauri.conf.json
@@ -10,6 +10,7 @@
     "frontendDist": "../dist"
   },
   "app": {
+    "macOSPrivateApi": true,
     "windows": [
       {
         "label": "main",
@@ -21,7 +22,8 @@
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "trafficLightPosition": { "x": 14, "y": 19 },
-        "dragDropEnabled": true
+        "dragDropEnabled": true,
+        "transparent": true
       }
     ],
     "security": {

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -150,7 +150,7 @@ export default function App() {
 
   if (tmuxReady === null) {
     return (
-      <div className="flex h-screen bg-[var(--bg-primary)]">
+      <div className="flex h-full bg-[var(--bg-primary)]">
         <div className="app-drag absolute inset-x-0 top-0 h-10" />
       </div>
     );
@@ -166,7 +166,7 @@ export default function App() {
   }
 
   return (
-    <div className="flex h-screen">
+    <div className="flex h-full">
       <Toaster
         position="top-right"
         theme="system"

--- a/desktop/frontend/src/DetachedApp.tsx
+++ b/desktop/frontend/src/DetachedApp.tsx
@@ -79,14 +79,14 @@ export function DetachedApp({ projectName }: DetachedAppProps) {
 
   if (!project) {
     return (
-      <div className="flex h-screen flex-col bg-[var(--bg-primary)]">
+      <div className="flex h-full flex-col bg-[var(--bg-primary)]">
         <div className="app-drag absolute inset-x-0 top-0 h-10" />
       </div>
     );
   }
 
   return (
-    <div className="flex h-screen">
+    <div className="flex h-full">
       <Toaster
         position="top-right"
         theme="system"

--- a/desktop/frontend/src/components/InteractivePane.tsx
+++ b/desktop/frontend/src/components/InteractivePane.tsx
@@ -257,6 +257,7 @@ function writeTerminalError(terminalId: string, err: unknown): void {
   term.write(`\r\n\x1b[31mlpm upload failed: ${msg}\x1b[0m\r\n`);
 }
 
+
 function createInteractiveSession(terminalId: string, cwd: string): InteractiveSession {
   const host = document.createElement("div");
   host.className = "absolute inset-0 overflow-hidden";

--- a/desktop/frontend/src/components/Settings.tsx
+++ b/desktop/frontend/src/components/Settings.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { toast } from "sonner";
 import { useSettingsStore } from "../store/settings";
+import { applyGlass, applyGlassDom, DEFAULT_INTERFACE_TRANSPARENCY } from "../glass";
 import { applyTheme, type Theme } from "../theme";
 import { useEventListener } from "../hooks/useEventListener";
 import {
@@ -105,7 +106,28 @@ export function Settings({
     (s) => s.terminalOpenInDefaultApp ?? false,
   );
   const experimentalTTS = useSettingsStore((s) => s.experimentalTTS);
+  const transparency = useSettingsStore((s) => s.transparency ?? false);
+  const interfaceTransparency = useSettingsStore(
+    (s) => s.interfaceTransparency ?? DEFAULT_INTERFACE_TRANSPARENCY,
+  );
+  const panelTransparency = useSettingsStore((s) => s.panelTransparency ?? 0);
   const updateSettings = useSettingsStore((s) => s.update);
+
+  // Terminal transparency was removed: xterm's WebGL renderer can't make the
+  // canvas see-through without breaking rendering (empty/black terminal), so
+  // glass applies to the interface (sidebar/tabs) and the content/panel zone.
+  const setTransparency = (on: boolean) => {
+    applyGlass(on, interfaceTransparency, panelTransparency);
+    void updateSettings({ transparency: on });
+  };
+  const setInterfaceTransparency = (level: number) => {
+    applyGlassDom(transparency, level, panelTransparency);
+    void updateSettings({ interfaceTransparency: level });
+  };
+  const setPanelTransparency = (level: number) => {
+    applyGlassDom(transparency, interfaceTransparency, level);
+    void updateSettings({ panelTransparency: level });
+  };
 
   const setTheme = (next: Theme) => {
     applyTheme(next);
@@ -324,7 +346,7 @@ export function Settings({
     <div className="-mx-6 flex flex-1 overflow-hidden">
       {updateStatus === "installing" && <InstallingOverlay phase={installPhase} progress={installProgress} />}
 
-      <nav className="flex w-42 shrink-0 flex-col border-r border-[var(--border)] bg-[var(--bg-sidebar)] px-3 pt-6">
+      <nav className="flex w-42 shrink-0 flex-col border-r border-[var(--border)] bg-[var(--bg-secondary)] px-3 pt-6">
         <h1 className="mb-4 px-2 text-lg font-semibold tracking-tight text-[var(--text-primary)]">Settings</h1>
         {navItems.map(([key, label]) => (
           <button
@@ -356,6 +378,45 @@ export function Settings({
               <SettingsRow label="Double-click to start/stop" description="Double-click a project in sidebar to toggle it">
                 <Toggle enabled={dblClick} onChange={(v) => updateSettings({ doubleClickToToggle: v })} />
               </SettingsRow>
+              <SettingsRow label="Transparency (Experimental)" description="Liquid Glass translucency. Heavier on the GPU.">
+                <Toggle enabled={transparency} onChange={setTransparency} />
+              </SettingsRow>
+              {transparency && (
+                <SettingsRow label="Sidebar transparency" description="How frosted the sidebar (and Settings menu) is.">
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="range"
+                      min={0}
+                      max={100}
+                      step={5}
+                      value={interfaceTransparency}
+                      onChange={(e) => setInterfaceTransparency(Number(e.target.value))}
+                      className="w-32 accent-[var(--accent-green)]"
+                    />
+                    <span className="min-w-[2.5rem] text-right font-mono text-xs tabular-nums text-[var(--text-muted)]">
+                      {interfaceTransparency}%
+                    </span>
+                  </div>
+                </SettingsRow>
+              )}
+              {transparency && (
+                <SettingsRow label="Panel transparency" description="How see-through the content area is — projects, settings, forms.">
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="range"
+                      min={0}
+                      max={100}
+                      step={5}
+                      value={panelTransparency}
+                      onChange={(e) => setPanelTransparency(Number(e.target.value))}
+                      className="w-32 accent-[var(--accent-green)]"
+                    />
+                    <span className="min-w-[2.5rem] text-right font-mono text-xs tabular-nums text-[var(--text-muted)]">
+                      {panelTransparency}%
+                    </span>
+                  </div>
+                </SettingsRow>
+              )}
             </SettingsSection>
 
             <SettingsSection title="About">

--- a/desktop/frontend/src/components/Sidebar.tsx
+++ b/desktop/frontend/src/components/Sidebar.tsx
@@ -672,7 +672,7 @@ export function Sidebar({ projects, groups, sidebarOrder, selected, collapsed, o
 
   return (
     <aside
-      className={`relative flex shrink-0 flex-col bg-[var(--bg-sidebar)] transition-[width] duration-200 ${collapsed ? "" : "border-r border-[var(--border)]"}`}
+      className={`glass-chrome relative flex shrink-0 flex-col bg-[var(--bg-sidebar)] transition-[width] duration-200 ${collapsed ? "" : "border-r border-[var(--border)]"}`}
       style={{ width: collapsed ? 0 : width, overflow: collapsed ? "hidden" : undefined }}
     >
       <div

--- a/desktop/frontend/src/glass.test.ts
+++ b/desktop/frontend/src/glass.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { chromeBgAlpha, panelBgAlpha } from "./glass";
+
+describe("chromeBgAlpha", () => {
+  it("is most solid at level 0 and most glassy at 100", () => {
+    expect(chromeBgAlpha(0)).toBeCloseTo(0.85, 5);
+    expect(chromeBgAlpha(100)).toBeCloseTo(0.3, 5);
+  });
+
+  it("stays within the legible band and is monotonic", () => {
+    let prev = chromeBgAlpha(0);
+    for (let l = 10; l <= 100; l += 10) {
+      const a = chromeBgAlpha(l);
+      expect(a).toBeLessThanOrEqual(prev);
+      expect(a).toBeGreaterThanOrEqual(0.3 - 1e-9);
+      expect(a).toBeLessThanOrEqual(0.85);
+      prev = a;
+    }
+  });
+
+  it("clamps out-of-range input", () => {
+    expect(chromeBgAlpha(-50)).toBeCloseTo(0.85, 5);
+    expect(chromeBgAlpha(999)).toBeCloseTo(0.3, 5);
+  });
+});
+
+describe("panelBgAlpha", () => {
+  it("is opaque at 0 and floored at 100", () => {
+    expect(panelBgAlpha(0)).toBe(1);
+    expect(panelBgAlpha(100)).toBeCloseTo(0.4, 5);
+  });
+});

--- a/desktop/frontend/src/glass.ts
+++ b/desktop/frontend/src/glass.ts
@@ -1,0 +1,53 @@
+import { SetTransparency } from "../bridge/commands";
+
+// The chrome (sidebar / toolbars) tint range. Higher slider = more see-through.
+// Floored well above 0 so chrome labels stay legible.
+const CHROME_ALPHA_MAX = 0.85;
+const CHROME_ALPHA_MIN = 0.3;
+
+// Default interface slider position (≈ the frosted look from design).
+export const DEFAULT_INTERFACE_TRANSPARENCY = 50;
+
+// Panels/forms/config surfaces. Floored above 0 so form text stays legible.
+const PANEL_ALPHA_FLOOR = 0.4;
+
+function clamp01to100(level: number): number {
+  return Math.min(100, Math.max(0, level));
+}
+
+// Slider level (0–100) -> chrome background alpha. 0 = most solid, 100 = most
+// glassy (but never below the legibility floor).
+export function chromeBgAlpha(level: number): number {
+  return CHROME_ALPHA_MAX - (clamp01to100(level) / 100) * (CHROME_ALPHA_MAX - CHROME_ALPHA_MIN);
+}
+
+// Slider level (0–100) -> panel/form background alpha. 0 = fully opaque, 100 =
+// the readability floor.
+export function panelBgAlpha(level: number): number {
+  return 1 - (clamp01to100(level) / 100) * (1 - PANEL_ALPHA_FLOOR);
+}
+
+// Reflect the glass settings onto <html>: `data-glass` toggles glass mode,
+// `--glass-chrome-alpha` drives the sidebar tint, `--glass-panel-alpha` the
+// content/panel tint. (The terminal canvas is intentionally NOT made
+// transparent — xterm's WebGL renderer breaks when allowTransparency is on.)
+export function applyGlassDom(
+  transparency: boolean,
+  interfaceTransparency: number,
+  panelTransparency: number,
+): void {
+  const root = document.documentElement;
+  root.setAttribute("data-glass", transparency ? "on" : "off");
+  root.style.setProperty("--glass-chrome-alpha", String(chromeBgAlpha(interfaceTransparency)));
+  root.style.setProperty("--glass-panel-alpha", String(panelBgAlpha(panelTransparency)));
+}
+
+// Full apply: DOM (CSS) plus the native window vibrancy via Rust.
+export function applyGlass(
+  transparency: boolean,
+  interfaceTransparency: number,
+  panelTransparency: number,
+): void {
+  applyGlassDom(transparency, interfaceTransparency, panelTransparency);
+  void SetTransparency(transparency).catch(() => {});
+}

--- a/desktop/frontend/src/main.tsx
+++ b/desktop/frontend/src/main.tsx
@@ -7,6 +7,7 @@ import { loadSettings } from "./store/settings";
 import { loadTerminals } from "./terminals";
 import { loadGroups } from "./store/groups";
 import { applyTheme } from "./theme";
+import { applyGlassDom, DEFAULT_INTERFACE_TRANSPARENCY } from "./glass";
 import { hydrateAppStore } from "./store/app";
 import { useComposerStore } from "./store/composer";
 import { initTTSEvents } from "./store/tts";
@@ -19,6 +20,14 @@ const detachedProject = new URLSearchParams(window.location.search).get(
 
 Promise.all([loadSettings(), loadTerminals(), loadGroups()]).then(([s, , g]) => {
   applyTheme(s.theme);
+  // Glass affects the main window only (detached windows aren't transparent).
+  // Native vibrancy is applied on the Rust side at startup; this sets the CSS.
+  if (!detachedProject)
+    applyGlassDom(
+      s.transparency ?? false,
+      s.interfaceTransparency ?? DEFAULT_INTERFACE_TRANSPARENCY,
+      s.panelTransparency ?? 0,
+    );
   hydrateAppStore(g);
   useComposerStore.getState().hydrate(s.composerOpen ?? false);
   initTTSEvents();

--- a/desktop/frontend/src/store/settings.ts
+++ b/desktop/frontend/src/store/settings.ts
@@ -26,6 +26,9 @@ export interface Settings {
   browserTheme?: "light" | "dark"; // unset = follow the app theme
 
   doubleClickToToggle: boolean;
+  transparency?: boolean;
+  interfaceTransparency?: number;
+  panelTransparency?: number;
   soundNotifications?: boolean;
   doneSound?: string;
   waitingSound?: string;
@@ -81,6 +84,15 @@ function normalize(s: main.Settings): Settings {
     browserTheme:
       s.browserTheme === "light" || s.browserTheme === "dark" ? s.browserTheme : undefined,
     doubleClickToToggle: s.doubleClickToToggle ?? defaults.doubleClickToToggle,
+    transparency: s.transparency ?? undefined,
+    interfaceTransparency:
+      typeof s.interfaceTransparency === "number"
+        ? Math.min(100, Math.max(0, s.interfaceTransparency))
+        : undefined,
+    panelTransparency:
+      typeof s.panelTransparency === "number"
+        ? Math.min(100, Math.max(0, s.panelTransparency))
+        : undefined,
     soundNotifications: s.soundNotifications,
     doneSound: s.doneSound || undefined,
     waitingSound: s.waitingSound || undefined,

--- a/desktop/frontend/src/styles/globals.css
+++ b/desktop/frontend/src/styles/globals.css
@@ -61,6 +61,15 @@
   --terminal-tab-active: #e5e5e5;
 }
 
+/* Fill the real window via the element chain, not 100vh — on a transparent
+   overlay-titlebar window 100vh can fall short of the window, leaving an
+   unpainted strip at the bottom that shows the desktop through. */
+html,
+body,
+#root {
+  height: 100%;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
@@ -68,6 +77,40 @@ body {
   color: var(--text-primary);
   overflow: hidden;
   user-select: none;
+}
+
+/* ---- Liquid Glass (Transparency, Experimental) ----------------------------
+   The window is created transparent and a native NSVisualEffectView vibrancy
+   sits behind the webview (toggled from Rust). We make the body transparent so
+   that frosted backdrop shows through, then turn the app chrome (sidebar +
+   terminal header) and panels translucent via the slider-driven alphas. The
+   terminal canvas itself stays opaque — xterm's WebGL renderer can't render a
+   transparent canvas without breaking. */
+[data-glass="on"] {
+  --glass-blur: 20px;
+}
+[data-glass="on"] body {
+  background: transparent;
+}
+/* The main content area's background comes from --bg-primary (Tailwind
+   bg-[var(--bg-primary)] on <main>), which the Panel slider drives below —
+   so panel transparency regulates the whole content/settings window. */
+[data-glass="on"][data-theme="dark"] {
+  /* Sidebar (app sidebar + Settings nav) — the "Sidebar transparency" slider. */
+  --bg-sidebar: rgba(30, 30, 36, var(--glass-chrome-alpha, 0.55));
+  /* Content surfaces (projects, settings, forms) — the "Panel transparency"
+     slider. Translucent only when moved (alpha defaults to 1 = unchanged). */
+  --bg-primary: rgba(26, 26, 26, var(--glass-panel-alpha, 1));
+  --bg-secondary: rgba(36, 36, 36, var(--glass-panel-alpha, 1));
+}
+[data-glass="on"][data-theme="light"] {
+  --bg-sidebar: rgba(250, 250, 252, var(--glass-chrome-alpha, 0.6));
+  --bg-primary: rgba(255, 255, 255, var(--glass-panel-alpha, 1));
+  --bg-secondary: rgba(245, 245, 245, var(--glass-panel-alpha, 1));
+}
+[data-glass="on"] .glass-chrome {
+  backdrop-filter: blur(var(--glass-blur)) saturate(150%);
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(150%);
 }
 
 .app-drag {

--- a/documentation/liquid-glass/problem-memory.md
+++ b/documentation/liquid-glass/problem-memory.md
@@ -1,0 +1,245 @@
+# Liquid Glass — Terminal Transparency Problem Memory
+
+> Terminal background won't go translucent in glass mode; latest attempt also
+> turned the terminal solid black (lost its theme color).
+> Last updated: 2026-06-21
+
+---
+
+## Problem: Terminal transparency never works (and now renders black)
+
+### Type: Bug (built on a false assumption)
+
+### Status: RESOLVED — terminal transparency abandoned (category proven dead)
+
+## FINAL root cause (the dead category)
+
+The earlier "it works" red-test was on a Cmd+R (HMR) state with live PTY sessions,
+which masked the truth. A FULL dev restart exposed it:
+- `allowTransparency: true` → terminal renders EMPTY on cold start (WebGL texture
+  atlas paints nothing on first frame).
+- `allowTransparency: false` + an `rgba()` theme background → xterm fails to make
+  it opaque and falls back to its default → pure BLACK / white, no theme.
+- Only safe combo: `allowTransparency: false` + a `#hex` background = normal
+  themed terminal, but NO transparency.
+
+There is no third option: the ONLY way to see through the xterm canvas is
+allowTransparency, and it breaks rendering in this stack (xterm 6.1-beta +
+addon-webgl 0.20-beta). **Category proven dead.** Terminal transparency removed.
+
+## Final solution
+- Removed the Terminal transparency slider + all its plumbing
+  (terminalTransparency setting, terminalBgAlpha/terminalThemeBackground/hexToRgba,
+  --terminal-alpha, the getTerminalTheme alpha branch, allowTransparency).
+- Terminals render exactly as baseline (opaque, themed).
+- Glass = Interface (sidebar/toolbars) + Panel (forms/config) transparency, both
+  pure CSS, both reliable. Native window vibrancy stays.
+- tsc clean, 98 tests pass.
+
+## Lesson for CLAUDE.md (proposed)
+- xterm.js WebGL renderer (current beta) cannot render a transparent canvas:
+  `allowTransparency:true` blanks the terminal on cold start; an rgba theme bg
+  without it renders black. Don't attempt terminal background transparency.
+- When testing Tauri rendering changes, ALWAYS full-restart `tauri dev` — Cmd+R
+  keeps live PTY/WebGL state and masks cold-start bugs.
+
+## Why the solution works (historical)
+
+The forced `rgba(255,0,0,0.5)` test rendered as **translucent red with visible
+text** in both terminals — proving definitively that **xterm honors background
+transparency** (allowTransparency + rgba theme). My 4-attempt-long belief that
+"xterm ignores transparency, must disable WebGL" was FALSE from the start, and
+the WebGL-disposal machinery built on it is what produced the black/no-color
+terminal (now removed).
+
+The real reasons the user saw "nothing":
+1. The webgl-dispose breakage (black) — fixed by removing that machinery.
+2. Dark-on-dark invisibility: the actual terminal bg `#2b2b2b` at 0.55 alpha over
+   a dark frosted backdrop is nearly indistinguishable from opaque. Fixed by
+   lowering TERMINAL_ALPHA_FLOOR 0.55 → 0.4 so max is clearly see-through.
+
+Final mechanism (simple, the whole time): `allowTransparency: true` on the
+Terminal + alpha baked into the themeOverride background (TerminalView
+`terminalThemeBackground`). No renderer swapping. WebGL stays on.
+
+### Cleanup done
+- Removed all WebGL runtime machinery + the per-pane effect (earlier).
+- Removed all [GLASS-DBG] diagnostics (glass.ts / TerminalView / InteractivePane).
+- Lowered terminal alpha floor to 0.4. tsc clean, 105 tests pass.
+
+### Secondary (still open): "Panel transparency" slider
+Proven via logs to correctly set `--bg-primary` rgba, but Settings panels are
+border-only (no --bg-primary fill) so the change isn't visible there. Needs the
+right target surfaces (modals/config editors) — separate small follow-up.
+
+---
+(historical) Status: Apply step PROVEN correct — isolating the render
+
+[GLASS-DBG] with terminal VISIBLE (global terminals `__global__-7..10`):
+```
+InteractivePane applying theme: hasThemeOverride: true,
+background: "rgba(43, 43, 43, 0.7075)", foreground: "#c8c8c8"
+```
+→ The translucent theme IS reaching xterm via term.options.theme. Wiring + apply
+are CORRECT. The bug is in how xterm RENDERS the rgba bg (or what's behind it).
+
+Also confirmed from full applyGlassDom dump: all CSS vars set correctly
+(--bg-primary rgba(26,26,26,0.82), --bg-sidebar rgba(...,0.30), --terminal-alpha
+0.7075). The Panel slider DOES change --bg-primary; it just "does nothing"
+because the Settings panels don't fill with --bg-primary. (Secondary, fix later.)
+
+GlobalTerminalsView terminal container is transparent (themeStyle = CSS vars
+only, no bg fill) — so backdrop is likely not the blocker.
+
+### Experiment running: forced `rgba(255,0,0,0.5)` terminal bg
+
+terminalThemeBackground temporarily returns bright half-transparent red to see
+what xterm actually paints. Outcome table:
+- translucent red → alpha works, fix backdrop
+- solid red → xterm ignores alpha → need CSS-layer approach under the canvas
+- black/no red → theme not reaching renderer → need refresh/recreate
+- red but text gone → WebGL+transparency text bug
+
+[GLASS-DBG] evidence (slider drag on Settings screen):
+- `applyGlassDom` fires with correct values (transparency:true, sliders change). ✅
+- `TerminalView xtermTheme` computes correct `rgba(43,43,43,0.57..)`. ✅
+- `InteractivePane applying theme` — **NEVER logs.** ❌
+
+So TerminalView builds the right translucent theme but InteractivePane never
+applies it → terminal shows xterm's built-in default (pure black/white, no theme
+colors), matching the user's exact words. BUT the logs were captured while on the
+Settings screen, where the terminal's InteractivePane may be unmounted — so the
+silence may be expected. Need the InteractivePane log captured WHILE a terminal is
+visible to know if it's an apply bug or just a not-mounted artifact.
+
+NEXT OBSERVATION NEEDED: with a terminal visible (and some colored output), drag
+the Terminal slider and report (a) `[GLASS-DBG] InteractivePane applying theme`
+lines, (b) does the bg change, (c) are there ANY colors in the output.
+
+After removing the WebGL machinery, user reports it got WORSE:
+- Terminal: "чёрный чёрный фон и белый белый текст, вообще нет цветов темы" =
+  PURE black bg + PURE white text, NO theme colors at all (= xterm's built-in
+  default theme, i.e. NO theme is being applied — not even getTerminalTheme's
+  #0d0d0d fallback).
+- Settings window LOST the glass transparency it had earlier (not slider-driven).
+- Terminal + Panel sliders do nothing.
+- ONLY the Interface (sidebar) slider works.
+
+Critical: "pure black + pure white + no colors" matches NO value my code can
+produce (themeOverride = theme color; getTerminalTheme fallback = #0d0d0d/#ccc).
+This means the running app is NOT executing my current code on those terminals —
+almost certainly HMR zombie xterm sessions (this module was hot-edited 6+ times,
+and it holds module-level session state + live xterm instances).
+
+### Unverified-until-now assumption (the real crack)
+
+"The running app reflects my current source." NEVER verified. Every fix was
+judged against a possibly-stale HMR state. Added [GLASS-DBG] console logging in
+glass.ts / TerminalView / InteractivePane to capture actual runtime values.
+
+### Experiment (awaiting user)
+
+1. FULLY quit `npm run tauri dev` (not Cmd+R) and relaunch — kills HMR zombies.
+2. Open the webview devtools console (right-click → Inspect).
+3. Toggle Transparency + drag each slider; report the `[GLASS-DBG]` lines.
+This tells us: what theme/background each terminal actually receives, and the
+real computed CSS vars — turning blind theorizing into observation.
+
+Removed all runtime WebGL machinery (session fields, load/dispose helpers,
+`applyTerminalGlass`, the per-pane transparency effect, the settings store
+imports in InteractivePane) and restored the original unconditional WebGL load.
+Kept `allowTransparency: true` + alpha baked into `xtermTheme.background`.
+tsc clean, 105 tests pass.
+
+### What the user actually wants
+
+"терминалу не получается вообще дать прозрачность ... он сейчас кажется даже
+потерял цвет который ему тема задает и просто чёрный фон показывает ... вот эти 2
+нижние опции ничего не делают" — the Terminal transparency slider should make the
+terminal background see-through (showing the frosted glass behind it) while
+keeping the theme colors; right now it does nothing and the terminal is black.
+
+### Success criteria
+
+Dragging "Terminal transparency" 0→100 visibly fades the terminal background from
+solid theme color to translucent (frosted glass shows through), text stays
+readable, and the theme colors are never lost.
+
+### Root cause of repeated failure
+
+Two compounding mistakes:
+
+1. **The real blocker (rounds 1–3):** interactive terminals get their background
+   from an explicit `themeOverride` ITheme built in `TerminalView` (solid
+   `colors.bg`). Every alpha mechanism I added elsewhere (getTerminalTheme
+   `--terminal-alpha`, the per-pane observer) was *bypassed* because themeOverride
+   takes precedence. Fixed in round 4 by baking alpha into `xtermTheme`.
+
+2. **The false assumption that made it worse (round 4):** I believed "WebGL
+   ignores `allowTransparency`, so glass mode must dispose the WebGL addon at
+   runtime and fall back to the DOM renderer." This is an outdated xterm-4.x
+   fact. **Disproved** by the installed addon source (see Evidence). Disposing
+   `WebglAddon` mid-session left the canvas in a broken state → solid black,
+   theme color gone. This webgl machinery is unnecessary AND harmful.
+
+### Evidence (decisive)
+
+`node_modules/@xterm/addon-webgl/lib/addon-webgl.js` (v0.20.0-beta, paired with
+`@xterm/xterm` 6.1.0-beta):
+
+```
+allowTransparency||(r=o.color.opaque(r))   // forces opaque ONLY when allowTransparency is false
+allowTransparency&&(_=o.color.opaque(_     // preserves alpha when allowTransparency is true
+allowTransparency?this._ctx.clearRect(...) // clears to transparent
+```
+
+→ WebGL honors transparency when `allowTransparency: true`. No renderer swap is
+needed. The disposal was the bug.
+
+### What's been tried
+
+#### Attempt 1: `getTerminalTheme` reads `--terminal-alpha`, converts hex→rgba
+- Hypothesis: terminal bg comes from `getTerminalTheme(el)` reading `--terminal-bg`.
+- Result: no change. **Signal:** interactive terminals don't use getTerminalTheme
+  for their visible bg — they use `themeOverride`.
+
+#### Attempt 2: per-pane effect + global observer re-applying getTerminalTheme
+- Result: no change. **Signal:** same bypass — themeOverride wins.
+
+#### Attempt 3: dispose WebGL on toggle + `applyTerminalGlass` over all sessions
+- Hypothesis: WebGL is opaque; force DOM renderer.
+- Result: no change first, then terminal went BLACK. **Signal:** disposing WebGL
+  mid-session breaks rendering; and WebGL was never the blocker.
+
+#### Attempt 4: bake alpha into `xtermTheme.background` in TerminalView
+- Hypothesis (correct part): the themeOverride is the real bg path.
+- Result: still black because the harmful WebGL disposal from attempt 3 remained.
+- **Signal:** the alpha path is right; the webgl machinery must be removed.
+
+### The fix (this round)
+
+- Keep `allowTransparency: true` on the interactive Terminal.
+- Keep alpha baked into `xtermTheme.background` (TerminalView `terminalThemeBackground`).
+- **Remove** all runtime WebGL machinery: `wantWebgl`, `webgl` session fields,
+  `loadWebglAddon`/`disposeWebglAddon` gating, `applyTerminalGlass`, and the
+  per-pane `[transparency, terminalTransparency]` effect. Restore the original
+  unconditional WebGL load. WebGL + allowTransparency + rgba bg just works.
+
+### Key files
+
+- `src/components/TerminalView.tsx` — builds `xtermTheme` (the themeOverride). THE bg path.
+- `src/components/InteractivePane.tsx` — `allowTransparency`, themeOverride effect, the webgl machinery to delete.
+- `src/glass.ts` — alpha mappings (terminal/chrome/panel).
+- `src/styles/globals.css` — glass CSS variables.
+- `src/components/Settings.tsx` — the three sliders + handlers.
+
+### Key constraints
+
+- DO NOT dispose/swap the WebGL addon at runtime — it breaks rendering.
+- Terminal alpha must flow through `themeOverride` (TerminalView), not getTerminalTheme.
+
+### Open secondary issue: "Panel transparency" slider appears to do nothing
+
+Likely because the Settings panels the user tested have no `--bg-secondary`/
+`--bg-primary` fill (they're border-only and already show glass-main). Revisit
+after the terminal fix: confirm which surfaces forms/config editors actually use.


### PR DESCRIPTION
> ⚠️ **EXPERIMENTAL — DO NOT MERGE WITHOUT MANUAL TESTING.**
> This touches the native transparent window + macOS vibrancy and CSS layering across the whole app. Needs a real click-through (especially on different window sizes and light/dark themes) before merging.

## Summary

Adds an opt-in **"Transparency (Experimental)"** toggle in General settings that gives the app a frosted *Liquid Glass* look: a native macOS window vibrancy (`NSVisualEffectView`) behind a transparent webview, controlled by two intensity sliders.

- **Sidebar transparency** — the app sidebar + the Settings menu (`--bg-sidebar`).
- **Panel transparency** — the content area: projects, settings, forms (`--bg-primary` / `--bg-secondary`).

Default off → app looks exactly as before.

## What's in scope

- `tauri.conf.json`: `transparent: true` + `macOSPrivateApi: true` on the main window.
- `Cargo.toml`: `window-vibrancy` crate + `macos-private-api` tauri feature.
- `mainwindow.rs`: `set_transparency` command (apply/clear `NSVisualEffectView`) + startup restore of the persisted setting.
- Frontend `glass.ts` + settings store fields (`transparency`, `interfaceTransparency`, `panelTransparency`), Settings UI sliders, and CSS variables driving the frosted surfaces.
- Fills the real window height (`height: 100%` chain instead of `100vh`) so a transparent window has no unpainted strip at the bottom.

## Intentionally NOT included (dead ends, documented)

- **Terminal transparency** — xterm's WebGL renderer cannot render a transparent canvas without breaking (empty terminal on cold start; black/no-theme with an rgba background). Proven and removed. See `documentation/liquid-glass/problem-memory.md`.
- **A separate "toolbar" glass bar** — fights the webview layering (color seams, gaps); the top zone is part of the content area and is covered by the Panel slider instead.

## Manual test checklist (before un-drafting)

- [ ] Toggle on/off — sidebar + content frost on, normal off.
- [ ] Both sliders visibly change their zones; Settings menu follows Panel only.
- [ ] No transparent strip at the window bottom at Panel 0%, across window resizes.
- [ ] Terminals render normally (themed, not black/empty) — cold start via full `tauri dev` restart, not just reload.
- [ ] Light + dark themes.
- [ ] Persists across restart; native vibrancy re-applies.
- [ ] Notable: `macOSPrivateApi` blocks Mac App Store distribution (fine — distributed via GitHub/updater).

## Notes

- `tsc --noEmit` clean; `vitest` green (alpha-mapping unit tests in `glass.test.ts`).
- Requires a Rust rebuild (new crate + window config) — full `tauri dev` restart, not hot reload.