### PR TITLE
feat(git): configurable pull/push/fetch modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ node_modules
 # OS
 .DS_Store
 secrets
+prompts
 prompts.superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ node_modules
 # OS
 .DS_Store
 secrets
-prompts
+prompts.superpowers/

--- a/desktop/frontend/bridge/commands.d.ts
+++ b/desktop/frontend/bridge/commands.d.ts
@@ -168,7 +168,6 @@ export function StopService(...args: any[]): Promise<any>;
 export function StopTTS(...args: any[]): Promise<any>;
 export function StopTerminal(...args: any[]): Promise<any>;
 export function StopWatchingProject(...args: any[]): Promise<any>;
-export function SyncBranch(...args: any[]): Promise<any>;
 export function TmuxInstalled(...args: any[]): Promise<any>;
 export function ToggleProjectService(...args: any[]): Promise<any>;
 export function TransformText(...args: any[]): Promise<any>;

--- a/desktop/frontend/bridge/commands.js
+++ b/desktop/frontend/bridge/commands.js
@@ -172,8 +172,8 @@ export function GitDiscardAll(cwd) {
 export function GitDiscardFiles(cwd, files) {
   return invoke("git_discard_files", { cwd, files });
 }
-export function GitFetchAll(cwd) {
-  return invoke("git_fetch_all", { cwd });
+export function GitFetchAll(cwd, flags) {
+  return invoke("git_fetch_all", { cwd, flags });
 }
 export function GitLogBranch(cwd, base) {
   return invoke("git_log_branch", { cwd, base });
@@ -184,8 +184,8 @@ export function GitMerge(cwd, branch) {
 export function GitMergeConflicts(cwd) {
   return invoke("git_merge_conflicts", { cwd });
 }
-export function GitPush(cwd) {
-  return invoke("git_push", { cwd });
+export function GitPush(cwd, flags) {
+  return invoke("git_push", { cwd, flags });
 }
 export function GitStatus(cwd) {
   return invoke("git_status", { cwd });
@@ -325,8 +325,8 @@ export function PlaySoundPreview(name, event) {
 export function PickAudioFile() {
   return invoke("pick_audio_file");
 }
-export function PullBranch(cwd, strategy) {
-  return invoke("pull_branch", { cwd, strategy });
+export function PullBranch(cwd, strategy, flags) {
+  return invoke("pull_branch", { cwd, strategy, flags });
 }
 export function ReadBranchNameInstructions() {
   return invoke("read_branch_name_instructions");
@@ -510,9 +510,6 @@ export function StopTTS() {
 }
 export function StopWatchingProject() {
   return invoke("stop_watching_project");
-}
-export function SyncBranch(cwd) {
-  return invoke("sync_branch", { cwd });
 }
 export function TmuxInstalled() {
   return invoke("tmux_installed");

--- a/desktop/frontend/src-tauri/src/generated_commands.rs
+++ b/desktop/frontend/src-tauri/src/generated_commands.rs
@@ -191,7 +191,6 @@ macro_rules! all_command_handlers {
         stop_terminal,
         stop_tts,
         stop_watching_project,
-        sync_branch,
         tmux_installed,
         toggle_project_service,
         transform_text,

--- a/desktop/frontend/src-tauri/src/git.rs
+++ b/desktop/frontend/src-tauri/src/git.rs
@@ -104,7 +104,7 @@ fn parse_ahead_behind(tail: &str) -> (i64, i64) {
 fn pull_args(strategy: &str) -> Vec<&'static str> {
     match strategy {
         "rebase" => vec!["pull", "--rebase"],
-        "merge" => vec!["pull", "--no-rebase"],
+        "ff" => vec!["pull"],
         _ => vec!["pull", "--ff-only"],
     }
 }
@@ -632,13 +632,20 @@ pub fn git_commit(cwd: String, message: String, files: Vec<String>) -> Result<()
 }
 
 #[tauri::command(async)]
-pub fn git_push(cwd: String) -> Result<(), String> {
-    git_out(&cwd, &["push", "-u", "origin", "HEAD"]).map(|_| ())
+pub fn git_push(cwd: String, flags: Vec<String>) -> Result<(), String> {
+    let mut args: Vec<String> = vec!["push".into()];
+    args.extend(flags);
+    args.extend(["-u", "origin", "HEAD"].iter().map(|s| s.to_string()));
+    let refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    git_out(&cwd, &refs).map(|_| ())
 }
 
 #[tauri::command(async)]
-pub fn git_fetch_all(cwd: String) -> Result<(), String> {
-    git_out(&cwd, &["fetch", "--all", "--prune"]).map(|_| ())
+pub fn git_fetch_all(cwd: String, flags: Vec<String>) -> Result<(), String> {
+    let mut args: Vec<String> = vec!["fetch".into()];
+    args.extend(flags);
+    let refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    git_out(&cwd, &refs).map(|_| ())
 }
 
 #[tauri::command(async)]
@@ -669,19 +676,11 @@ pub fn git_abort_merge(cwd: String) -> Result<(), String> {
 }
 
 #[tauri::command(async)]
-pub fn pull_branch(cwd: String, strategy: String) -> Result<(), String> {
-    git_out(&cwd, &pull_args(&strategy)).map(|_| ())
-}
-
-#[tauri::command(async)]
-pub fn sync_branch(cwd: String) -> Result<(), String> {
-    let strat = crate::config::load_settings()
-        .get("gitPullStrategy")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    pull_branch(cwd.clone(), strat)?;
-    git_out(&cwd, &["push"]).map(|_| ())
+pub fn pull_branch(cwd: String, strategy: String, flags: Vec<String>) -> Result<(), String> {
+    let mut args: Vec<String> = pull_args(&strategy).into_iter().map(String::from).collect();
+    args.extend(flags);
+    let refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    git_out(&cwd, &refs).map(|_| ())
 }
 
 // ---- gh / PR ----------------------------------------------------------------

--- a/desktop/frontend/src/components/BranchSwitcher.tsx
+++ b/desktop/frontend/src/components/BranchSwitcher.tsx
@@ -5,12 +5,27 @@ import {
   CreateBranch,
   DeleteBranch,
   GitDiscardAll,
+  GitFetchAll,
   GitPush,
   PullBranch,
   RenameBranch,
-  SyncBranch,
 } from "../../bridge/commands";
-import { getSettings, saveSettings, DEFAULT_PULL_STRATEGY, type GitPullStrategy } from "../store/settings";
+import { getSettings } from "../store/settings";
+import {
+  DEFAULT_PULL_CONFIG,
+  DEFAULT_PUSH_CONFIG,
+  DEFAULT_FETCH_CONFIG,
+  pullFlags,
+  pushFlags,
+  fetchFlags,
+  type GitPullConfig,
+  type GitPushConfig,
+  type GitFetchConfig,
+} from "../gitOptions";
+import { DrillMenu } from "./DrillMenu";
+import { PullSplitRow, pullConfigScreen } from "./pullMenu";
+import { PushSplitRow, pushConfigScreen } from "./pushMenu";
+import { FetchSplitRow, fetchConfigScreen } from "./fetchMenu";
 import { main } from "../../bridge/models";
 import { useOutsideClick } from "../hooks/useOutsideClick";
 import { useEventListener } from "../hooks/useEventListener";
@@ -21,14 +36,10 @@ import { CommitModal } from "./CommitModal";
 import { MergeBranchDialog } from "./MergeBranchDialog";
 import { PRModal } from "./PRModal";
 import { ConfirmDialog } from "./ui/ConfirmDialog";
-import { BranchIcon, ChevronLeftIcon, CloudBranchIcon, CopyIcon, PencilIcon, TrashIcon, UndoIcon } from "./icons";
+import { BranchIcon, CloudBranchIcon, CopyIcon, PencilIcon, TrashIcon, UndoIcon } from "./icons";
 import { branchKey, orderBranches, RemoteBadge } from "./branchUtils";
 import { relativeTime } from "../relativeTime";
 
-const PULL_STRATEGIES: { value: GitPullStrategy; label: string }[] = [
-  { value: "ff-only", label: "Pull" },
-  { value: "rebase", label: "Pull (Rebase)" },
-];
 
 export function BranchSwitcher({ projectName, projectPath, gitState }: {
   projectName: string;
@@ -45,31 +56,13 @@ export function BranchSwitcher({ projectName, projectPath, gitState }: {
   const [creatingPR, setCreatingPR] = useState(false);
   const [merging, setMerging] = useState(false);
   const [commitMenuOpen, setCommitMenuOpen] = useState(false);
-  const [pullMenuOpen, setPullMenuOpen] = useState(false);
   const [confirmDiscardAllOpen, setConfirmDiscardAllOpen] = useState(false);
   const [discarding, setDiscarding] = useState(false);
   const [renamingKey, setRenamingKey] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
   const [deletingBranch, setDeletingBranch] = useState<main.Branch | null>(null);
   const searchRef = useRef<HTMLInputElement>(null);
-  const pullCloseTimer = useRef<number | null>(null);
 
-  useEffect(() => () => {
-    if (pullCloseTimer.current) window.clearTimeout(pullCloseTimer.current);
-  }, []);
-
-  const openPullMenu = () => {
-    if (pullCloseTimer.current) {
-      window.clearTimeout(pullCloseTimer.current);
-      pullCloseTimer.current = null;
-    }
-    setPullMenuOpen(true);
-  };
-
-  const schedulePullClose = () => {
-    if (pullCloseTimer.current) window.clearTimeout(pullCloseTimer.current);
-    pullCloseTimer.current = window.setTimeout(() => setPullMenuOpen(false), 120);
-  };
   const commitMenuRef = useOutsideClick<HTMLDivElement>(
     () => setCommitMenuOpen(false),
     commitMenuOpen,
@@ -136,29 +129,12 @@ export function BranchSwitcher({ projectName, projectPath, gitState }: {
     setOpen(!open);
   };
 
-  const sync = async () => {
-    if (busy) return;
-    setBusy(true);
-    try {
-      await SyncBranch(projectPath);
-      await refresh();
-    } catch (err) {
-      toast.error(`Sync: ${err}`);
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const pull = async (strategy: GitPullStrategy) => {
+  const runPull = async (cfg: GitPullConfig) => {
     if (busy) return;
     setCommitMenuOpen(false);
-    setPullMenuOpen(false);
-    if (strategy !== (getSettings().gitPullStrategy ?? DEFAULT_PULL_STRATEGY)) {
-      void saveSettings({ gitPullStrategy: strategy });
-    }
     setBusy(true);
     try {
-      await PullBranch(projectPath, strategy);
+      await PullBranch(projectPath, cfg.strategy, pullFlags(cfg));
       await refresh();
     } catch (err) {
       toast.error(`Pull: ${err}`);
@@ -167,12 +143,14 @@ export function BranchSwitcher({ projectName, projectPath, gitState }: {
     }
   };
 
-  const push = async () => {
+  const runPullDefault = () => runPull(getSettings().gitPull ?? DEFAULT_PULL_CONFIG);
+
+  const runPush = async (cfg: GitPushConfig) => {
     if (busy) return;
     setCommitMenuOpen(false);
     setBusy(true);
     try {
-      await GitPush(projectPath);
+      await GitPush(projectPath, pushFlags(cfg));
       await refresh();
       toast.success("Pushed");
     } catch (err) {
@@ -180,6 +158,47 @@ export function BranchSwitcher({ projectName, projectPath, gitState }: {
     } finally {
       setBusy(false);
     }
+  };
+
+  const runPushDefault = () => runPush(getSettings().gitPush ?? DEFAULT_PUSH_CONFIG);
+
+  const runFetch = async (cfg: GitFetchConfig) => {
+    if (busy) return;
+    setCommitMenuOpen(false);
+    setBusy(true);
+    try {
+      await GitFetchAll(projectPath, fetchFlags(cfg));
+      await refresh();
+      toast.success("Fetched");
+    } catch (err) {
+      toast.error(`Fetch: ${err}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const runFetchDefault = () => runFetch(getSettings().gitFetch ?? DEFAULT_FETCH_CONFIG);
+
+  const runSync = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const pull = getSettings().gitPull ?? DEFAULT_PULL_CONFIG;
+      const push = getSettings().gitPush ?? DEFAULT_PUSH_CONFIG;
+      await PullBranch(projectPath, pull.strategy, pullFlags(pull));
+      await GitPush(projectPath, pushFlags(push));
+      await refresh();
+    } catch (err) {
+      toast.error(`Sync: ${err}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const syncToolbarAction = () => {
+    if (status.behind > 0 && status.ahead > 0) return runSync();
+    if (status.behind > 0) return runPullDefault();
+    return runPushDefault();
   };
 
   const handleDiscardAll = async () => {
@@ -249,7 +268,7 @@ export function BranchSwitcher({ projectName, projectPath, gitState }: {
     <div className="flex items-center gap-1">
       {needsSync && (
         <button
-          onClick={sync}
+          onClick={syncToolbarAction}
           disabled={busy}
           title={busy ? "Syncing…" : `Pull ${status.behind}, push ${status.ahead}`}
           className="flex items-center gap-1 rounded-md border border-[var(--border)] bg-[var(--bg-secondary)] px-2.5 py-1 text-[11px] font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-40"
@@ -425,55 +444,63 @@ export function BranchSwitcher({ projectName, projectPath, gitState }: {
           <ChevronDown />
         </button>
         {commitMenuOpen && (
-          <div className="absolute bottom-full right-0 z-10 mb-2 w-72 overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--bg-primary)] py-1.5 shadow-2xl">
-            <button
-              onClick={() => { setCommitMenuOpen(false); setCommitting(true); }}
-              disabled={status.uncommitted === 0}
-              className="flex w-full items-center gap-2.5 px-4 py-2 text-left text-[13px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-40"
-            >
-              <CommitIcon size={14} />
-              Commit
-            </button>
-            <PullMenu
-              busy={busy}
-              currentStrategy={getSettings().gitPullStrategy ?? DEFAULT_PULL_STRATEGY}
-              open={pullMenuOpen}
-              onOpen={openPullMenu}
-              onScheduleClose={schedulePullClose}
-              onPull={pull}
+          <div className="absolute bottom-full right-0 z-10 mb-2">
+            <DrillMenu
+              root={{
+                render: (api) => (
+                  <>
+                    <button
+                      onClick={() => { setCommitMenuOpen(false); setCommitting(true); }}
+                      disabled={status.uncommitted === 0}
+                      className="flex w-full items-center gap-2.5 px-4 py-2 text-left text-[13px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-40"
+                    >
+                      <CommitIcon size={14} />
+                      Commit
+                    </button>
+                    <PullSplitRow
+                      busy={busy}
+                      onRun={runPullDefault}
+                      onConfigure={() => api.push(pullConfigScreen({ busy, onRun: runPullDefault }))}
+                    />
+                    <PushSplitRow
+                      busy={busy}
+                      onRun={runPushDefault}
+                      onConfigure={() => api.push(pushConfigScreen({ busy, onRun: runPushDefault }))}
+                    />
+                    <FetchSplitRow
+                      busy={busy}
+                      onRun={runFetchDefault}
+                      onConfigure={() => api.push(fetchConfigScreen({ busy, onRun: runFetchDefault }))}
+                    />
+                    <button
+                      onClick={() => { setCommitMenuOpen(false); setCreatingPR(true); }}
+                      className="flex w-full items-center gap-2.5 px-4 py-2 text-left text-[13px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+                    >
+                      <PRMenuIcon />
+                      Create PR
+                    </button>
+                    <button
+                      onClick={() => { setCommitMenuOpen(false); setMerging(true); }}
+                      disabled={busy}
+                      className="flex w-full items-center gap-2.5 px-4 py-2 text-left text-[13px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      <MergeMenuIcon />
+                      Merge
+                    </button>
+                    <div className="my-1.5 border-t border-[var(--border)]" />
+                    <button
+                      onClick={() => { setCommitMenuOpen(false); setConfirmDiscardAllOpen(true); }}
+                      disabled={status.uncommitted === 0}
+                      className="flex w-full items-center gap-2.5 px-4 py-2 text-left text-[13px] text-[var(--accent-red)] transition-colors hover:bg-[var(--bg-hover)] disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      <UndoIcon />
+                      Discard all changes
+                    </button>
+                  </>
+                ),
+              }}
+              onClose={() => setCommitMenuOpen(false)}
             />
-            <button
-              onClick={push}
-              disabled={busy}
-              className="flex w-full items-center gap-2.5 px-4 py-2 text-left text-[13px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-40"
-            >
-              <PushIcon />
-              Push
-            </button>
-            <button
-              onClick={() => { setCommitMenuOpen(false); setCreatingPR(true); }}
-              className="flex w-full items-center gap-2.5 px-4 py-2 text-left text-[13px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
-            >
-              <PRMenuIcon />
-              Create PR
-            </button>
-            <button
-              onClick={() => { setCommitMenuOpen(false); setMerging(true); }}
-              disabled={busy}
-              className="flex w-full items-center gap-2.5 px-4 py-2 text-left text-[13px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:cursor-not-allowed disabled:opacity-40"
-            >
-              <MergeMenuIcon />
-              Merge
-            </button>
-            <div className="my-1.5 border-t border-[var(--border)]" />
-            <button
-              onClick={() => { setCommitMenuOpen(false); setConfirmDiscardAllOpen(true); }}
-              disabled={status.uncommitted === 0}
-              className="flex w-full items-center gap-2.5 px-4 py-2 text-left text-[13px] text-[var(--accent-red)] transition-colors hover:bg-[var(--bg-hover)] disabled:cursor-not-allowed disabled:opacity-40"
-            >
-              <UndoIcon />
-              Discard all changes
-            </button>
           </div>
         )}
       </div>
@@ -596,13 +623,6 @@ function ChevronDown() {
   );
 }
 
-function CheckIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="mt-0.5 shrink-0 text-[var(--text-primary)]">
-      <polyline points="20 6 9 17 4 12" />
-    </svg>
-  );
-}
 
 function CommitIcon({ size = 12 }: { size?: number } = {}) {
   return (
@@ -646,76 +666,3 @@ function PlusIcon() {
   );
 }
 
-function PullIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M12 4v11" />
-      <polyline points="7 10 12 15 17 10" />
-      <line x1="5" y1="20" x2="19" y2="20" />
-    </svg>
-  );
-}
-
-function PushIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <line x1="5" y1="4" x2="19" y2="4" />
-      <path d="M12 9v11" />
-      <polyline points="7 14 12 9 17 14" />
-    </svg>
-  );
-}
-
-function PullMenu({
-  busy,
-  currentStrategy,
-  open,
-  onOpen,
-  onScheduleClose,
-  onPull,
-}: {
-  busy: boolean;
-  currentStrategy: GitPullStrategy;
-  open: boolean;
-  onOpen: () => void;
-  onScheduleClose: () => void;
-  onPull: (strategy: GitPullStrategy) => void;
-}) {
-  const currentLabel =
-    PULL_STRATEGIES.find((s) => s.value === currentStrategy)?.label ?? "Pull";
-  return (
-    <div className="relative" onMouseEnter={onOpen} onMouseLeave={onScheduleClose}>
-      <button
-        onClick={() => onPull(currentStrategy)}
-        disabled={busy}
-        className="flex w-full items-center gap-2.5 px-4 py-2 text-left text-[13px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-40"
-      >
-        <PullIcon />
-        {currentLabel}
-        <span className="ml-auto flex text-[var(--text-muted)]"><ChevronLeftIcon /></span>
-      </button>
-      {open && (
-        <div
-          onMouseEnter={onOpen}
-          onMouseLeave={onScheduleClose}
-          className="absolute right-full bottom-0 mr-1 w-56 overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--bg-primary)] py-1.5 shadow-2xl"
-        >
-          {PULL_STRATEGIES.map((opt) => {
-            const active = currentStrategy === opt.value;
-            return (
-              <button
-                key={opt.value}
-                onClick={() => onPull(opt.value)}
-                disabled={busy}
-                className="flex w-full items-center gap-2.5 px-4 py-2 text-left text-[13px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-40"
-              >
-                <span className="flex w-3.5 shrink-0">{active && <CheckIcon />}</span>
-                <span className={active ? "text-[var(--text-primary)]" : ""}>{opt.label}</span>
-              </button>
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
-}

--- a/desktop/frontend/src/components/DrillMenu.tsx
+++ b/desktop/frontend/src/components/DrillMenu.tsx
@@ -1,0 +1,48 @@
+import { useState, type ReactNode } from "react";
+import { ChevronLeftIcon } from "./icons";
+
+export interface DrillApi {
+  push: (screen: DrillScreen) => void;
+  pop: () => void;
+  close: () => void;
+}
+
+export interface DrillScreen {
+  title?: string;
+  render: (api: DrillApi) => ReactNode;
+}
+
+export function DrillMenu({
+  root,
+  onClose,
+}: {
+  root: DrillScreen;
+  onClose: () => void;
+}) {
+  const [stack, setStack] = useState<DrillScreen[]>([]);
+  const api: DrillApi = {
+    push: (screen) => setStack((s) => [...s, screen]),
+    pop: () => setStack((s) => s.slice(0, -1)),
+    close: onClose,
+  };
+  const screen = stack.length ? stack[stack.length - 1] : root;
+  const drilled = stack.length > 0;
+  return (
+    <div className="w-72 overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--bg-primary)] py-1.5 shadow-2xl">
+      {drilled && (
+        <div className="mb-1 flex items-center gap-2 border-b border-[var(--border)] px-2 pb-1.5">
+          <button
+            onClick={api.pop}
+            className="flex h-6 w-6 items-center justify-center rounded-md text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+          >
+            <ChevronLeftIcon />
+          </button>
+          <span className="text-[12.5px] font-medium text-[var(--text-primary)]">
+            {screen.title}
+          </span>
+        </div>
+      )}
+      {screen.render(api)}
+    </div>
+  );
+}

--- a/desktop/frontend/src/components/FlagRow.tsx
+++ b/desktop/frontend/src/components/FlagRow.tsx
@@ -1,0 +1,35 @@
+import { CheckIcon } from "./icons";
+
+export function FlagRow({
+  label,
+  flag,
+  checked,
+  onToggle,
+  disabled = false,
+}: {
+  label: string;
+  flag: string;
+  checked: boolean;
+  onToggle: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      onClick={onToggle}
+      disabled={disabled}
+      className="flex w-full items-center gap-2.5 px-4 py-2 text-left text-[13px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-40"
+    >
+      <span
+        className={`flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded border ${
+          checked
+            ? "border-[var(--accent-green)] bg-[var(--accent-green)] text-white"
+            : "border-[var(--border)]"
+        }`}
+      >
+        {checked && <CheckIcon />}
+      </span>
+      <span className={checked ? "text-[var(--text-primary)]" : ""}>{label}</span>
+      <span className="ml-auto font-mono text-[11px] text-[var(--text-muted)]">{flag}</span>
+    </button>
+  );
+}

--- a/desktop/frontend/src/components/MenuSplitRow.tsx
+++ b/desktop/frontend/src/components/MenuSplitRow.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+import { ChevronRightIcon } from "./icons";
+
+export function MenuSplitRow({
+  icon,
+  label,
+  onRun,
+  onConfigure,
+  disabled = false,
+}: {
+  icon: ReactNode;
+  label: ReactNode;
+  onRun: () => void;
+  onConfigure: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="flex items-center">
+      <button
+        onClick={onRun}
+        disabled={disabled}
+        className="flex flex-1 items-center gap-2.5 px-4 py-2 text-left text-[13px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-40"
+      >
+        {icon}
+        {label}
+      </button>
+      <button
+        onClick={onConfigure}
+        disabled={disabled}
+        title="Configure"
+        className="flex items-center border-l border-[var(--border)] px-3 py-2 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-40"
+      >
+        <ChevronRightIcon />
+      </button>
+    </div>
+  );
+}

--- a/desktop/frontend/src/components/ProjectGitSubmenu.tsx
+++ b/desktop/frontend/src/components/ProjectGitSubmenu.tsx
@@ -20,6 +20,15 @@ import {
   PullBranch,
 } from "../../bridge/commands";
 import { main } from "../../bridge/models";
+import { getSettings } from "../store/settings";
+import {
+  DEFAULT_PULL_CONFIG,
+  DEFAULT_PUSH_CONFIG,
+  DEFAULT_FETCH_CONFIG,
+  pullFlags,
+  pushFlags,
+  fetchFlags,
+} from "../gitOptions";
 
 interface ProjectGitSubmenuProps {
   projectPath: string | null;
@@ -138,22 +147,32 @@ function GitSubmenuItems({
       <ContextMenuItem
         label="Pull"
         icon={<DownloadIcon />}
-        onClick={() => runOp("Pulling…", "Pulled", "Pull", () => PullBranch(projectPath, "ff-only"))}
-      />
-      <ContextMenuItem
-        label="Pull (Rebase)"
-        icon={<DownloadIcon />}
-        onClick={() => runOp("Pulling…", "Pulled", "Pull", () => PullBranch(projectPath, "rebase"))}
+        onClick={() =>
+          runOp("Pulling…", "Pulled", "Pull", () => {
+            const cfg = getSettings().gitPull ?? DEFAULT_PULL_CONFIG;
+            return PullBranch(projectPath, cfg.strategy, pullFlags(cfg));
+          })
+        }
       />
       <ContextMenuItem
         label="Push"
         icon={<UploadIcon />}
-        onClick={() => runOp("Pushing…", "Pushed", "Push", () => GitPush(projectPath))}
+        onClick={() =>
+          runOp("Pushing…", "Pushed", "Push", () => {
+            const cfg = getSettings().gitPush ?? DEFAULT_PUSH_CONFIG;
+            return GitPush(projectPath, pushFlags(cfg));
+          })
+        }
       />
       <ContextMenuItem
         label="Fetch"
         icon={<RefreshIcon />}
-        onClick={() => runOp("Fetching…", "Fetched", "Fetch", () => GitFetchAll(projectPath))}
+        onClick={() =>
+          runOp("Fetching…", "Fetched", "Fetch", () => {
+            const cfg = getSettings().gitFetch ?? DEFAULT_FETCH_CONFIG;
+            return GitFetchAll(projectPath, fetchFlags(cfg));
+          })
+        }
       />
       <ContextMenuSeparator />
       <ContextMenuItem label="Switch branch…" icon={<BranchIcon size={14} />} onClick={close(onSwitchBranch)} />

--- a/desktop/frontend/src/components/fetchMenu.tsx
+++ b/desktop/frontend/src/components/fetchMenu.tsx
@@ -1,0 +1,78 @@
+import { useSettingsStore, saveSettings } from "../store/settings";
+import { DEFAULT_FETCH_CONFIG, type GitFetchConfig } from "../gitOptions";
+import { RefreshIcon } from "./icons";
+import { MenuSplitRow } from "./MenuSplitRow";
+import { FlagRow } from "./FlagRow";
+import type { DrillScreen } from "./DrillMenu";
+
+export function FetchSplitRow({
+  busy,
+  onRun,
+  onConfigure,
+}: {
+  busy: boolean;
+  onRun: () => void;
+  onConfigure: () => void;
+}) {
+  return (
+    <MenuSplitRow
+      icon={<RefreshIcon />}
+      label="Fetch"
+      onRun={onRun}
+      onConfigure={onConfigure}
+      disabled={busy}
+    />
+  );
+}
+
+function FetchConfigBody({ busy, onRun }: { busy: boolean; onRun: () => void }) {
+  const cfg = useSettingsStore((s) => s.gitFetch) ?? DEFAULT_FETCH_CONFIG;
+  const patch = (p: Partial<GitFetchConfig>) =>
+    void saveSettings({ gitFetch: { ...cfg, ...p } });
+  return (
+    <>
+      <FlagRow
+        label="All remotes"
+        flag="--all"
+        checked={cfg.all}
+        onToggle={() => patch({ all: !cfg.all })}
+        disabled={busy}
+      />
+      <FlagRow
+        label="Prune"
+        flag="--prune"
+        checked={cfg.prune}
+        onToggle={() => patch({ prune: !cfg.prune })}
+        disabled={busy}
+      />
+      <FlagRow
+        label="Prune tags"
+        flag="--prune-tags"
+        checked={cfg.pruneTags}
+        onToggle={() => patch({ pruneTags: !cfg.pruneTags })}
+        disabled={busy}
+      />
+      <FlagRow
+        label="Tags"
+        flag="--tags"
+        checked={cfg.tags}
+        onToggle={() => patch({ tags: !cfg.tags })}
+        disabled={busy}
+      />
+      <button
+        onClick={onRun}
+        disabled={busy}
+        className="mt-1 flex w-full items-center justify-center px-4 py-2 text-[13px] font-medium text-[var(--accent-green)] transition-colors hover:bg-[var(--bg-hover)] disabled:opacity-40"
+      >
+        Run fetch
+      </button>
+    </>
+  );
+}
+
+export function fetchConfigScreen(opts: { busy: boolean; onRun: () => void }): DrillScreen {
+  return {
+    title: "Fetch",
+    render: () => <FetchConfigBody busy={opts.busy} onRun={opts.onRun} />,
+  };
+}

--- a/desktop/frontend/src/components/pullMenu.tsx
+++ b/desktop/frontend/src/components/pullMenu.tsx
@@ -1,0 +1,129 @@
+import { useSettingsStore, saveSettings } from "../store/settings";
+import {
+  DEFAULT_PULL_CONFIG,
+  PULL_STRATEGIES,
+  PULL_STRATEGY_LABELS,
+  type GitPullConfig,
+  type PullStrategy,
+} from "../gitOptions";
+import { CheckIcon, ChevronRightIcon, DownloadIcon } from "./icons";
+import { MenuSplitRow } from "./MenuSplitRow";
+import { FlagRow } from "./FlagRow";
+import type { DrillApi, DrillScreen } from "./DrillMenu";
+
+export function PullSplitRow({
+  busy,
+  onRun,
+  onConfigure,
+}: {
+  busy: boolean;
+  onRun: () => void;
+  onConfigure: () => void;
+}) {
+  const cfg = useSettingsStore((s) => s.gitPull) ?? DEFAULT_PULL_CONFIG;
+  return (
+    <MenuSplitRow
+      icon={<DownloadIcon />}
+      label={PULL_STRATEGY_LABELS[cfg.strategy]}
+      onRun={onRun}
+      onConfigure={onConfigure}
+      disabled={busy}
+    />
+  );
+}
+
+function PullConfigBody({
+  busy,
+  onRun,
+  onAdvanced,
+}: {
+  busy: boolean;
+  onRun: () => void;
+  onAdvanced: () => void;
+}) {
+  const cfg = useSettingsStore((s) => s.gitPull) ?? DEFAULT_PULL_CONFIG;
+  const setStrategy = (strategy: PullStrategy) =>
+    void saveSettings({ gitPull: { ...cfg, strategy } });
+  return (
+    <>
+      <div className="px-4 pb-1 pt-1 text-[10px] font-medium uppercase tracking-wide text-[var(--text-muted)]">
+        Default on click
+      </div>
+      {PULL_STRATEGIES.map((s) => {
+        const active = cfg.strategy === s;
+        return (
+          <button
+            key={s}
+            onClick={() => setStrategy(s)}
+            disabled={busy}
+            className="flex w-full items-center gap-2.5 px-4 py-2 text-left text-[13px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-40"
+          >
+            <span className="flex w-3.5 shrink-0">{active && <CheckIcon />}</span>
+            <span className={active ? "text-[var(--text-primary)]" : ""}>
+              {PULL_STRATEGY_LABELS[s]}
+            </span>
+          </button>
+        );
+      })}
+      <div className="my-1 border-t border-[var(--border)]" />
+      <button
+        onClick={onAdvanced}
+        className="flex w-full items-center gap-2.5 px-4 py-2 text-left text-[13px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+      >
+        Advanced flags
+        <span className="ml-auto flex text-[var(--text-muted)]">
+          <ChevronRightIcon />
+        </span>
+      </button>
+      <button
+        onClick={onRun}
+        disabled={busy}
+        className="mt-1 flex w-full items-center justify-center px-4 py-2 text-[13px] font-medium text-[var(--accent-green)] transition-colors hover:bg-[var(--bg-hover)] disabled:opacity-40"
+      >
+        Run pull
+      </button>
+    </>
+  );
+}
+
+function PullAdvancedBody({ busy }: { busy: boolean }) {
+  const cfg = useSettingsStore((s) => s.gitPull) ?? DEFAULT_PULL_CONFIG;
+  const patch = (p: Partial<GitPullConfig>) =>
+    void saveSettings({ gitPull: { ...cfg, ...p } });
+  return (
+    <>
+      <FlagRow
+        label="Autostash"
+        flag="--autostash"
+        checked={cfg.autostash}
+        onToggle={() => patch({ autostash: !cfg.autostash })}
+        disabled={busy}
+      />
+      <FlagRow
+        label="No verify"
+        flag="--no-verify"
+        checked={cfg.noVerify}
+        onToggle={() => patch({ noVerify: !cfg.noVerify })}
+        disabled={busy}
+      />
+    </>
+  );
+}
+
+export function pullConfigScreen(opts: { busy: boolean; onRun: () => void }): DrillScreen {
+  return {
+    title: "Pull",
+    render: (api: DrillApi) => (
+      <PullConfigBody
+        busy={opts.busy}
+        onRun={opts.onRun}
+        onAdvanced={() =>
+          api.push({
+            title: "Pull · Advanced",
+            render: () => <PullAdvancedBody busy={opts.busy} />,
+          })
+        }
+      />
+    ),
+  };
+}

--- a/desktop/frontend/src/components/pushMenu.tsx
+++ b/desktop/frontend/src/components/pushMenu.tsx
@@ -1,0 +1,128 @@
+import { useSettingsStore, saveSettings } from "../store/settings";
+import {
+  DEFAULT_PUSH_CONFIG,
+  PUSH_MODES,
+  PUSH_MODE_LABELS,
+  type GitPushConfig,
+  type PushMode,
+} from "../gitOptions";
+import { CheckIcon, ChevronRightIcon, UploadIcon } from "./icons";
+import { MenuSplitRow } from "./MenuSplitRow";
+import { FlagRow } from "./FlagRow";
+import type { DrillApi, DrillScreen } from "./DrillMenu";
+
+export function PushSplitRow({
+  busy,
+  onRun,
+  onConfigure,
+}: {
+  busy: boolean;
+  onRun: () => void;
+  onConfigure: () => void;
+}) {
+  const cfg = useSettingsStore((s) => s.gitPush) ?? DEFAULT_PUSH_CONFIG;
+  return (
+    <MenuSplitRow
+      icon={<UploadIcon />}
+      label={PUSH_MODE_LABELS[cfg.mode]}
+      onRun={onRun}
+      onConfigure={onConfigure}
+      disabled={busy}
+    />
+  );
+}
+
+function PushConfigBody({
+  busy,
+  onRun,
+  onAdvanced,
+}: {
+  busy: boolean;
+  onRun: () => void;
+  onAdvanced: () => void;
+}) {
+  const cfg = useSettingsStore((s) => s.gitPush) ?? DEFAULT_PUSH_CONFIG;
+  const setMode = (mode: PushMode) => void saveSettings({ gitPush: { ...cfg, mode } });
+  return (
+    <>
+      <div className="px-4 pb-1 pt-1 text-[10px] font-medium uppercase tracking-wide text-[var(--text-muted)]">
+        Default on click
+      </div>
+      {PUSH_MODES.map((m) => {
+        const active = cfg.mode === m;
+        return (
+          <button
+            key={m}
+            onClick={() => setMode(m)}
+            disabled={busy}
+            className="flex w-full items-center gap-2.5 px-4 py-2 text-left text-[13px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-40"
+          >
+            <span className="flex w-3.5 shrink-0">{active && <CheckIcon />}</span>
+            <span className={active ? "text-[var(--text-primary)]" : ""}>
+              {PUSH_MODE_LABELS[m]}
+            </span>
+          </button>
+        );
+      })}
+      <div className="my-1 border-t border-[var(--border)]" />
+      <button
+        onClick={onAdvanced}
+        className="flex w-full items-center gap-2.5 px-4 py-2 text-left text-[13px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+      >
+        Advanced flags
+        <span className="ml-auto flex text-[var(--text-muted)]">
+          <ChevronRightIcon />
+        </span>
+      </button>
+      <button
+        onClick={onRun}
+        disabled={busy}
+        className="mt-1 flex w-full items-center justify-center px-4 py-2 text-[13px] font-medium text-[var(--accent-green)] transition-colors hover:bg-[var(--bg-hover)] disabled:opacity-40"
+      >
+        Run push
+      </button>
+    </>
+  );
+}
+
+function PushAdvancedBody({ busy }: { busy: boolean }) {
+  const cfg = useSettingsStore((s) => s.gitPush) ?? DEFAULT_PUSH_CONFIG;
+  const patch = (p: Partial<GitPushConfig>) =>
+    void saveSettings({ gitPush: { ...cfg, ...p } });
+  return (
+    <>
+      <FlagRow
+        label="No verify"
+        flag="--no-verify"
+        checked={cfg.noVerify}
+        onToggle={() => patch({ noVerify: !cfg.noVerify })}
+        disabled={busy}
+      />
+      <FlagRow
+        label="Push tags"
+        flag="--tags"
+        checked={cfg.tags}
+        onToggle={() => patch({ tags: !cfg.tags })}
+        disabled={busy}
+      />
+    </>
+  );
+}
+
+export function pushConfigScreen(opts: { busy: boolean; onRun: () => void }): DrillScreen {
+  return {
+    title: "Push",
+    render: (api: DrillApi) => (
+      <PushConfigBody
+        busy={opts.busy}
+        onRun={opts.onRun}
+        onAdvanced={() =>
+          api.push({
+            title: "Push · Advanced",
+            render: () => <PushAdvancedBody busy={opts.busy} />,
+          })
+        }
+      />
+    ),
+  };
+}

--- a/desktop/frontend/src/gitOptions.test.ts
+++ b/desktop/frontend/src/gitOptions.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import {
+  pullFlags,
+  pushFlags,
+  fetchFlags,
+  normalizeGitPull,
+  normalizeGitPush,
+  normalizeGitFetch,
+  DEFAULT_PULL_CONFIG,
+  DEFAULT_PUSH_CONFIG,
+  DEFAULT_FETCH_CONFIG,
+} from "./gitOptions";
+
+describe("pullFlags", () => {
+  it("returns nothing when no flags set", () => {
+    expect(pullFlags(DEFAULT_PULL_CONFIG)).toEqual([]);
+  });
+  it("emits autostash and no-verify in order", () => {
+    expect(pullFlags({ strategy: "rebase", autostash: true, noVerify: true })).toEqual([
+      "--autostash",
+      "--no-verify",
+    ]);
+  });
+});
+
+describe("pushFlags", () => {
+  it("returns nothing for the default push", () => {
+    expect(pushFlags(DEFAULT_PUSH_CONFIG)).toEqual([]);
+  });
+  it("emits force-with-lease, no-verify, tags", () => {
+    expect(pushFlags({ mode: "force-with-lease", noVerify: true, tags: true })).toEqual([
+      "--force-with-lease",
+      "--no-verify",
+      "--tags",
+    ]);
+  });
+});
+
+describe("normalizeGitPull", () => {
+  it("falls back to ff when nothing is stored", () => {
+    expect(normalizeGitPull(undefined, undefined)).toEqual({
+      strategy: "ff",
+      autostash: false,
+      noVerify: false,
+    });
+  });
+  it("migrates a legacy ff-only strategy string", () => {
+    expect(normalizeGitPull(undefined, "ff-only").strategy).toBe("ff-only");
+  });
+  it("migrates a legacy rebase strategy string", () => {
+    expect(normalizeGitPull(undefined, "rebase").strategy).toBe("rebase");
+  });
+  it("maps an unknown legacy value (merge) to the default", () => {
+    expect(normalizeGitPull(undefined, "merge").strategy).toBe("ff");
+  });
+  it("prefers the new object over the legacy string and coerces booleans", () => {
+    expect(normalizeGitPull({ strategy: "rebase", autostash: 1 }, "ff-only")).toEqual({
+      strategy: "rebase",
+      autostash: true,
+      noVerify: false,
+    });
+  });
+});
+
+describe("normalizeGitPush", () => {
+  it("defaults to a plain push", () => {
+    expect(normalizeGitPush(undefined)).toEqual({
+      mode: "default",
+      noVerify: false,
+      tags: false,
+    });
+  });
+  it("keeps a valid force-with-lease mode", () => {
+    expect(normalizeGitPush({ mode: "force-with-lease", tags: true })).toEqual({
+      mode: "force-with-lease",
+      noVerify: false,
+      tags: true,
+    });
+  });
+});
+
+describe("fetchFlags", () => {
+  it("emits all and prune for the default fetch", () => {
+    expect(fetchFlags(DEFAULT_FETCH_CONFIG)).toEqual(["--all", "--prune"]);
+  });
+  it("emits every flag in order when all are on", () => {
+    expect(fetchFlags({ all: true, prune: true, pruneTags: true, tags: true })).toEqual([
+      "--all",
+      "--prune",
+      "--prune-tags",
+      "--tags",
+    ]);
+  });
+  it("emits nothing when everything is off", () => {
+    expect(fetchFlags({ all: false, prune: false, pruneTags: false, tags: false })).toEqual([]);
+  });
+});
+
+describe("normalizeGitFetch", () => {
+  it("defaults all and prune to on, tags off", () => {
+    expect(normalizeGitFetch(undefined)).toEqual({
+      all: true,
+      prune: true,
+      pruneTags: false,
+      tags: false,
+    });
+  });
+  it("preserves explicit false for all and prune", () => {
+    expect(normalizeGitFetch({ all: false, prune: false })).toEqual({
+      all: false,
+      prune: false,
+      pruneTags: false,
+      tags: false,
+    });
+  });
+  it("coerces truthy values to booleans", () => {
+    expect(normalizeGitFetch({ tags: 1, pruneTags: "yes" })).toEqual({
+      all: true,
+      prune: true,
+      pruneTags: true,
+      tags: true,
+    });
+  });
+});

--- a/desktop/frontend/src/gitOptions.ts
+++ b/desktop/frontend/src/gitOptions.ts
@@ -1,0 +1,121 @@
+export const PULL_STRATEGIES = ["ff", "ff-only", "rebase"] as const;
+export type PullStrategy = (typeof PULL_STRATEGIES)[number];
+export const DEFAULT_PULL_STRATEGY: PullStrategy = "ff";
+
+export const PUSH_MODES = ["default", "force-with-lease"] as const;
+export type PushMode = (typeof PUSH_MODES)[number];
+export const DEFAULT_PUSH_MODE: PushMode = "default";
+
+export interface GitFetchConfig {
+  all: boolean;
+  prune: boolean;
+  pruneTags: boolean;
+  tags: boolean;
+}
+
+export const DEFAULT_FETCH_CONFIG: GitFetchConfig = {
+  all: true,
+  prune: true,
+  pruneTags: false,
+  tags: false,
+};
+
+export interface GitPullConfig {
+  strategy: PullStrategy;
+  autostash: boolean;
+  noVerify: boolean;
+}
+
+export interface GitPushConfig {
+  mode: PushMode;
+  noVerify: boolean;
+  tags: boolean;
+}
+
+export const DEFAULT_PULL_CONFIG: GitPullConfig = {
+  strategy: DEFAULT_PULL_STRATEGY,
+  autostash: false,
+  noVerify: false,
+};
+
+export const DEFAULT_PUSH_CONFIG: GitPushConfig = {
+  mode: DEFAULT_PUSH_MODE,
+  noVerify: false,
+  tags: false,
+};
+
+export const PULL_STRATEGY_LABELS: Record<PullStrategy, string> = {
+  ff: "Pull (ff if possible)",
+  "ff-only": "Pull (ff-only)",
+  rebase: "Pull (rebase)",
+};
+
+export const PUSH_MODE_LABELS: Record<PushMode, string> = {
+  default: "Push",
+  "force-with-lease": "Push (force-with-lease)",
+};
+
+function isPullStrategy(v: unknown): v is PullStrategy {
+  return typeof v === "string" && (PULL_STRATEGIES as readonly string[]).includes(v);
+}
+
+function isPushMode(v: unknown): v is PushMode {
+  return typeof v === "string" && (PUSH_MODES as readonly string[]).includes(v);
+}
+
+export function pullFlags(config: GitPullConfig): string[] {
+  const flags: string[] = [];
+  if (config.autostash) flags.push("--autostash");
+  if (config.noVerify) flags.push("--no-verify");
+  return flags;
+}
+
+export function pushFlags(config: GitPushConfig): string[] {
+  const flags: string[] = [];
+  if (config.mode === "force-with-lease") flags.push("--force-with-lease");
+  if (config.noVerify) flags.push("--no-verify");
+  if (config.tags) flags.push("--tags");
+  return flags;
+}
+
+export function fetchFlags(config: GitFetchConfig): string[] {
+  const flags: string[] = [];
+  if (config.all) flags.push("--all");
+  if (config.prune) flags.push("--prune");
+  if (config.pruneTags) flags.push("--prune-tags");
+  if (config.tags) flags.push("--tags");
+  return flags;
+}
+
+export function normalizeGitPull(raw: unknown, legacyStrategy?: unknown): GitPullConfig {
+  const obj = (raw ?? {}) as Partial<GitPullConfig>;
+  const strategy = isPullStrategy(obj.strategy)
+    ? obj.strategy
+    : isPullStrategy(legacyStrategy)
+      ? legacyStrategy
+      : DEFAULT_PULL_STRATEGY;
+  return {
+    strategy,
+    autostash: !!obj.autostash,
+    noVerify: !!obj.noVerify,
+  };
+}
+
+export function normalizeGitPush(raw: unknown): GitPushConfig {
+  const obj = (raw ?? {}) as Partial<GitPushConfig>;
+  return {
+    mode: isPushMode(obj.mode) ? obj.mode : DEFAULT_PUSH_MODE,
+    noVerify: !!obj.noVerify,
+    tags: !!obj.tags,
+  };
+}
+
+export function normalizeGitFetch(raw: unknown): GitFetchConfig {
+  const obj = (raw ?? {}) as Partial<GitFetchConfig>;
+  return {
+    all: obj.all ?? DEFAULT_FETCH_CONFIG.all,
+    prune: obj.prune ?? DEFAULT_FETCH_CONFIG.prune,
+    pruneTags: !!obj.pruneTags,
+    tags: !!obj.tags,
+  };
+}

--- a/desktop/frontend/src/store/settings.ts
+++ b/desktop/frontend/src/store/settings.ts
@@ -2,16 +2,14 @@ import { create } from "zustand";
 import { LoadSettings, SaveSettings } from "../../bridge/commands";
 import type { main } from "../../bridge/models";
 import type { Theme } from "../theme";
-
-export const GIT_PULL_STRATEGIES = ["ff-only", "merge", "rebase"] as const;
-
-export type GitPullStrategy = (typeof GIT_PULL_STRATEGIES)[number];
-
-export const DEFAULT_PULL_STRATEGY: GitPullStrategy = "ff-only";
-
-function isGitPullStrategy(value: string | undefined): value is GitPullStrategy {
-  return !!value && (GIT_PULL_STRATEGIES as readonly string[]).includes(value);
-}
+import {
+  normalizeGitPull,
+  normalizeGitPush,
+  normalizeGitFetch,
+  type GitPullConfig,
+  type GitPushConfig,
+  type GitFetchConfig,
+} from "../gitOptions";
 
 export interface DetachedWindowState {
   detached: boolean;
@@ -49,7 +47,9 @@ export interface Settings {
   configEditorMode?: "form" | "yaml";
   showProjectName?: boolean;
   lastSelectedProject?: string;
-  gitPullStrategy?: GitPullStrategy;
+  gitPull?: GitPullConfig;
+  gitPush?: GitPushConfig;
+  gitFetch?: GitFetchConfig;
   experimentalTTS?: boolean;
   ttsEnabled?: boolean;
   ttsVoice?: string;
@@ -108,7 +108,9 @@ function normalize(s: main.Settings): Settings {
         : undefined,
     showProjectName: s.showProjectName,
     lastSelectedProject: s.lastSelectedProject,
-    gitPullStrategy: isGitPullStrategy(s.gitPullStrategy) ? s.gitPullStrategy : undefined,
+    gitPull: normalizeGitPull(s.gitPull, s.gitPullStrategy),
+    gitPush: normalizeGitPush(s.gitPush),
+    gitFetch: normalizeGitFetch(s.gitFetch),
     experimentalTTS: s.experimentalTTS,
     ttsEnabled: s.ttsEnabled,
     ttsVoice: s.ttsVoice || undefined,


### PR DESCRIPTION
## Summary

Pull, Push, and Fetch now have remembered defaults plus optional flags, chosen through an iOS-style drill-in menu in the commit dropdown — without bloating the UI.

- **Split rows** for Pull / Push / Fetch: clicking the text runs the saved default; the `›` chevron drills into config (and an advanced flags level) in place, on the same anchor, with back-navigation.
- **Pull**: strategy `ff if possible` / `ff-only` / `rebase` + flags `--autostash`, `--no-verify`.
- **Push**: mode `default` / `force-with-lease` + flags `--no-verify`, `--tags`.
- **Fetch**: flag toggles `--all`, `--prune`, `--prune-tags`, `--tags` (all/prune on by default).
- **Toolbar sync icon** is context-aware: only-behind → pull, only-ahead → push, diverged → pull-then-push — all using the configured algorithms.
- Defaults persist globally (`gitPull` / `gitPush` / `gitFetch`); legacy `gitPullStrategy` is migrated. Backend pull/push/fetch commands take a flags array; the unused `sync_branch` command was removed.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 118/118 pass (new `gitOptions` flag-builder + migration tests)
- [x] `npm run build` succeeds
- [x] `cargo check` clean
- [ ] Manual: drill-in config, preset/flag persistence across restart, the three sync-icon states, and the right-click Git menu