### PR TITLE
fix(skill): drop obsolete /lpm gitignore so skills.sh finds the skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,6 @@
 PROJECT.md
 docs/superpowers/
 
-# Go binary (root only; keep the lpm/ skill directory tracked)
-/lpm
-!/lpm/
 *.exe
 
 # Desktop app


### PR DESCRIPTION
## Problem

After renaming the skill directory to `lpm/`, `npx skills add gug007/lpm` fails with **"No skills found. Skills require a SKILL.md with name and description."**

## Cause

`.gitignore` still carried the legacy Go-binary ignore `/lpm` (plus a `!/lpm/` negation). Git itself honors the negation, but the skills.sh installer's ignore-aware directory scan follows the "can't re-include a path under an excluded parent" rule and skips the whole `lpm/` directory — so it discovers zero skills.

There is **no Go build in this repo** (0 `.go` files), so the ignore is dead code.

## Fix

Remove the `/lpm` and `!/lpm/` lines. The skill files are already tracked, so nothing else changes — this only unblocks the installer's discovery.

## Verify
```
npx skills add gug007/lpm -s lpm
```
should now find the `lpm` skill.