### PR TITLE
feat(composer): keep tab on send, ⌘T/⌘W control, draggable tabs

### DIFF
--- a/desktop/frontend/src/components/ComposerTabStrip.tsx
+++ b/desktop/frontend/src/components/ComposerTabStrip.tsx
@@ -1,4 +1,19 @@
-import { Fragment, useEffect, useRef, type MouseEvent } from "react";
+import { Fragment, useEffect, useRef, useState, type MouseEvent } from "react";
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragOverEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  horizontalListSortingStrategy,
+  useSortable,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { PlusIcon, XIcon } from "./icons";
 
 export interface ComposerTabView {
@@ -12,18 +27,117 @@ interface ComposerTabStripProps {
   onSelect: (id: string) => void;
   onClose: (id: string) => void;
   onAdd: () => void;
+  onReorder: (ids: string[]) => void;
+}
+
+// Matches the terminal tab strip's insertion marker (TerminalTabDnd.tsx) so the
+// two drag interactions look identical: a 3px rounded cyan bar with a soft glow.
+const INDICATOR_BAR =
+  "h-5 w-[3px] rounded-full bg-[var(--accent-cyan)] shadow-[0_0_8px_var(--accent-cyan)]";
+
+// Absolute so the host tab doesn't reflow when the bar appears at its left edge.
+function LeadingDropIndicator() {
+  return (
+    <span
+      aria-hidden
+      className={`${INDICATOR_BAR} pointer-events-none absolute left-[-2px] top-1/2 -translate-y-1/2`}
+    />
+  );
+}
+
+interface SortableComposerTabProps {
+  tab: ComposerTabView;
+  active: boolean;
+  separator: boolean;
+  separatorHidden: boolean;
+  showLeadingIndicator: boolean;
+  onSelect: (id: string) => void;
+  onClose: (e: MouseEvent, id: string) => void;
+  activeRef?: React.Ref<HTMLDivElement>;
+}
+
+// One draggable tab. {...listeners} (no {...attributes}) sits on the wrapper so
+// the inner select/close buttons stay the only focusable controls — same choice
+// as TerminalTabDnd's SortableTab. The 5px pointer threshold lets a plain click
+// still reach onSelect / onClose.
+function SortableComposerTab({
+  tab,
+  active,
+  separator,
+  separatorHidden,
+  showLeadingIndicator,
+  onSelect,
+  onClose,
+  activeRef,
+}: SortableComposerTabProps) {
+  const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: tab.id });
+  const label = tab.label || "New input";
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.3 : undefined,
+    position: "relative",
+  };
+  return (
+    <Fragment>
+      <div ref={setNodeRef} style={style} {...listeners} className="flex items-center">
+        {showLeadingIndicator && !isDragging && <LeadingDropIndicator />}
+        <div
+          ref={active ? activeRef : undefined}
+          className={`group flex h-6 w-[160px] min-w-[52px] shrink items-center rounded-t-lg text-[11px] font-medium transition-colors ${
+            active
+              ? "composer-tab-active text-[var(--text-primary)]"
+              : "text-[var(--terminal-header-text)] hover:bg-[var(--terminal-header-hover)] hover:text-[var(--terminal-tab-active)]"
+          }`}
+        >
+          <button
+            type="button"
+            onClick={() => onSelect(tab.id)}
+            title={label}
+            aria-current={active ? "true" : undefined}
+            className="min-w-0 flex-1 truncate py-0.5 pl-2.5 pr-1 text-left outline-none"
+          >
+            {label}
+          </button>
+          <button
+            type="button"
+            onClick={(e) => onClose(e, tab.id)}
+            aria-label="Close input"
+            title="Close input"
+            className={`mr-1.5 flex h-4 w-4 shrink-0 items-center justify-center rounded outline-none transition-opacity hover:text-[var(--accent-red)] focus-visible:text-[var(--accent-red)] focus-visible:opacity-100 [&>svg]:h-3 [&>svg]:w-3 ${
+              active ? "opacity-60 hover:opacity-100" : "opacity-0 group-hover:opacity-100"
+            }`}
+          >
+            <XIcon />
+          </button>
+        </div>
+      </div>
+      {separator && (
+        <span
+          aria-hidden
+          className={`h-3.5 w-px shrink-0 bg-[var(--border)] transition-opacity ${
+            separatorHidden ? "opacity-0" : "opacity-100"
+          }`}
+        />
+      )}
+    </Fragment>
+  );
 }
 
 // A Chrome-style row of prepared inputs shown above the composer when more than
