### PR TITLE
fix(terminal): Copy/Save/Clear console respect the active filter

### DIFF
--- a/desktop/frontend/src/components/InteractivePane.tsx
+++ b/desktop/frontend/src/components/InteractivePane.tsx
@@ -141,6 +141,8 @@ interface InteractiveSession {
   // closing over stale component state don't fire.
   onScrollState?: (atBottom: boolean) => void;
   onExit?: (exitCode: number) => void;
+  // Run after the buffer is cleared so a live filter overlay refreshes too.
+  onAfterClear?: () => void;
   themeOverride: ITheme | null;
 
   // Marks the session disconnected (same path onData uses on a failed write).
@@ -329,7 +331,15 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
   term.attachCustomKeyEventHandler((e) => {
     if (handleCopyShortcut(e, term, serialize)) return false;
     if (handleSelectAllShortcut(e, term)) return false;
-    if (handleClearShortcut(e, term)) return false;
+    if (
+      handleClearShortcut(e, term, {
+        onClear: () => {
+          term.clear();
+          interactiveSessions.get(terminalId)?.onAfterClear?.();
+        },
+      })
+    )
+      return false;
     if (!e.metaKey) return true;
     return false;
   });
@@ -523,10 +533,15 @@ export function InteractivePane({
   themeOverrideRef.current = themeOverride;
   onExitRef.current = onExit;
 
+  // Clear the buffer and refresh any live filter overlay so both empty at once.
+  const clearConsole = () => {
+    sessionRef.current?.term.clear();
+    filterRef.current?.refresh();
+  };
+
   useImperativeHandle(ref, () => ({
     clear() {
-      const session = sessionRef.current;
-      if (session) session.term.clear();
+      clearConsole();
     },
     findNext(query: string) {
       return sessionRef.current?.search?.findNext(query) ?? false;
@@ -653,6 +668,7 @@ export function InteractivePane({
       themeOverrideRef.current ?? getTerminalTheme(el);
     session.themeOverride = themeOverrideRef.current ?? null;
     session.onScrollState = (atBottom) => scrollCallbackRef.current?.(atBottom);
+    session.onAfterClear = () => filterRef.current?.refresh();
     session.onExit = (code) => onExitRef.current?.(code);
 
     el.appendChild(session.host);
@@ -688,6 +704,7 @@ export function InteractivePane({
       ro.disconnect();
       session.onScrollState = undefined;
       session.onExit = undefined;
+      session.onAfterClear = undefined;
       filterRef.current?.dispose();
       filterRef.current = null;
       if (session.host.parentNode) {
@@ -765,7 +782,8 @@ export function InteractivePane({
           term={sessionRef.current.term}
           serialize={sessionRef.current.serialize}
           canPaste
-          onClear={() => sessionRef.current?.term.clear()}
+          filter={filterRef.current}
+          onClear={clearConsole}
           onPaste={() => {
             navigator.clipboard
               .readText()

--- a/desktop/frontend/src/components/Pane.tsx
+++ b/desktop/frontend/src/components/Pane.tsx
@@ -30,6 +30,8 @@ interface PaneSession {
   cwd: string;
   pathLinkDisposable: IDisposable | null;
   onScrollState?: (atBottom: boolean) => void;
+  // Run after the pane is cleared so a live filter overlay refreshes too.
+  onAfterClear?: () => void;
 }
 
 const paneSessions = new Map<string, PaneSession>();
@@ -99,6 +101,7 @@ function createPaneSession(opts: { fontSize: number; theme: ITheme; cwd: string 
 function clearPaneSession(session: PaneSession): void {
   session.term.reset();
   session.prevLines = [];
+  session.onAfterClear?.();
 }
 
 export function disposePaneSession(key: string): void {
@@ -219,6 +222,7 @@ export function Pane({ label, onLabelClick, labelActions, output, visible = true
       session.onScrollState = (atBottom) => {
         scrollCallbackRef.current?.(atBottom);
       };
+      session.onAfterClear = () => filterRef.current?.refresh();
 
       try { session.fit.fit(); } catch {}
 
@@ -253,6 +257,7 @@ export function Pane({ label, onLabelClick, labelActions, output, visible = true
         globalObserver.disconnect();
         ro.disconnect();
         session.onScrollState = undefined;
+        session.onAfterClear = undefined;
         filterRef.current?.dispose();
         filterRef.current = null;
 
@@ -386,6 +391,7 @@ export function Pane({ label, onLabelClick, labelActions, output, visible = true
             term={sessionRef.current.term}
             serialize={sessionRef.current.serialize}
             canPaste={false}
+            filter={filterRef.current}
             onClear={() => {
               const s = sessionRef.current;
               if (s) clearPaneSession(s);

--- a/desktop/frontend/src/components/terminal/ConsoleContextMenu.tsx
+++ b/desktop/frontend/src/components/terminal/ConsoleContextMenu.tsx
@@ -3,7 +3,7 @@ import type { SerializeAddon } from "@xterm/addon-serialize";
 import { ContextMenuItem } from "../ui/ContextMenuItem";
 import { ContextMenuShell } from "../ui/ContextMenuShell";
 import { copyTerminalSelection } from "./copySelection";
-import { copyConsole, saveConsole } from "./consoleActions";
+import { copyConsole, saveConsole, type ConsoleFilter } from "./consoleActions";
 
 interface ConsoleContextMenuProps {
   x: number;
@@ -11,6 +11,7 @@ interface ConsoleContextMenuProps {
   term: Terminal;
   serialize: SerializeAddon | null;
   canPaste: boolean;
+  filter?: ConsoleFilter | null;
   onClear: () => void;
   onPaste?: () => void;
   onClose: () => void;
@@ -22,6 +23,7 @@ export function ConsoleContextMenu({
   term,
   serialize,
   canPaste,
+  filter,
   onClear,
   onPaste,
   onClose,
@@ -56,11 +58,11 @@ export function ConsoleContextMenu({
       <div className="my-1 h-px bg-[var(--border)]" />
       <ContextMenuItem
         label="Copy console"
-        onClick={run(() => void copyConsole(term))}
+        onClick={run(() => void copyConsole(term, filter))}
       />
       <ContextMenuItem
         label="Save as..."
-        onClick={run(() => void saveConsole(term))}
+        onClick={run(() => void saveConsole(term, filter))}
       />
     </ContextMenuShell>
   );

--- a/desktop/frontend/src/components/terminal/FilterMirror.ts
+++ b/desktop/frontend/src/components/terminal/FilterMirror.ts
@@ -3,7 +3,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { SearchAddon } from "@xterm/addon-search";
 import type { SerializeAddon } from "@xterm/addon-serialize";
 import { TERMINAL_FONT_FAMILY } from "../terminal-utils";
-import { filterLines } from "./filterLines";
+import { filterLines, stripAnsi } from "./filterLines";
 
 const MATCH_DECORATIONS = {
   matchBackground: "#5c4a00",
@@ -58,6 +58,26 @@ export class FilterMirror {
     if (this.host) this.host.style.display = "block";
     this.subscribeLive();
     this.run();
+  }
+
+  // True while a query is actively filtering the overlay (what the user sees).
+  isActive(): boolean {
+    return this.active && this.query.length > 0;
+  }
+
+  // The matched lines as plain text, recomputed from the live source so it
+  // reflects the full filtered set independent of the mirror's rendering.
+  getFilteredText(): string {
+    if (!this.query) return "";
+    return filterLines(this.readSourceText(), this.query)
+      .map(stripAnsi)
+      .join("\n");
+  }
+
+  // Re-derive the overlay from the current source (e.g. after the underlying
+  // terminal is cleared, so the filtered view empties too).
+  refresh(): void {
+    if (this.active && this.query) this.run();
   }
 
   setTheme(theme: ITheme): void {

--- a/desktop/frontend/src/components/terminal/consoleActions.test.ts
+++ b/desktop/frontend/src/components/terminal/consoleActions.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const saveTextFile = vi.fn(
+  (_name: string, _text: string): Promise<boolean> => Promise.resolve(true),
+);
+vi.mock("../../../bridge/commands", () => ({
+  SaveTextFile: (name: string, text: string) => saveTextFile(name, text),
+}));
+
+import { copyConsole, saveConsole } from "./consoleActions";
+
+// Minimal xterm-buffer stand-in: bufferToPlainText reads buffer.active.
+function fakeTerm(lines: string[]) {
+  return {
+    buffer: {
+      active: {
+        length: lines.length,
+        getLine: (i: number) => ({ translateToString: () => lines[i] }),
+      },
+    },
+  } as never;
+}
+
+let written: string | null;
+
+beforeEach(() => {
+  written = null;
+  saveTextFile.mockClear();
+  vi.stubGlobal("navigator", {
+    clipboard: {
+      writeText: vi.fn(async (t: string) => {
+        written = t;
+      }),
+    },
+  });
+});
+
+describe("copyConsole respects an active filter", () => {
+  it("copies ONLY the filtered text when the filter is active", async () => {
+    const term = fakeTerm(["noise 1", "noise 2", "the match"]);
+    const filter = { isActive: () => true, getFilteredText: () => "the match" };
+    await copyConsole(term, filter);
+    expect(written).toBe("the match");
+  });
+
+  it("copies the full buffer when there is no filter", async () => {
+    await copyConsole(fakeTerm(["a", "b"]), null);
+    expect(written).toBe("a\nb");
+  });
+
+  it("copies the full buffer when a filter exists but is inactive", async () => {
+    const filter = { isActive: () => false, getFilteredText: () => "SHOULD NOT USE" };
+    await copyConsole(fakeTerm(["a", "b"]), filter);
+    expect(written).toBe("a\nb");
+  });
+});
+
+describe("saveConsole respects an active filter", () => {
+  it("saves ONLY the filtered text when the filter is active", async () => {
+    const filter = { isActive: () => true, getFilteredText: () => "only this" };
+    await saveConsole(fakeTerm(["x", "y", "only this"]), filter);
+    expect(saveTextFile).toHaveBeenCalledTimes(1);
+    expect(saveTextFile.mock.calls[0][1]).toBe("only this");
+  });
+
+  it("saves the full buffer with no filter", async () => {
+    await saveConsole(fakeTerm(["x", "y"]), null);
+    expect(saveTextFile.mock.calls[0][1]).toBe("x\ny");
+  });
+});

--- a/desktop/frontend/src/components/terminal/consoleActions.ts
+++ b/desktop/frontend/src/components/terminal/consoleActions.ts
@@ -12,8 +12,22 @@ export function bufferToPlainText(term: Terminal): string {
   return lines.join("\n");
 }
 
-export async function copyConsole(term: Terminal): Promise<void> {
-  const text = bufferToPlainText(term);
+// An active console filter (the FilterMirror). When present, copy/save operate
+// on the filtered lines the user is actually looking at, not the full buffer.
+export interface ConsoleFilter {
+  isActive(): boolean;
+  getFilteredText(): string;
+}
+
+function consoleText(term: Terminal, filter?: ConsoleFilter | null): string {
+  return filter?.isActive() ? filter.getFilteredText() : bufferToPlainText(term);
+}
+
+export async function copyConsole(
+  term: Terminal,
+  filter?: ConsoleFilter | null,
+): Promise<void> {
+  const text = consoleText(term, filter);
   if (!text) return;
   try {
     await navigator.clipboard.writeText(text);
@@ -23,8 +37,11 @@ export async function copyConsole(term: Terminal): Promise<void> {
   }
 }
 
-export async function saveConsole(term: Terminal): Promise<void> {
-  const text = bufferToPlainText(term);
+export async function saveConsole(
+  term: Terminal,
+  filter?: ConsoleFilter | null,
+): Promise<void> {
+  const text = consoleText(term, filter);
   const name = `console-${Date.now()}.log`;
   try {
     const saved = await SaveTextFile(name, text);


### PR DESCRIPTION
## Problem

When a **filter** is active in a terminal (the `FilterMirror` overlay showing only matched lines):

- **Copy console** / **Save as...** copied/saved the *entire* console, not the filtered view.
- **Clear console** emptied the underlying buffer but left the filtered overlay showing stale lines.

Reproduced on the **service-log tab** (e.g. the dev-server output), where it's most visible.

## Cause

The console actions read the raw xterm buffer / reset it directly, ignoring the separate `FilterMirror` overlay the user actually sees.

Critically, terminals are rendered by **two** components, each with its own `FilterMirror` + `ConsoleContextMenu`:
- `InteractivePane.tsx` — interactive shells
- `Pane.tsx` — **service logs**

## Fix

- `FilterMirror` exposes `isActive()`, `getFilteredText()` (matched lines, recomputed canonically), and `refresh()`.
- `copyConsole`/`saveConsole` take an optional filter source and use the filtered text when a filter is active.
- All clear paths (context-menu **Clear console**, imperative clear, and **⌃L**) refresh the overlay after clearing, so the filtered view empties in the same action. Filter stays active (re-renders to "No matches").
- Wired into **both** `InteractivePane.tsx` and `Pane.tsx`.

No-filter behaviour is unchanged.

## Verification
- `tsc --noEmit` clean · `vitest run` (incl. new `consoleActions.test.ts`, 5 cases proving Copy/Save honor the filter)
- `vite build` clean
- Manually confirmed working on a service-log tab.