### PR TITLE
Add app-owned clipboard copy support to terminals

### DIFF
--- a/desktop/frontend/bridge/commands.d.ts
+++ b/desktop/frontend/bridge/commands.d.ts
@@ -161,6 +161,7 @@ export function SaveTerminals(...args: any[]): Promise<any>;
 export function SaveTextFile(...args: any[]): Promise<any>;
 export function SaveWindowSize(...args: any[]): Promise<any>;
 export function SearchBranches(...args: any[]): Promise<any>;
+export function SetClipboardText(...args: any[]): Promise<any>;
 export function SetProjectLabel(...args: any[]): Promise<any>;
 export function StartLogStreaming(...args: any[]): Promise<any>;
 export function StartProject(...args: any[]): Promise<any>;

--- a/desktop/frontend/bridge/commands.js
+++ b/desktop/frontend/bridge/commands.js
@@ -487,6 +487,9 @@ export function SaveWindowSize(width, height) {
 export function SearchBranches(cwd, query) {
   return invoke("search_branches", { cwd, query });
 }
+export function SetClipboardText(text) {
+  return invoke("set_clipboard_text", { text });
+}
 export function SetProjectLabel(name, label) {
   return invoke("set_project_label", { name, label });
 }

--- a/desktop/frontend/src-tauri/src/clipboard.rs
+++ b/desktop/frontend/src-tauri/src/clipboard.rs
@@ -110,3 +110,30 @@ pub fn save_clipboard_image_impl(b64_data: &str, mime_type: &str) -> Result<Stri
 pub fn save_clipboard_image(b64_data: String, mime_type: String) -> Result<String, String> {
     save_clipboard_image_impl(&b64_data, &mime_type)
 }
+
+/// Write text to the system clipboard via pbcopy. The WKWebView refuses
+/// `navigator.clipboard` writes that aren't tied to a user gesture, which is
+/// exactly the case for OSC 52 writes arriving asynchronously from the PTY.
+#[tauri::command(async)]
+pub fn set_clipboard_text(text: String) -> Result<(), String> {
+    let mut child = std::process::Command::new("pbcopy")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map_err(|e| format!("spawn pbcopy: {e}"))?;
+    // Always reap the child, even when the write fails, so no zombie is left.
+    let write_res = match child.stdin.take() {
+        Some(mut stdin) => stdin
+            .write_all(text.as_bytes())
+            .map_err(|e| format!("write pbcopy: {e}")),
+        None => Err("pbcopy stdin unavailable".to_string()),
+    };
+    let wait_res = child.wait().map_err(|e| format!("wait pbcopy: {e}"));
+    write_res?;
+    let status = wait_res?;
+    if !status.success() {
+        return Err(format!("pbcopy exited with {status}"));
+    }
+    Ok(())
+}

--- a/desktop/frontend/src-tauri/src/generated_commands.rs
+++ b/desktop/frontend/src-tauri/src/generated_commands.rs
@@ -168,6 +168,7 @@ macro_rules! all_command_handlers {
         save_branch_name_instructions,
         save_clipboard_image,
         save_commit_instructions,
+        set_clipboard_text,
         save_config,
         save_global_config,
         save_composer_actions,

--- a/desktop/frontend/src-tauri/src/pty.rs
+++ b/desktop/frontend/src-tauri/src/pty.rs
@@ -240,6 +240,11 @@ fn start_internal(
         for (k, v) in std::env::vars() {
             builder.env(k, v);
         }
+        // The app may itself descend from a tmux pane (services run in tmux;
+        // dev runs launched from one), but these terminals are not tmux panes —
+        // a leaked TMUX makes TUIs like Claude Code disable their mouse UX.
+        builder.env_remove("TMUX");
+        builder.env_remove("TMUX_PANE");
         builder.env("TERM", "xterm-256color");
         builder.env("TERM_PROGRAM", "kitty");
         builder.env("LPM_SOCKET_PATH", config::socket_path());
@@ -259,6 +264,11 @@ fn start_internal(
         for (k, v) in std::env::vars() {
             builder.env(k, v);
         }
+        // The app may itself descend from a tmux pane (services run in tmux;
+        // dev runs launched from one), but these terminals are not tmux panes —
+        // a leaked TMUX makes TUIs like Claude Code disable their mouse UX.
+        builder.env_remove("TMUX");
+        builder.env_remove("TMUX_PANE");
         builder.env("TERM", "xterm-256color");
         builder.env("TERM_PROGRAM", "kitty");
         builder.env("LPM_SOCKET_PATH", config::socket_path());

--- a/desktop/frontend/src/components/ComposerReopenBar.tsx
+++ b/desktop/frontend/src/components/ComposerReopenBar.tsx
@@ -1,9 +1,10 @@
+import { composerPlaceholder } from "../composerText";
 import { useComposerStore } from "../store/composer";
 import { MessageIcon } from "./icons";
 
 interface ComposerReopenBarProps {
-  // Terminal the input would target; mirrors the composer's own placeholder so
-  // the collapsed bar stands in for the same input.
+  // Terminal the input would target; drives the same placeholder as the live
+  // input so the collapsed bar stands in for the same field.
   targetLabel: string;
   // Terminal font size; the label scales with it just like the composer's real
   // placeholder, so toggling open doesn't jump the text size.
@@ -21,16 +22,16 @@ export function ComposerReopenBar({ targetLabel, fontSize }: ComposerReopenBarPr
         onClick={() => useComposerStore.getState().setOpen(true)}
         title="Show input (⌘I)"
         aria-label={`Show message input for ${targetLabel}`}
-        className="group flex w-full cursor-pointer items-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)] px-3 py-1.5 text-left text-[var(--text-muted)] transition-colors hover:border-[var(--text-muted)] hover:text-[var(--text-primary)]"
+        className="flex w-full cursor-pointer items-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)] px-3 py-1.5 text-left text-[var(--text-muted)] transition-colors hover:border-[var(--text-muted)] hover:text-[var(--text-primary)]"
       >
-        <span className="flex shrink-0 items-center opacity-70 transition-opacity group-hover:opacity-100">
+        <span className="flex shrink-0 items-center">
           <MessageIcon />
         </span>
         <span
           style={{ fontSize, lineHeight: 1.5 }}
           className="min-w-0 flex-1 truncate"
         >
-          Send to {targetLabel}…
+          {composerPlaceholder(targetLabel)}
         </span>
         <span className="shrink-0 font-mono text-[11px]">⌘I</span>
       </button>

--- a/desktop/frontend/src/components/InteractivePane.tsx
+++ b/desktop/frontend/src/components/InteractivePane.tsx
@@ -13,13 +13,14 @@ import {
   AckTerminalData,
   ReadClipboardFiles,
   SaveClipboardImage,
+  SetClipboardText,
   IsTerminalRemote,
   UploadAndQuoteForTerminal,
   UploadClipboardImageForTerminal,
 } from "../../bridge/commands";
 import { sendTerminalInput, shellQuote } from "../terminal-io";
 import { getTerminalTheme, openTerminalLink, TERMINAL_FONT_FAMILY } from "./terminal-utils";
-import { handleCopyShortcut, handleSelectAllShortcut, handleClearShortcut } from "./terminal/copySelection";
+import { handleCopyShortcut, handleNativeCopy, handleSelectAllShortcut, handleClearShortcut, isCopyShortcut } from "./terminal/copySelection";
 import { ConsoleContextMenu } from "./terminal/ConsoleContextMenu";
 import { applyFilterQuery, FilterMirror } from "./terminal/FilterMirror";
 import { stripAnsi } from "./terminal/filterLines";
@@ -55,6 +56,35 @@ interface InteractivePaneProps {
 
 // Flow control: ack in batches to reduce IPC calls (matches VS Code's approach)
 const ACK_SIZE = 5000;
+
+// ⌘C this soon after a drag reported to a mouse-owning app asks the app to
+// copy its own selection (Ctrl+C — Claude Code's only copy trigger). Past the
+// window the selection is too likely gone, and a bare Ctrl+C doubles as an
+// interrupt, so the chord is not translated.
+const APP_SELECTION_WINDOW_MS = 15000;
+// An app may write the clipboard only on the heels of the user's own input to
+// its terminal (a copy is always an answer to a keystroke or click there).
+// Anything later — or from a session the user isn't touching — is dropped.
+const APP_CLIPBOARD_INPUT_WINDOW_MS = 15000;
+// While its selection is active, Claude Code advertises the copy chord as
+// " · ctrl+c to copy" in its status row. Requiring that advertisement — in
+// its separator form, and only in the last drawn rows where the status line
+// lives — means a Ctrl+C is only ever sent to an app that just promised it
+// copies, and transcript prose merely mentioning the chord can't authorize
+// one. The status row is the last non-blank row: Claude draws inline (blank
+// screen below its chrome) in short sessions and bottom-anchored in full
+// ones, so fixed bottom offsets miss it.
+const APP_COPY_HINT_RE = /·\s*ctrl\+c to copy/i;
+const APP_COPY_HINT_ROWS = 3;
+
+// Serialized so two copies arriving close together can't land out of order
+// and leave the clipboard holding the older payload.
+let clipboardWriteChain: Promise<void> = Promise.resolve();
+function writeAppClipboard(text: string): void {
+  clipboardWriteChain = clipboardWriteChain
+    .then(() => SetClipboardText(text))
+    .catch(() => {});
+}
 
 // A multi-part submit gates each paste on the receiver going quiet rather than on
 // a fixed delay: Claude Code resolves a pasted image path into an attachment
@@ -136,6 +166,7 @@ interface InteractiveSession {
 
   cwd: string;
   pathLinkDisposable: IDisposable | null;
+  osc52Disposable: IDisposable | null;
 
   // Installed by the current React mount, cleared on unmount so callbacks
   // closing over stale component state don't fire.
@@ -156,6 +187,7 @@ export { interactiveSessions };
 function disposeSession(s: InteractiveSession) {
   s.destroy();
   s.pathLinkDisposable?.dispose();
+  s.osc52Disposable?.dispose();
   s.term.dispose();
   s.host.remove();
 }
@@ -283,6 +315,21 @@ function writeTerminalError(terminalId: string, err: unknown): void {
   term.write(`\r\n\x1b[31mlpm upload failed: ${msg}\x1b[0m\r\n`);
 }
 
+function viewportShowsAppCopyHint(term: Terminal): boolean {
+  const buf = term.buffer.active;
+  const end = Math.min(buf.viewportY + term.rows, buf.length);
+  let checked = 0;
+  for (let y = end - 1; y >= buf.viewportY && checked < APP_COPY_HINT_ROWS; y--) {
+    const line = buf.getLine(y);
+    if (!line) continue;
+    const text = line.translateToString(true);
+    if (!/\S/.test(text)) continue;
+    checked++;
+    if (APP_COPY_HINT_RE.test(text)) return true;
+  }
+  return false;
+}
+
 function createInteractiveSession(terminalId: string, cwd: string): InteractiveSession {
   const host = document.createElement("div");
   host.className = "absolute inset-0 overflow-hidden";
@@ -300,6 +347,8 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
     theme: getTerminalTheme(),
     allowProposedApi: true,
     vtExtensions: { kittyKeyboard: true },
+    // Mouse-owning apps suppress local selection; ⌥ drag opts back into it.
+    macOptionClickForcesSelection: true,
     linkHandler: { activate: openTerminalLink },
   });
 
@@ -325,6 +374,63 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
     term.unicode.activeVersion = "11";
   } catch {}
 
+  // When an app owns the mouse it also owns the selection: Claude Code
+  // highlights dragged text itself and copies it (via OSC 52) only when it
+  // receives Ctrl+C while that selection is active. Watch the outgoing SGR
+  // mouse reports for a left-button drag — the gesture that gives the app a
+  // selection worth copying — so ⌘C right after can be translated into the
+  // app's own copy. A motionless click clears the app's selection, so it
+  // clears the marker too.
+  let lastAppDragAt = 0;
+  let lastUserInputAt = 0;
+  let dragHasMotion = false;
+  let copyChordForwarded = false;
+
+  term.onData((data) => {
+    lastUserInputAt = Date.now();
+    // Any typed/pasted input clears Claude Code's selection (any printable
+    // key does, without being consumed), so it disarms the marker too —
+    // mouse reports and focus in/out are the only traffic that doesn't.
+    if (data.replace(/\x1b\[(?:<\d+;\d+;\d+[Mm]|[IO])/g, "")) {
+      lastAppDragAt = 0;
+      dragHasMotion = false;
+      return;
+    }
+    if (term.modes.mouseTrackingMode === "none") return;
+    for (const m of data.matchAll(/\x1b\[<(\d+);\d+;\d+([Mm])/g)) {
+      const btn = Number(m[1]);
+      if (btn >= 64) continue; // wheel
+      if ((btn & 3) !== 0) continue; // left button only
+      if (btn & 32) {
+        dragHasMotion = true;
+      } else if (m[2] === "m") {
+        lastAppDragAt = dragHasMotion ? Date.now() : 0;
+        dragHasMotion = false;
+      } else {
+        dragHasMotion = false;
+      }
+    }
+  });
+
+  // A copy chord with no local selection belongs to the mouse-owning app:
+  // right after a drag the app is holding a selection, and Claude Code copies
+  // it on Ctrl+C — its only external copy trigger. One-shot so a repeat ⌘C
+  // can't turn into a bare interrupt once the selection is gone.
+  const tryAppCopy = (): boolean => {
+    if (
+      lastAppDragAt &&
+      Date.now() - lastAppDragAt < APP_SELECTION_WINDOW_MS &&
+      term.modes.mouseTrackingMode !== "none" &&
+      viewportShowsAppCopyHint(term)
+    ) {
+      lastAppDragAt = 0;
+      lastUserInputAt = Date.now();
+      sendTerminalInput(terminalId, "\x03").catch(() => {});
+      return true;
+    }
+    return false;
+  };
+
   // Intercept Cmd+key combos before kitty keyboard protocol encodes them.
   // Without this, Cmd+V/C/etc. are sent as CSI u sequences instead of
   // triggering paste/copy/other OS-level shortcuts.
@@ -340,9 +446,47 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
       })
     )
       return false;
+    // ⌘C with no local selection belongs to the mouse-owning app. (On macOS
+    // the native Edit→Copy accelerator usually claims the chord before any
+    // keydown reaches the page — the copy listener below handles that path —
+    // but a keydown that does arrive gets the same treatment.)
+    if (isCopyShortcut(e) && !term.hasSelection()) {
+      // Keep keyup pairing consistent with what its keydown did, so kitty
+      // apps that track key releases never see an orphan press or release.
+      if (e.type !== "keydown") return copyChordForwarded;
+      if (tryAppCopy()) {
+        copyChordForwarded = false;
+        e.preventDefault();
+        return false;
+      }
+      copyChordForwarded = true;
+      return true;
+    }
     if (!e.metaKey) return true;
     return false;
   });
+
+  // The native Edit→Copy accelerator delivers ⌘C as a copy event on the
+  // focused element (no DOM keydown fires), so this listener is the primary
+  // entry point for the chord: local selection wins, otherwise the app gets
+  // to copy its own.
+  host.addEventListener(
+    "copy",
+    (e) => {
+      if (handleNativeCopy(e, term, serialize)) return;
+      if (tryAppCopy()) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    },
+    true,
+  );
+
+  // xterm preventDefaults mousedown (killing the browser's focus change) and
+  // only focuses itself when the app owns the mouse — a plain selection drag
+  // leaves focus in the composer, and the ⌘C that follows would never reach
+  // this terminal. Clicking a terminal means keys belong to it.
+  host.addEventListener("mousedown", () => term.focus());
 
   term.open(host);
 
@@ -369,12 +513,39 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
     themeOverride: null,
     cwd,
     pathLinkDisposable: null,
+    osc52Disposable: null,
     destroy: () => {},
   };
 
   try {
     session.pathLinkDisposable = registerPathLinkProvider(term, {
       getCwd: () => session.cwd,
+    });
+  } catch {}
+
+  // OSC 52: programs that own their selection (Claude Code under mouse
+  // reporting) copy by emitting the selected text; land it in the system
+  // clipboard. Write-only — "?" queries are never answered, since responding
+  // would hand the clipboard contents to the running program.
+  try {
+    session.osc52Disposable = term.parser.registerOscHandler(52, (data) => {
+      const sep = data.indexOf(";");
+      if (sep === -1) return true;
+      const target = data.slice(0, sep);
+      const payload = data.slice(sep + 1);
+      if (target && !target.includes("c")) return true;
+      if (!payload || payload === "?") return true;
+      if (Date.now() - lastUserInputAt > APP_CLIPBOARD_INPUT_WINDOW_MS) return true;
+      // A hidden pane can't be answering the user — drop background writes.
+      if (!session.host.isConnected || session.host.offsetParent === null) return true;
+      try {
+        const bytes = Uint8Array.from(atob(payload), (ch) => ch.charCodeAt(0));
+        const text = new TextDecoder().decode(bytes);
+        if (text) writeAppClipboard(text);
+      } catch {
+        // Malformed base64 — ignore.
+      }
+      return true;
     });
   } catch {}
 

--- a/desktop/frontend/src/components/InteractivePane.tsx
+++ b/desktop/frontend/src/components/InteractivePane.tsx
@@ -57,11 +57,12 @@ interface InteractivePaneProps {
 // Flow control: ack in batches to reduce IPC calls (matches VS Code's approach)
 const ACK_SIZE = 5000;
 
-// ⌘C this soon after a drag reported to a mouse-owning app asks the app to
-// copy its own selection (Ctrl+C — Claude Code's only copy trigger). Past the
-// window the selection is too likely gone, and a bare Ctrl+C doubles as an
-// interrupt, so the chord is not translated.
-const APP_SELECTION_WINDOW_MS = 15000;
+// A copy this soon after a selection gesture reported to a mouse-owning app
+// asks the app to copy its own selection (Ctrl+C — Claude Code's only copy
+// trigger). The on-screen copy hint is what verifies the selection is still
+// alive at fire time; the window just bounds how long a stale gesture can
+// authorize one, since a bare Ctrl+C doubles as an interrupt.
+const APP_SELECTION_WINDOW_MS = 60000;
 // An app may write the clipboard only on the heels of the user's own input to
 // its terminal (a copy is always an answer to a keystroke or click there).
 // Anything later — or from a session the user isn't touching — is dropped.
@@ -167,6 +168,11 @@ interface InteractiveSession {
   cwd: string;
   pathLinkDisposable: IDisposable | null;
   osc52Disposable: IDisposable | null;
+
+  // Copy routed to the mouse-owning app (Claude Code's Ctrl+C-with-selection);
+  // exposed so the context menu shares the ⌘C path's gates.
+  canAppCopy: () => boolean;
+  tryAppCopy: () => boolean;
 
   // Installed by the current React mount, cleared on unmount so callbacks
   // closing over stale component state don't fire.
@@ -349,6 +355,11 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
     vtExtensions: { kittyKeyboard: true },
     // Mouse-owning apps suppress local selection; ⌥ drag opts back into it.
     macOptionClickForcesSelection: true,
+    // On mac xterm word-selects under a right-click by default. That phantom
+    // selection would shadow the running app's own selection in the context
+    // menu, making Copy grab the word under the cursor instead of asking the
+    // app for what the user highlighted.
+    rightClickSelectsWord: false,
     linkHandler: { activate: openTerminalLink },
   });
 
@@ -384,6 +395,7 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
   let lastAppDragAt = 0;
   let lastUserInputAt = 0;
   let dragHasMotion = false;
+  let multiClickPending = false;
   let copyChordForwarded = false;
 
   term.onData((data) => {
@@ -404,8 +416,11 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
       if (btn & 32) {
         dragHasMotion = true;
       } else if (m[2] === "m") {
-        lastAppDragAt = dragHasMotion ? Date.now() : 0;
+        // Drags and double/triple clicks give the app a selection; a plain
+        // motionless click clears one.
+        lastAppDragAt = dragHasMotion || multiClickPending ? Date.now() : 0;
         dragHasMotion = false;
+        multiClickPending = false;
       } else {
         dragHasMotion = false;
       }
@@ -416,19 +431,18 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
   // right after a drag the app is holding a selection, and Claude Code copies
   // it on Ctrl+C — its only external copy trigger. One-shot so a repeat ⌘C
   // can't turn into a bare interrupt once the selection is gone.
+  const canAppCopy = (): boolean =>
+    lastAppDragAt !== 0 &&
+    Date.now() - lastAppDragAt < APP_SELECTION_WINDOW_MS &&
+    term.modes.mouseTrackingMode !== "none" &&
+    viewportShowsAppCopyHint(term);
+
   const tryAppCopy = (): boolean => {
-    if (
-      lastAppDragAt &&
-      Date.now() - lastAppDragAt < APP_SELECTION_WINDOW_MS &&
-      term.modes.mouseTrackingMode !== "none" &&
-      viewportShowsAppCopyHint(term)
-    ) {
-      lastAppDragAt = 0;
-      lastUserInputAt = Date.now();
-      sendTerminalInput(terminalId, "\x03").catch(() => {});
-      return true;
-    }
-    return false;
+    if (!canAppCopy()) return false;
+    lastAppDragAt = 0;
+    lastUserInputAt = Date.now();
+    sendTerminalInput(terminalId, "\x03").catch(() => {});
+    return true;
   };
 
   // Intercept Cmd+key combos before kitty keyboard protocol encodes them.
@@ -485,8 +499,13 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
   // xterm preventDefaults mousedown (killing the browser's focus change) and
   // only focuses itself when the app owns the mouse — a plain selection drag
   // leaves focus in the composer, and the ⌘C that follows would never reach
-  // this terminal. Clicking a terminal means keys belong to it.
-  host.addEventListener("mousedown", () => term.focus());
+  // this terminal. Clicking a terminal means keys belong to it. The click
+  // count rides along: SGR reports can't distinguish a double-click word
+  // selection from a selection-clearing single click.
+  host.addEventListener("mousedown", (e) => {
+    term.focus();
+    if (e.button === 0) multiClickPending = e.detail >= 2;
+  });
 
   term.open(host);
 
@@ -514,6 +533,8 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
     cwd,
     pathLinkDisposable: null,
     osc52Disposable: null,
+    canAppCopy,
+    tryAppCopy,
     destroy: () => {},
   };
 
@@ -954,6 +975,8 @@ export function InteractivePane({
           serialize={sessionRef.current.serialize}
           canPaste
           filter={filterRef.current}
+          appCopyAvailable={sessionRef.current.canAppCopy()}
+          onAppCopy={() => sessionRef.current?.tryAppCopy()}
           onClear={clearConsole}
           onPaste={() => {
             navigator.clipboard

--- a/desktop/frontend/src/components/Pane.tsx
+++ b/desktop/frontend/src/components/Pane.tsx
@@ -6,7 +6,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { getTerminalTheme, openTerminalLink } from "./terminal-utils";
-import { copyTerminalSelection, handleCopyShortcut, handleSelectAllShortcut, handleClearShortcut } from "./terminal/copySelection";
+import { copyTerminalSelection, handleCopyShortcut, handleNativeCopy, handleSelectAllShortcut, handleClearShortcut } from "./terminal/copySelection";
 import { applyFilterQuery, FilterMirror } from "./terminal/FilterMirror";
 import { registerPathLinkProvider } from "./terminal/pathLinkProvider";
 import { ChevronRightIcon } from "./icons";
@@ -94,6 +94,12 @@ function createPaneSession(opts: { fontSize: number; theme: ITheme; cwd: string 
     if (handleClearShortcut(e, term, { force: true, onClear: () => clearPaneSession(session) })) return false;
     return true;
   });
+
+  host.addEventListener("copy", (e) => handleNativeCopy(e, term, serialize), true);
+
+  // xterm preventDefaults mousedown without focusing itself, so a selection
+  // drag would otherwise leave ⌘C pointed at the previously focused element.
+  host.addEventListener("mousedown", () => term.focus());
 
   return session;
 }

--- a/desktop/frontend/src/components/TerminalComposer.tsx
+++ b/desktop/frontend/src/components/TerminalComposer.tsx
@@ -44,6 +44,7 @@ import { loadImageDataUrl } from "./imageDataUrl";
 import { TerminalHistoryButton } from "./TerminalHistoryButton";
 import { TerminalDropOverlay } from "./terminal/TerminalDropOverlay";
 import { basename } from "../path";
+import { composerPlaceholder } from "../composerText";
 import {
   caretCharOffset,
   caretEdges,
@@ -1589,7 +1590,7 @@ export function TerminalComposer({ terminalId, historyKey, projectName, shown, f
             style={textStyle}
             className="pointer-events-none absolute left-3.5 top-2.5 text-[var(--text-muted)]"
           >
-            Send to {targetLabel}…
+            {composerPlaceholder(targetLabel)}
           </div>
         )}
         {hint && (

--- a/desktop/frontend/src/components/terminal/ConsoleContextMenu.tsx
+++ b/desktop/frontend/src/components/terminal/ConsoleContextMenu.tsx
@@ -12,6 +12,10 @@ interface ConsoleContextMenuProps {
   serialize: SerializeAddon | null;
   canPaste: boolean;
   filter?: ConsoleFilter | null;
+  // The running app holds the selection (mouse-owning TUIs); Copy asks it to
+  // copy instead of reading the terminal's own (empty) selection.
+  appCopyAvailable?: boolean;
+  onAppCopy?: () => void;
   onClear: () => void;
   onPaste?: () => void;
   onClose: () => void;
@@ -24,6 +28,8 @@ export function ConsoleContextMenu({
   serialize,
   canPaste,
   filter,
+  appCopyAvailable,
+  onAppCopy,
   onClear,
   onPaste,
   onClose,
@@ -38,8 +44,11 @@ export function ConsoleContextMenu({
       <ContextMenuItem
         label="Copy"
         shortcut="⌘C"
-        disabled={!hasSelection}
-        onClick={run(() => copyTerminalSelection(term, serialize))}
+        disabled={!hasSelection && !appCopyAvailable}
+        onClick={run(() => {
+          if (hasSelection) copyTerminalSelection(term, serialize);
+          else onAppCopy?.();
+        })}
       />
       {canPaste && onPaste && (
         <ContextMenuItem label="Paste" shortcut="⌘V" onClick={run(onPaste)} />

--- a/desktop/frontend/src/components/terminal/FilterMirror.ts
+++ b/desktop/frontend/src/components/terminal/FilterMirror.ts
@@ -3,6 +3,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { SearchAddon } from "@xterm/addon-search";
 import type { SerializeAddon } from "@xterm/addon-serialize";
 import { TERMINAL_FONT_FAMILY } from "../terminal-utils";
+import { handleCopyShortcut, handleNativeCopy } from "./copySelection";
 import { filterLines, stripAnsi } from "./filterLines";
 
 const MATCH_DECORATIONS = {
@@ -133,6 +134,11 @@ export class FilterMirror {
       search = new SearchAddon();
       term.loadAddon(search);
     } catch {}
+    term.attachCustomKeyEventHandler((e) => !handleCopyShortcut(e, term, null));
+    host.addEventListener("copy", (e) => handleNativeCopy(e, term, null), true);
+    // xterm preventDefaults mousedown without focusing itself, so a selection
+    // drag would otherwise leave ⌘C pointed at the previously focused element.
+    host.addEventListener("mousedown", () => term.focus());
     term.open(host);
 
     this.mirror = term;

--- a/desktop/frontend/src/components/terminal/copySelection.test.ts
+++ b/desktop/frontend/src/components/terminal/copySelection.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { handleCopyShortcut, handleNativeCopy } from "./copySelection";
+
+interface FakeRow {
+  text: string;
+  wrapped?: boolean;
+}
+
+function fakeTerm(
+  rows: FakeRow[],
+  sel?: { startX?: number; endX?: number },
+) {
+  const startX = sel?.startX ?? 0;
+  const endX = rows.length ? (sel?.endX ?? rows[rows.length - 1].text.length) : 0;
+  return {
+    getSelection: () => rows.map((r) => r.text).join("\n"),
+    getSelectionPosition: () =>
+      rows.length
+        ? {
+            start: { x: startX, y: 0 },
+            end: { x: endX, y: rows.length - 1 },
+          }
+        : undefined,
+    buffer: {
+      active: {
+        getLine: (y: number) => ({
+          isWrapped: !!rows[y].wrapped,
+          translateToString: (_trim: boolean, sx: number, ex?: number) =>
+            rows[y].text.slice(sx, ex),
+        }),
+      },
+    },
+  } as never;
+}
+
+function keyEvent(over: Partial<KeyboardEvent> = {}): KeyboardEvent {
+  return {
+    type: "keydown",
+    key: "c",
+    metaKey: true,
+    ctrlKey: false,
+    altKey: false,
+    preventDefault: vi.fn(),
+    ...over,
+  } as unknown as KeyboardEvent;
+}
+
+function copyEvent() {
+  const data = new Map<string, string>();
+  const event = {
+    clipboardData: {
+      setData: (type: string, value: string) => data.set(type, value),
+    },
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  } as unknown as ClipboardEvent;
+  return { event, data };
+}
+
+let written: string | null;
+
+beforeEach(() => {
+  written = null;
+  vi.stubGlobal("navigator", {
+    clipboard: {
+      writeText: vi.fn(async (t: string) => {
+        written = t;
+      }),
+    },
+  });
+});
+
+describe("handleCopyShortcut", () => {
+  it("copies the cleaned selection on ⌘C keydown", async () => {
+    const e = keyEvent();
+    const handled = handleCopyShortcut(e, fakeTerm([{ text: "  foo" }, { text: "  bar" }]), null);
+    await Promise.resolve();
+    expect(handled).toBe(true);
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(written).toBe("foo\nbar");
+  });
+
+  it("still matches when Caps Lock uppercases the key", async () => {
+    const e = keyEvent({ key: "C" });
+    const handled = handleCopyShortcut(e, fakeTerm([{ text: "foo" }]), null);
+    await Promise.resolve();
+    expect(handled).toBe(true);
+    expect(written).toBe("foo");
+  });
+
+  it("matches the physical C key on non-Latin layouts", async () => {
+    const e = keyEvent({ key: "с", code: "KeyC" });
+    const handled = handleCopyShortcut(e, fakeTerm([{ text: "foo" }]), null);
+    await Promise.resolve();
+    expect(handled).toBe(true);
+    expect(written).toBe("foo");
+  });
+
+  it("does not match the physical C key when the layout puts another Latin letter there", () => {
+    const e = keyEvent({ key: "j", code: "KeyC" });
+    expect(handleCopyShortcut(e, fakeTerm([{ text: "foo" }]), null)).toBe(false);
+    expect(written).toBeNull();
+  });
+
+  it("leaves ⌘C alone when nothing is selected, so the app can receive it", () => {
+    const e = keyEvent();
+    expect(handleCopyShortcut(e, fakeTerm([]), null)).toBe(false);
+    expect(e.preventDefault).not.toHaveBeenCalled();
+    expect(written).toBeNull();
+  });
+
+  it("ignores Ctrl+C so it keeps interrupting the running program", () => {
+    const e = keyEvent({ metaKey: false, ctrlKey: true });
+    expect(handleCopyShortcut(e, fakeTerm([{ text: "foo" }]), null)).toBe(false);
+    expect(e.preventDefault).not.toHaveBeenCalled();
+    expect(written).toBeNull();
+  });
+
+  it("ignores ⌘C on keyup", () => {
+    const e = keyEvent({ type: "keyup" });
+    expect(handleCopyShortcut(e, fakeTerm([{ text: "foo" }]), null)).toBe(false);
+    expect(e.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("ignores ⌘C with Ctrl or Alt held", () => {
+    expect(handleCopyShortcut(keyEvent({ ctrlKey: true }), fakeTerm([{ text: "x" }]), null)).toBe(false);
+    expect(handleCopyShortcut(keyEvent({ altKey: true }), fakeTerm([{ text: "x" }]), null)).toBe(false);
+  });
+
+  it("ignores ⌘⇧C so it stays inert like before", () => {
+    const e = keyEvent({ key: "C", shiftKey: true });
+    expect(handleCopyShortcut(e, fakeTerm([{ text: "x" }]), null)).toBe(false);
+    expect(e.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("leaves a whitespace-only selection alone instead of blanking the clipboard", () => {
+    const e = keyEvent();
+    expect(handleCopyShortcut(e, fakeTerm([{ text: "   " }, { text: "\t " }]), null)).toBe(false);
+    expect(e.preventDefault).not.toHaveBeenCalled();
+    expect(written).toBeNull();
+  });
+
+  it("respects partial-row selection bounds", async () => {
+    const e = keyEvent();
+    const term = fakeTerm(
+      [{ text: "hello world" }, { text: "second line" }],
+      { startX: 6, endX: 6 },
+    );
+    handleCopyShortcut(e, term, null);
+    await Promise.resolve();
+    expect(written).toBe("world\nsecond");
+  });
+});
+
+describe("handleNativeCopy", () => {
+  it("writes the cleaned selection into the clipboard event", () => {
+    const { event, data } = copyEvent();
+    const handled = handleNativeCopy(event, fakeTerm([{ text: "  foo" }, { text: "  bar" }]), null);
+    expect(handled).toBe(true);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(data.get("text/plain")).toBe("foo\nbar");
+    expect(data.has("text/html")).toBe(false);
+    expect(written).toBeNull();
+  });
+
+  it("writes text/html when a serializer is available", () => {
+    const { event, data } = copyEvent();
+    const serialize = { serializeAsHTML: () => "<pre>html</pre>" } as never;
+    handleNativeCopy(event, fakeTerm([{ text: "foo" }]), serialize);
+    expect(data.get("text/plain")).toBe("foo");
+    expect(data.get("text/html")).toBe("<pre>html</pre>");
+  });
+
+  it("leaves the event alone when nothing is selected", () => {
+    const { event, data } = copyEvent();
+    expect(handleNativeCopy(event, fakeTerm([]), null)).toBe(false);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(data.size).toBe(0);
+  });
+
+  it("merges soft-wrapped rows back into one logical line", () => {
+    const { event, data } = copyEvent();
+    handleNativeCopy(event, fakeTerm([{ text: "aaa" }, { text: "bbb", wrapped: true }]), null);
+    expect(data.get("text/plain")).toBe("aaabbb");
+  });
+
+  it("strips a shared agent gutter prefix", () => {
+    const { event, data } = copyEvent();
+    handleNativeCopy(event, fakeTerm([{ text: "▎ foo" }, { text: "▎ bar" }]), null);
+    expect(data.get("text/plain")).toBe("foo\nbar");
+  });
+
+});
+
+describe("cleaning semantics", () => {
+  function copied(rows: Array<{ text: string; wrapped?: boolean }>): string | undefined {
+    const { event, data } = copyEvent();
+    handleNativeCopy(event, fakeTerm(rows), null);
+    return data.get("text/plain");
+  }
+
+  it("strips the gutter at exactly the 4-in-5 ratio", () => {
+    expect(
+      copied([
+        { text: "▎ a" },
+        { text: "▎ b" },
+        { text: "▎ c" },
+        { text: "▎ d" },
+        { text: "plain" },
+      ]),
+    ).toBe("a\nb\nc\nd\nplain");
+  });
+
+  it("keeps the gutter below the ratio", () => {
+    expect(
+      copied([{ text: "▎ a" }, { text: "▎ b" }, { text: "▎ c" }, { text: "x" }, { text: "y" }]),
+    ).toBe("▎ a\n▎ b\n▎ c\nx\ny");
+  });
+
+  it("dedents a single indented line entirely", () => {
+    expect(copied([{ text: "    return x;" }])).toBe("return x;");
+  });
+
+  it("collapses runs of blank lines down to one", () => {
+    expect(copied([{ text: "a" }, { text: "" }, { text: "" }, { text: "b" }])).toBe("a\n\nb");
+  });
+});

--- a/desktop/frontend/src/components/terminal/copySelection.ts
+++ b/desktop/frontend/src/components/terminal/copySelection.ts
@@ -217,15 +217,22 @@ async function writeClipboard(plain: string, html: string | null): Promise<void>
   await navigator.clipboard.writeText(plain);
 }
 
-export function copyTerminalSelection(
+interface ClipboardPayload {
+  plain: string;
+  html: string | null;
+}
+
+function buildClipboardPayload(
   term: Terminal,
   serialize: SerializeAddon | null,
-): void {
+): ClipboardPayload | null {
   const selection = getSelectionRespectingWraps(term);
-  if (!selection) return;
+  if (!selection) return null;
 
   const rules = detectRules(selection);
   const plain = cleanPlainText(selection, rules);
+  // A whitespace-only selection cleans to nothing — don't blank the clipboard.
+  if (!/\S/.test(plain)) return null;
 
   let html: string | null = null;
   if (serialize) {
@@ -236,22 +243,62 @@ export function copyTerminalSelection(
     }
   }
 
-  void writeClipboard(plain, html).catch(() => {});
+  return { plain, html };
 }
 
-// Returns true if the event was a Cmd+C that we handled. Callers should
-// return `false` from their attachCustomKeyEventHandler so xterm doesn't
-// also process the event.
+export function copyTerminalSelection(
+  term: Terminal,
+  serialize: SerializeAddon | null,
+): void {
+  const payload = buildClipboardPayload(term, serialize);
+  if (!payload) return;
+  void writeClipboard(payload.plain, payload.html).catch(() => {});
+}
+
+export function isCopyShortcut(e: KeyboardEvent): boolean {
+  if (!e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return false;
+  const key = e.key.toLowerCase();
+  if (key === "c") return true;
+  // Non-Latin layouts (e.g. Russian "с") keep ⌘C on the physical C key but
+  // report their own letter; Latin layouts that move "c" elsewhere (Dvorak)
+  // must not match the physical key.
+  return e.code === "KeyC" && !/^[a-z]$/.test(key);
+}
+
+// Returns true if the event was a Cmd+C over a live selection that we copied.
+// Callers should return `false` from their attachCustomKeyEventHandler so
+// xterm doesn't also process the event. Without a selection the event is left
+// untouched — the running app may own the mouse (and with it the selection),
+// in which case the chord belongs to the app, not to us.
 export function handleCopyShortcut(
   e: KeyboardEvent,
   term: Terminal,
   serialize: SerializeAddon | null,
 ): boolean {
-  if (!(e.metaKey && e.key === "c" && e.type === "keydown")) return false;
+  if (!(isCopyShortcut(e) && e.type === "keydown")) return false;
+  const payload = buildClipboardPayload(term, serialize);
+  if (!payload) return false;
   // Stop WebKit's native Cmd+C from clobbering our clipboard write with the
   // raw selection from xterm's hidden helper textarea.
   e.preventDefault();
-  copyTerminalSelection(term, serialize);
+  void writeClipboard(payload.plain, payload.html).catch(() => {});
+  return true;
+}
+
+// Populates a native copy (Edit menu, context menu) with the same cleaned
+// payload the shortcut path produces, instead of xterm's raw selection text.
+export function handleNativeCopy(
+  e: ClipboardEvent,
+  term: Terminal,
+  serialize: SerializeAddon | null,
+): boolean {
+  if (!e.clipboardData) return false;
+  const payload = buildClipboardPayload(term, serialize);
+  if (!payload) return false;
+  e.preventDefault();
+  e.stopPropagation();
+  e.clipboardData.setData("text/plain", payload.plain);
+  if (payload.html) e.clipboardData.setData("text/html", payload.html);
   return true;
 }
 

--- a/desktop/frontend/src/components/terminal/copySelection.ts
+++ b/desktop/frontend/src/components/terminal/copySelection.ts
@@ -1,5 +1,6 @@
 import type { Terminal } from "@xterm/xterm";
 import type { SerializeAddon } from "@xterm/addon-serialize";
+import { SetClipboardText } from "../../../bridge/commands";
 
 // Cleans terminal selections before they hit the clipboard:
 //   1. merges soft-wrapped rows back into one logical line
@@ -214,7 +215,13 @@ async function writeClipboard(plain: string, html: string | null): Promise<void>
       // Rich write rejected — fall through to plain-text only.
     }
   }
-  await navigator.clipboard.writeText(plain);
+  try {
+    await navigator.clipboard.writeText(plain);
+  } catch {
+    // The WKWebView refuses clipboard writes it doesn't consider gesture-
+    // backed (context-menu clicks among them) — write through the backend.
+    await SetClipboardText(plain);
+  }
 }
 
 interface ClipboardPayload {

--- a/desktop/frontend/src/composerText.ts
+++ b/desktop/frontend/src/composerText.ts
@@ -1,0 +1,5 @@
+// The composer's placeholder, shared by the live input and its closed-state
+// stand-in (ComposerReopenBar) so both always read the same and can't drift.
+export function composerPlaceholder(targetLabel: string): string {
+  return `Send to ${targetLabel}…`;
+}


### PR DESCRIPTION
Adds robust terminal copy support for app-owned selections, including Claude Code-style mouse selections and OSC 52 clipboard writes. Also tightens normal terminal copy behavior and shares composer placeholder text across open/collapsed states.

- Added a Tauri `SetClipboardText` command backed by `pbcopy`
- Routed app-owned terminal copy through guarded Ctrl+C forwarding and OSC 52 handling
- Made context menu Copy work for both xterm selections and app-owned selections
- Improved native copy/focus handling across terminal panes and filtered output
- Removed leaked `TMUX` environment vars from spawned PTYs
- Shared composer placeholder text between the composer and reopen bar
- Added tests for terminal copy selection behavior