-// one draft is open. Tabs are equal width — capped at a target, shrinking in step
-// as more open and scrolling past a minimum — and sit flush with hairline
-// separators (hidden next to the active tab). The active one, the draft in the
-// editor, is a raised neutral pill; a trailing "+" opens another.
-export function ComposerTabStrip({ tabs, activeId, onSelect, onClose, onAdd }: ComposerTabStripProps) {
+// one draft is open, drag-reorderable with the same @dnd-kit pattern as the
+// terminal tabs. The active tab is a raised pill; a trailing "+" opens another.
+export function ComposerTabStrip({ tabs, activeId, onSelect, onClose, onAdd, onReorder }: ComposerTabStripProps) {
   const activeRef = useRef<HTMLDivElement>(null);
+  // Index of the tab the drag is currently over, or null when no drag is in
+  // progress. Drives the cyan insertion bar on that tab.
+  const [overIndex, setOverIndex] = useState<number | null>(null);
 
-  // Keep the active tab visible when the row overflows — e.g. a tab added off the
-  // right edge — since the scrollbar is hidden and gives no other cue.
+  // Pointer only, 5px activation: a quick click still falls through to the tab's
+  // own handlers, and no KeyboardSensor hijacks Enter/Space on the buttons.
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+
+  // Keep the active tab visible when the row overflows.
   useEffect(() => {
     activeRef.current?.scrollIntoView({ inline: "nearest", block: "nearest" });
   }, [activeId]);
@@ -33,63 +147,58 @@ export function ComposerTabStrip({ tabs, activeId, onSelect, onClose, onAdd }: C
     onClose(id);
   };
 
+  const handleDragOver = (e: DragOverEvent) => {
+    const overId = e.over ? String(e.over.id) : null;
+    setOverIndex(overId ? tabs.findIndex((t) => t.id === overId) : null);
+  };
+
+  const handleDragEnd = (e: DragEndEvent) => {
+    setOverIndex(null);
+    const { active, over } = e;
+    if (!over) return;
+    const from = tabs.findIndex((t) => t.id === String(active.id));
+    const to = tabs.findIndex((t) => t.id === String(over.id));
+    if (from < 0 || to < 0 || from === to) return;
+    onReorder(arrayMove(tabs.map((t) => t.id), from, to));
+  };
+
   return (
-    <div className="no-scrollbar flex items-center overflow-x-auto pl-3">
-      {tabs.map((tab, i) => {
-        const active = tab.id === activeId;
-        const nextActive = i + 1 < tabs.length && tabs[i + 1].id === activeId;
-        const label = tab.label || "New input";
-        return (
-          <Fragment key={tab.id}>
-            <div
-              ref={active ? activeRef : undefined}
-              className={`group flex h-6 w-[160px] min-w-[52px] shrink items-center rounded-t-lg text-[11px] font-medium transition-colors ${
-                active
-                  ? "composer-tab-active text-[var(--text-primary)]"
-                  : "text-[var(--terminal-header-text)] hover:bg-[var(--terminal-header-hover)] hover:text-[var(--terminal-tab-active)]"
-              }`}
-            >
-              <button
-                type="button"
-                onClick={() => onSelect(tab.id)}
-                title={label}
-                aria-current={active ? "true" : undefined}
-                className="min-w-0 flex-1 truncate py-0.5 pl-2.5 pr-1 text-left outline-none"
-              >
-                {label}
-              </button>
-              <button
-                type="button"
-                onClick={(e) => handleClose(e, tab.id)}
-                aria-label="Close input"
-                title="Close input"
-                className={`mr-1.5 flex h-4 w-4 shrink-0 items-center justify-center rounded outline-none transition-opacity hover:text-[var(--accent-red)] focus-visible:text-[var(--accent-red)] focus-visible:opacity-100 [&>svg]:h-3 [&>svg]:w-3 ${
-                  active ? "opacity-60 hover:opacity-100" : "opacity-0 group-hover:opacity-100"
-                }`}
-              >
-                <XIcon />
-              </button>
-            </div>
-            {i < tabs.length - 1 && (
-              <span
-                aria-hidden
-                className={`h-3.5 w-px shrink-0 bg-[var(--border)] transition-opacity ${
-                  active || nextActive ? "opacity-0" : "opacity-100"
-                }`}
+    <DndContext
+      sensors={sensors}
+      onDragOver={handleDragOver}
+      onDragEnd={handleDragEnd}
+      onDragCancel={() => setOverIndex(null)}
+    >
+      <SortableContext items={tabs.map((t) => t.id)} strategy={horizontalListSortingStrategy}>
+        <div className="no-scrollbar flex items-center overflow-x-auto pl-3">
+          {tabs.map((tab, i) => {
+            const active = tab.id === activeId;
+            const nextActive = i + 1 < tabs.length && tabs[i + 1].id === activeId;
+            return (
+              <SortableComposerTab
+                key={tab.id}
+                tab={tab}
+                active={active}
+                separator={i < tabs.length - 1}
+                separatorHidden={active || nextActive}
+                showLeadingIndicator={overIndex === i}
+                onSelect={onSelect}
+                onClose={handleClose}
+                activeRef={activeRef}
               />
-            )}
-          </Fragment>
-        );
-      })}
-      <button
-        type="button"
-        onClick={onAdd}
-        aria-label="New input"
-        title="New input"
-        className="ml-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[var(--text-muted)] outline-none transition-colors hover:bg-[var(--terminal-header-hover)] hover:text-[var(--text-primary)] [&>svg]:h-3.5 [&>svg]:w-3.5"
-      >
-        <PlusIcon />
-      </button>
-    </div>
+            );
+          })}
+          <button
+            type="button"
+            onClick={onAdd}
+            aria-label="New input"
+            title="New input"
+            className="ml-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[var(--text-muted)] outline-none transition-colors hover:bg-[var(--terminal-header-hover)] hover:text-[var(--text-primary)] [&>svg]:h-3.5 [&>svg]:w-3.5"
+          >
+            <PlusIcon />
+          </button>
+        </div>
+      </SortableContext>
+    </DndContext>
   );
 }

--- a/desktop/frontend/src/components/Settings.tsx
+++ b/desktop/frontend/src/components/Settings.tsx
@@ -106,6 +106,9 @@ export function Settings({
   const openFilesInDefaultApp = useSettingsStore(
     (s) => s.terminalOpenInDefaultApp ?? false,
   );
+  const autoCloseComposerOnSend = useSettingsStore(
+    (s) => s.autoCloseComposerOnSend ?? true,
+  );
   const experimentalTTS = useSettingsStore((s) => s.experimentalTTS);
   const updateSettings = useSettingsStore((s) => s.update);
 
@@ -488,6 +491,15 @@ export function Settings({
                 <Toggle
                   enabled={openFilesInDefaultApp}
                   onChange={(v) => updateSettings({ terminalOpenInDefaultApp: v })}
+                />
+              </SettingsRow>
+              <SettingsRow
+                label="Auto close composer on send"
+                description="Sending a prepared input clears it and closes its tab when more than one is open, instead of keeping the tab"
+              >
+                <Toggle
+                  enabled={autoCloseComposerOnSend}
+                  onChange={(v) => updateSettings({ autoCloseComposerOnSend: v })}
                 />
               </SettingsRow>
             </SettingsSection>

--- a/desktop/frontend/src/components/TerminalComposer.tsx
+++ b/desktop/frontend/src/components/TerminalComposer.tsx
@@ -614,15 +614,19 @@ export function TerminalComposer({ terminalId, historyKey, projectName, shown, f
     [addImageBlob, insertImageChips, focusAtPoint],
   );
 
-  // Retire the just-sent prompt by clearing it in place — the tab always stays,
-  // regardless of how many are open, so a send never pulls a prepared input out
-  // from under the user. Resolved by id because a tab switch during an image
-  // upload can leave the sent prompt no longer the active one: when it's still
-  // active we empty the live editor (syncState mirrors it back into the tab);
-  // when it isn't, we clear that tab's stored snapshot and leave the editor be.
+  // Retire the just-sent prompt, resolved by id because a tab switch during an
+  // image upload can leave it no longer the active one. With "auto close on send"
+  // on (the default) a sent prompt drops its tab when others are open — its
+  // neighbour takes over — and a lone tab is cleared in place. With it off the
+  // tab always stays and is only cleared, so a send never pulls a prepared input
+  // out from under the user. Clearing the active prompt empties the live editor
+  // (syncState mirrors it back into the tab); an inactive one clears its snapshot.
   const finishSend = (sentId: string, editor: HTMLDivElement) => {
     const idx = tabs.current.findIndex((t) => t.id === sentId);
-    if (idx !== -1) {
+    const autoClose = getSettings().autoCloseComposerOnSend !== false;
+    if (idx !== -1 && autoClose && tabs.current.length > 1) {
+      removeTabAt(idx, sentId === activeId.current);
+    } else if (idx !== -1) {
       if (sentId === activeId.current) {
         histIdx.current = -1;
         imagePaths.current.clear();
@@ -1034,14 +1038,12 @@ export function TerminalComposer({ terminalId, historyKey, projectName, shown, f
         return;
       }
     }
-    // ⌘T / ⌘W act on the composer's own tabs while the input is focused,
-    // shadowing the global new-terminal / close-terminal shortcuts. addTab
+    // ⌘⇧T / ⌘⇧W act on the composer's own tabs while the input is focused. addTab
     // already creates and jumps to the new tab; closeTab no-ops on the last tab
-    // (so ⌘W there does nothing) and otherwise adopts the left neighbour. Gated
-    // to ⌘ only — Ctrl+T/Ctrl+W are native macOS field edits (transpose / delete
-    // word) that must keep working; the generic guard below still stops their
-    // global terminal shortcut from firing.
-    if (e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey) {
+    // (so ⌘⇧W there does nothing) and otherwise adopts the left neighbour. Plain
+    // ⌘T is let through to the global new-terminal shortcut (see the guard below);
+    // plain ⌘W stays swallowed so it never closes the terminal while typing.
+    if (e.metaKey && e.shiftKey && !e.ctrlKey && !e.altKey) {
       const k = e.key.toLowerCase();
       if (k === "t") {
         e.preventDefault();
@@ -1058,9 +1060,12 @@ export function TerminalComposer({ terminalId, historyKey, projectName, shown, f
     }
     // Keep app-chrome shortcuts (⌘W close tab, ⌘D split, ⌘F find, ⌘1-9 switch
     // project) from firing while typing here. ⌘I still bubbles so it can toggle
-    // the composer closed; native edit shortcuts (copy/paste/select-all) keep
+    // the composer closed, and plain ⌘T bubbles so it opens a new terminal even
+    // with the input focused; native edit shortcuts (copy/paste/select-all) keep
     // working since we never preventDefault them.
-    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() !== "i") {
+    const guardKey = e.key.toLowerCase();
+    const passesThrough = guardKey === "i" || (e.metaKey && !e.shiftKey && guardKey === "t");
+    if ((e.metaKey || e.ctrlKey) && !passesThrough) {
       e.stopPropagation();
     }
     // Any caret move can make WebKit inject stray chars around a chip — the

--- a/desktop/frontend/src/components/TerminalComposer.tsx
+++ b/desktop/frontend/src/components/TerminalComposer.tsx
@@ -397,12 +397,13 @@ export function TerminalComposer({ terminalId, historyKey, projectName, shown, f
     syncState();
   }, [syncState, loadTab]);
 
-  // Drop the tab at `idx`; if it was the visible one, adopt its neighbor into the
-  // editor (the next tab, or the new last when the end was removed).
+  // Drop the tab at `idx`; if it was the visible one, adopt the tab to its left
+  // (or the new first tab when the leftmost was closed) so closing walks toward
+  // the start of the strip, not the end.
   const removeTabAt = useCallback(
     (idx: number, wasActive: boolean) => {
       tabs.current.splice(idx, 1);
-      if (wasActive) loadTab(tabs.current[Math.min(idx, tabs.current.length - 1)]);
+      if (wasActive) loadTab(tabs.current[Math.max(0, idx - 1)]);
     },
     [loadTab],
   );
@@ -421,6 +422,20 @@ export function TerminalComposer({ terminalId, historyKey, projectName, shown, f
       syncState();
     },
     [syncState, removeTabAt],
+  );
+
+  // Apply a drag-reorder from the strip: rebuild `tabs.current` in the given id
+  // order, then persist. The active tab is tracked by id, so reordering never
+  // changes which prompt is in the editor — only the row order moves.
+  const reorderTabs = useCallback(
+    (ids: string[]) => {
+      const byId = new Map(tabs.current.map((t) => [t.id, t]));
+      const next = ids.map((id) => byId.get(id)).filter((t): t is ComposerInputTab => !!t);
+      if (next.length !== tabs.current.length) return;
+      tabs.current = next;
+      syncState();
+    },
+    [syncState],
   );
 
   const registerImagePath = useCallback((path: string): HTMLSpanElement => {
@@ -599,19 +614,27 @@ export function TerminalComposer({ terminalId, historyKey, projectName, shown, f
     [addImageBlob, insertImageChips, focusAtPoint],
   );
 
-  // Retire the just-sent prompt, resolved by id (a tab switch during an image
-  // upload can leave it no longer active — or already closed). With other prompts
-  // open the sent tab is dropped, and its neighbor takes over only if it was the
-  // one on screen; a lone tab is cleared in place and kept.
+  // Retire the just-sent prompt by clearing it in place — the tab always stays,
+  // regardless of how many are open, so a send never pulls a prepared input out
+  // from under the user. Resolved by id because a tab switch during an image
+  // upload can leave the sent prompt no longer the active one: when it's still
+  // active we empty the live editor (syncState mirrors it back into the tab);
+  // when it isn't, we clear that tab's stored snapshot and leave the editor be.
   const finishSend = (sentId: string, editor: HTMLDivElement) => {
     const idx = tabs.current.findIndex((t) => t.id === sentId);
-    if (idx !== -1 && tabs.current.length > 1) {
-      removeTabAt(idx, sentId === activeId.current);
-    } else if (idx !== -1) {
-      histIdx.current = -1;
-      imagePaths.current.clear();
-      setEditorContent(editor, "");
-      setPreview(null);
+    if (idx !== -1) {
+      if (sentId === activeId.current) {
+        histIdx.current = -1;
+        imagePaths.current.clear();
+        setEditorContent(editor, "");
+        setPreview(null);
+      } else {
+        const tab = tabs.current[idx];
+        tab.text = "";
+        tab.imagePaths = new Map();
+        tab.imgCounter = 0;
+        tab.histIdx = -1;
+      }
     }
     syncState();
     editor.focus();
@@ -1011,6 +1034,28 @@ export function TerminalComposer({ terminalId, historyKey, projectName, shown, f
         return;
       }
     }
+    // ⌘T / ⌘W act on the composer's own tabs while the input is focused,
+    // shadowing the global new-terminal / close-terminal shortcuts. addTab
+    // already creates and jumps to the new tab; closeTab no-ops on the last tab
+    // (so ⌘W there does nothing) and otherwise adopts the left neighbour. Gated
+    // to ⌘ only — Ctrl+T/Ctrl+W are native macOS field edits (transpose / delete
+    // word) that must keep working; the generic guard below still stops their
+    // global terminal shortcut from firing.
+    if (e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey) {
+      const k = e.key.toLowerCase();
+      if (k === "t") {
+        e.preventDefault();
+        e.stopPropagation();
+        addTab();
+        return;
+      }
+      if (k === "w") {
+        e.preventDefault();
+        e.stopPropagation();
+        closeTab(activeId.current);
+        return;
+      }
+    }
     // Keep app-chrome shortcuts (⌘W close tab, ⌘D split, ⌘F find, ⌘1-9 switch
     // project) from firing while typing here. ⌘I still bubbles so it can toggle
     // the composer closed; native edit shortcuts (copy/paste/select-all) keep
@@ -1163,6 +1208,7 @@ export function TerminalComposer({ terminalId, historyKey, projectName, shown, f
           onSelect={switchTab}
           onClose={closeTab}
           onAdd={addTab}
+          onReorder={reorderTabs}
         />
       )}
       <div

--- a/desktop/frontend/src/components/TerminalComposer.tsx
+++ b/desktop/frontend/src/components/TerminalComposer.tsx
@@ -1040,9 +1040,8 @@ export function TerminalComposer({ terminalId, historyKey, projectName, shown, f
     }
     // ⌘⇧T / ⌘⇧W act on the composer's own tabs while the input is focused. addTab
     // already creates and jumps to the new tab; closeTab no-ops on the last tab
-    // (so ⌘⇧W there does nothing) and otherwise adopts the left neighbour. Plain
-    // ⌘T is let through to the global new-terminal shortcut (see the guard below);
-    // plain ⌘W stays swallowed so it never closes the terminal while typing.
+    // (so ⌘⇧W there does nothing) and otherwise adopts the left neighbour. The
+    // plain (un-shifted) chords fall through to the app chrome — see the guard below.
     if (e.metaKey && e.shiftKey && !e.ctrlKey && !e.altKey) {
       const k = e.key.toLowerCase();
       if (k === "t") {
@@ -1058,13 +1057,15 @@ export function TerminalComposer({ terminalId, historyKey, projectName, shown, f
         return;
       }
     }
-    // Keep app-chrome shortcuts (⌘W close tab, ⌘D split, ⌘F find, ⌘1-9 switch
-    // project) from firing while typing here. ⌘I still bubbles so it can toggle
-    // the composer closed, and plain ⌘T bubbles so it opens a new terminal even
-    // with the input focused; native edit shortcuts (copy/paste/select-all) keep
-    // working since we never preventDefault them.
+    // Keep app-chrome shortcuts (⌘D split, ⌘F find, ⌘1-9 switch project) from
+    // firing while typing here. ⌘I still bubbles so it can toggle the composer
+    // closed, and plain ⌘T / ⌘W bubble so they open / close the terminal even with
+    // the input focused (⌘⇧W above already handled the composer's own tabs); native
+    // edit shortcuts (copy/paste/select-all) keep working since we never
+    // preventDefault them.
     const guardKey = e.key.toLowerCase();
-    const passesThrough = guardKey === "i" || (e.metaKey && !e.shiftKey && guardKey === "t");
+    const passesThrough =
+      guardKey === "i" || (e.metaKey && !e.shiftKey && (guardKey === "t" || guardKey === "w"));
     if ((e.metaKey || e.ctrlKey) && !passesThrough) {
       e.stopPropagation();
     }
@@ -1201,7 +1202,7 @@ export function TerminalComposer({ terminalId, historyKey, projectName, shown, f
   const showActions = ai.anyAvailable;
   // Reserve room on the right for the floating button cluster so text never
   // slides under it; each button is 28px wide with a 4px gap.
-  const footerButtons = (showActions ? 1 : 0) + (tabView.length <= 1 ? 1 : 0) + 2;
+  const footerButtons = (showActions ? 1 : 0) + 3;
   const editorPadRight = 8 + footerButtons * 28 + (footerButtons - 1) * 4 + 12;
 
   return (
@@ -1309,19 +1310,15 @@ export function TerminalComposer({ terminalId, historyKey, projectName, shown, f
               onManage={() => setActionsModalOpen(true)}
             />
           )}
-          {tabView.length <= 1 && (
-            // With the tab strip hidden (a single input), the strip's own "+" is
-            // gone, so this is the only way to open another prepared input.
-            <button
-              type="button"
-              onClick={addTab}
-              aria-label="New input"
-              title="New input"
-              className="flex h-7 w-7 items-center justify-center rounded-lg text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
-            >
-              <PlusIcon />
-            </button>
-          )}
+          <button
+            type="button"
+            onClick={addTab}
+            aria-label="New input"
+            title="New input"
+            className="flex h-7 w-7 items-center justify-center rounded-lg text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+          >
+            <PlusIcon />
+          </button>
           <TerminalHistoryButton
             terminalId={historyKey}
             projectName={projectName}

--- a/desktop/frontend/src/store/settings.ts
+++ b/desktop/frontend/src/store/settings.ts
@@ -60,11 +60,13 @@ export interface Settings {
   duplicateExcludeUncommitted?: boolean;
   duplicateReinstallDeps?: boolean;
   composerOpen?: boolean;
+  autoCloseComposerOnSend?: boolean;
 }
 
 const defaults: Settings = {
   theme: "dark",
   doubleClickToToggle: false,
+  autoCloseComposerOnSend: true,
 };
 
 interface SettingsActions {
@@ -118,6 +120,7 @@ function normalize(s: main.Settings): Settings {
     duplicateExcludeUncommitted: s.duplicateExcludeUncommitted,
     duplicateReinstallDeps: s.duplicateReinstallDeps,
     composerOpen: s.composerOpen,
+    autoCloseComposerOnSend: s.autoCloseComposerOnSend ?? defaults.autoCloseComposerOnSend,
     detachedWindows: s.detachedWindows
       ? Object.fromEntries(
           Object.entries(s.detachedWindows).map(([name, raw]) => {


### PR DESCRIPTION
## Summary
Composer (prepared-input tabs) improvements: tab lifecycle, keyboard control, drag reordering, and a configurable send behaviour.

## Changes
- **Keyboard control while the composer is focused.**
  - **⌘⇧T** — open a new composer tab and jump to it.
  - **⌘⇧W** — close the current composer tab (focuses the tab to its left; no-op on the last tab).
  - **⌘T** — opens a new terminal (falls through to the global shortcut even with the input focused).
  - Plain ⌘W stays swallowed so it never closes the terminal while typing; native macOS Ctrl+T/Ctrl+W editing is untouched.
- **Draggable tabs.** Composer tabs are drag-reorderable via `@dnd-kit`, mirroring the terminal tab pattern (5px pointer activation, cyan insertion indicator). Order persists through the existing draft save.
- **"Auto close composer on send" setting** (Settings → Terminal, default **on**):
  - **On** — sending a prompt clears it and closes its tab when 2+ tabs are open (a lone tab is cleared in place).
  - **Off** — the tab always stays and is just cleared, so a send never pulls a prepared input out from under you.

## Impact
- `TerminalComposer.tsx` — `finishSend` (setting-aware), `handleKeyDown` (⌘⇧T/⌘⇧W + plain ⌘T pass-through), `removeTabAt` (adopt left neighbour), new `reorderTabs`.
- `ComposerTabStrip.tsx` — rewritten as an `@dnd-kit` sortable strip.
- `store/settings.ts` + `Settings.tsx` — new `autoCloseComposerOnSend` setting and its Terminal-tab toggle (persists as free-form JSON, no backend change).
- No image/preview behaviour touched.

## Test plan
- `npx tsc --noEmit`, `vitest` (101/101), and `npm run build` all pass.
- Manual (`npm run tauri dev`): ⌘⇧T/⌘⇧W manage composer tabs; ⌘T opens a terminal with the composer focused; drag to reorder 3+ tabs (plain click still selects, × still closes); toggle the setting and confirm send closes vs. keeps the tab when 2+ are open.