### PR TITLE
Add live mirroring for detached terminals

### DIFF
--- a/desktop/frontend/bridge/commands.js
+++ b/desktop/frontend/bridge/commands.js
@@ -499,8 +499,8 @@ export function SetProjectLabel(name, label) {
 export function MoveProjectRoot(name, newRoot) {
   return invoke("move_project_root", { name, newRoot });
 }
-export function StartLogStreaming(projectName) {
-  return invoke("start_log_streaming", { projectName });
+export function StartLogStreaming(projectName, viewer) {
+  return invoke("start_log_streaming", { projectName, viewer });
 }
 export function StartProject(name, profile) {
   return invoke("start_project", { name, profile });
@@ -532,8 +532,8 @@ export function StartWatchingProject(path) {
 export function StopAll() {
   return invoke("stop_all");
 }
-export function StopLogStreaming(projectName) {
-  return invoke("stop_log_streaming", { projectName });
+export function StopLogStreaming(projectName, viewer) {
+  return invoke("stop_log_streaming", { projectName, viewer });
 }
 export function StopProject(name) {
   return invoke("stop_project", { name });

--- a/desktop/frontend/src-tauri/src/log_streaming.rs
+++ b/desktop/frontend/src-tauri/src/log_streaming.rs
@@ -4,7 +4,7 @@
 // + AtomicBool cancel flag (PTY-style; no tokio).
 use crate::{config, tmux};
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -20,9 +20,18 @@ struct LogUpdate {
     content: String,
 }
 
+// One poller per project, refcounted by viewer. Both the main window and a
+// detached mirror can watch the same project's logs; the poller must live while
+// EITHER is watching, so a viewer set governs it instead of a bare cancel flag —
+// otherwise one window pausing (hidden/deselected) would freeze the other's logs.
+pub struct Stream {
+    cancel: Arc<AtomicBool>,
+    viewers: HashSet<String>,
+}
+
 pub struct LogState {
-    // keyed by project FILE name -> cancel flag for its poller
-    pub streams: Mutex<HashMap<String, Arc<AtomicBool>>>,
+    // keyed by project FILE name -> its poller + active viewers
+    pub streams: Mutex<HashMap<String, Stream>>,
 }
 
 impl Default for LogState {
@@ -56,21 +65,42 @@ pub fn start_log_streaming(
     app: AppHandle,
     state: State<'_, LogState>,
     project_name: String,
+    viewer: Option<String>,
 ) -> Result<(), String> {
+    let viewer = viewer.unwrap_or_else(|| "main".to_string());
+
+    {
+        let mut streams = state.streams.lock().unwrap();
+        // A poller already running for this project just gains a viewer — never
+        // respawn (that would double-emit); the existing thread already serves
+        // every window listening on the global `log-update` event.
+        if let Some(existing) = streams.get_mut(&project_name) {
+            existing.viewers.insert(viewer);
+            return Ok(());
+        }
+    }
+
     // Resolve the session up front; if the project can't be read, no-op.
     let session = match config::spawn_info(&project_name) {
         Ok(info) => info.session,
         Err(_) => return Ok(()),
     };
 
-    // Cancel-and-replace any existing poller so we never double-emit.
     let stop = Arc::new(AtomicBool::new(false));
     {
         let mut streams = state.streams.lock().unwrap();
-        if let Some(old) = streams.remove(&project_name) {
-            old.store(true, Ordering::SeqCst);
+        // Re-check under the lock: a concurrent start may have spawned first.
+        if let Some(existing) = streams.get_mut(&project_name) {
+            existing.viewers.insert(viewer);
+            return Ok(());
         }
-        streams.insert(project_name.clone(), stop.clone());
+        streams.insert(
+            project_name.clone(),
+            Stream {
+                cancel: stop.clone(),
+                viewers: HashSet::from([viewer]),
+            },
+        );
     }
 
     std::thread::spawn(move || {
@@ -88,9 +118,22 @@ pub fn start_log_streaming(
 }
 
 #[tauri::command(async)]
-pub fn stop_log_streaming(state: State<'_, LogState>, project_name: String) -> Result<(), String> {
-    if let Some(stop) = state.streams.lock().unwrap().remove(&project_name) {
-        stop.store(true, Ordering::SeqCst);
+pub fn stop_log_streaming(
+    state: State<'_, LogState>,
+    project_name: String,
+    viewer: Option<String>,
+) -> Result<(), String> {
+    let viewer = viewer.unwrap_or_else(|| "main".to_string());
+    let mut streams = state.streams.lock().unwrap();
+    let Some(existing) = streams.get_mut(&project_name) else {
+        return Ok(());
+    };
+    existing.viewers.remove(&viewer);
+    // Stop the poller only when the last viewer leaves, so one window pausing
+    // doesn't freeze the other's live logs.
+    if existing.viewers.is_empty() {
+        existing.cancel.store(true, Ordering::SeqCst);
+        streams.remove(&project_name);
     }
     Ok(())
 }

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import { useAppEvents } from "./hooks/useAppEvents";
 import { useProjectWatcher } from "./hooks/useProjectWatcher";
 import { getSettings, saveSettings } from "./store/settings";
 import { useAppStore } from "./store/app";
+import { onRunInDuplicates } from "./mirror";
 
 import { InstallTmux, TmuxInstalled } from "../bridge/commands";
 
@@ -72,13 +73,12 @@ export default function App() {
   const moveProjectsToGroup = useAppStore((s) => s.moveProjectsToGroup);
   const detachProject = useAppStore((s) => s.detachProject);
   const attachProject = useAppStore((s) => s.attachProject);
-  const focusDetachedProject = useAppStore((s) => s.focusDetachedProject);
   const refreshAfterRename = useAppStore((s) => s.refreshAfterRename);
 
-  const handleSelect = async (name: string) => {
-    // Race guard: if the window closed between sidebar paint and click,
-    // fall back to in-pane selection instead of swallowing the click.
-    if (detached.has(name) && (await focusDetachedProject(name))) return;
+  const handleSelect = (name: string) => {
+    // The main window owns every project's terminals, including detached ones
+    // (mirrored into their own window). Clicking a detached project shows it
+    // inline here rather than redirecting to its window — it's live in both.
     selectProject(name);
   };
 
@@ -94,6 +94,20 @@ export default function App() {
   useProjectsSync();
   useAppEvents();
   const isFullscreen = useIsFullscreen();
+
+  // A mirror (detached) window can trigger run-in-duplicates but can't create
+  // the copies itself — they mount and auto-run in this main window's store.
+  useEffect(
+    () =>
+      onRunInDuplicates((p) =>
+        bulkDuplicate(
+          p.project,
+          p.count,
+          p.opts as Parameters<typeof bulkDuplicate>[2],
+        ),
+      ),
+    [bulkDuplicate],
+  );
 
   useEffect(() => {
     TmuxInstalled().then(setTmuxReady);
@@ -141,12 +155,12 @@ export default function App() {
     if (projects.length > 0) pruneVisitedToProjects();
   }, [projects, pruneVisitedToProjects]);
 
-  // Hide detached projects from main-window content — their detail view
-  // lives in their own window, and rendering it inline too would duplicate
-  // terminal mounts and steal focus from the detached webview.
+  // The main window owns every project's terminals, so a detached project stays
+  // mounted here (its detached window is a mirror that adopts these live PTYs).
+  // Detached projects are always kept mounted — even when not selected — so the
+  // owner exists for the mirror to attach to (e.g. a window restored at launch).
   const visitedProjects = projects.filter(
-    (p) =>
-      !detached.has(p.name) && (p.name === selected || visited.has(p.name)),
+    (p) => detached.has(p.name) || p.name === selected || visited.has(p.name),
   );
 
   if (tmuxReady === null) {

--- a/desktop/frontend/src/components/BrowserMirrorPlaceholder.tsx
+++ b/desktop/frontend/src/components/BrowserMirrorPlaceholder.tsx
@@ -1,0 +1,14 @@
+import { GlobeIcon } from "./icons";
+
+// A browser tab is backed by a single native webview keyed by the tab id, which
+// only one window can own. In a mirror window we render this placeholder instead
+// of a second BrowserPane so we never fight the owner over the webview's bounds
+// or tear it down when the mirror closes.
+export function BrowserMirrorPlaceholder() {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-2 bg-[var(--bg-primary)] text-[var(--text-muted)]">
+      <GlobeIcon />
+      <div className="text-xs">Browser is available in the main window</div>
+    </div>
+  );
+}

--- a/desktop/frontend/src/components/InteractivePane.tsx
+++ b/desktop/frontend/src/components/InteractivePane.tsx
@@ -746,6 +746,15 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
   );
 
   // Cross-window mirroring wiring.
+  //
+  // Size authority follows OS window focus: activating a window reconciles this
+  // session's geometry (a focused mirror claims the PTY size for its container;
+  // a focused owner re-fits and reclaims it), so whichever window the user is in
+  // gets a perfectly fitted terminal. One listener for both roles — reconcile
+  // dispatches on IS_MIRROR_WINDOW and no-ops for panes that aren't laid out.
+  const onWinFocus = () => reconcileGeometry(session, terminalId);
+  window.addEventListener("focus", onWinFocus);
+
   let cleanupMirror: (() => void) | null = null;
   if (IS_MIRROR_WINDOW) {
     // Render the owner's authoritative geometry (the mirror never fits its own
@@ -834,8 +843,9 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
     };
   } else {
     // Owner: seed a joining mirror's screen, and honor the mirror's DESIRED
-    // geometry only while our own pane is hidden — so a mirror that is the sole
-    // visible view isn't stuck at our stale/default size.
+    // geometry whenever this window isn't the active one (unfocused or pane
+    // hidden) — size authority follows focus. Resize our own xterm to match so
+    // this view letterboxes instead of mis-wrapping while the mirror drives.
     const offSnapReq = onMirrorSnapshotRequest(terminalId, () => {
       replyMirrorSnapshot(terminalId, {
         data: serialize?.serialize() ?? "",
@@ -843,8 +853,16 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
         rows: term.rows,
       });
     });
+    // This window owns the shared PTY size while it's the focused, laid-out
+    // view; only then does it ignore the mirror's desired size and drive its
+    // own. (macOS focuses one window at a time, so authority is never contested.)
+    const hasSizeAuthority = () => document.hasFocus() && isLaidOut();
     const offDesired = onMirrorDesired(terminalId, ({ cols, rows }) => {
-      if (!cols || !rows || isLaidOut()) return;
+      if (!cols || !rows) return;
+      if (hasSizeAuthority()) return;
+      try {
+        term.resize(cols, rows);
+      } catch {}
       driveOwnerSize(cols, rows);
     });
     cleanupMirror = () => {
@@ -857,6 +875,7 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
     textarea?.removeEventListener("paste", handlePaste, true);
     if (typeof cleanupOutput === "function") cleanupOutput();
     if (typeof cleanupExit === "function") cleanupExit();
+    window.removeEventListener("focus", onWinFocus);
     cleanupMirror?.();
   };
 
@@ -875,11 +894,19 @@ function getOrCreateInteractiveSession(terminalId: string, cwd: string): Interac
 }
 
 // React to a geometry trigger (mount, container resize, font change, becoming
-// visible): the owner fits its xterm to its container and drives the shared PTY
-// size, while a mirror never fits (that would mis-wrap the shared stream) and
-// instead publishes the size its container could hold for the owner to honor.
+// visible or focused): the owner fits its xterm to its container and drives the
+// shared PTY size, while a mirror never fits (that would mis-wrap the shared
+// stream) and instead publishes the size its container could hold. Size
+// authority follows OS window focus — only a focused mirror claims the PTY, so
+// whichever window the user is working in gets a perfectly fitted terminal and
+// an unfocused claim can never fight the active window.
 function reconcileGeometry(session: InteractiveSession, terminalId: string): void {
+  // A pane with no layout (hidden tab / a detached project kept mounted but
+  // unselected in the main window) has nothing to reconcile — skip before any
+  // fit/measure so a window-focus event doesn't fan out to every hidden pane.
+  if (session.host.offsetParent === null) return;
   if (IS_MIRROR_WINDOW) {
+    if (!document.hasFocus()) return;
     const dims = session.fit.proposeDimensions();
     if (dims && dims.cols && dims.rows) {
       broadcastMirrorDesired(terminalId, { cols: dims.cols, rows: dims.rows });

--- a/desktop/frontend/src/components/InteractivePane.tsx
+++ b/desktop/frontend/src/components/InteractivePane.tsx
@@ -26,6 +26,17 @@ import { applyFilterQuery, FilterMirror } from "./terminal/FilterMirror";
 import { stripAnsi } from "./terminal/filterLines";
 import { registerPathLinkProvider } from "./terminal/pathLinkProvider";
 import { registerFileDropHandler } from "../fileDrop";
+import {
+  IS_MIRROR_WINDOW,
+  broadcastMirrorSize,
+  onMirrorSize,
+  broadcastMirrorDesired,
+  onMirrorDesired,
+  onMirrorSnapshotRequest,
+  replyMirrorSnapshot,
+  requestMirrorSnapshot,
+  onMirrorSnapshot,
+} from "../mirror";
 import "@xterm/xterm/css/xterm.css";
 
 export interface InteractivePaneHandle {
@@ -573,7 +584,12 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
   ensureThemeObserver();
 
   let unsentAck = 0;
+  // Only the owner window acks. A mirror renders the same global broadcast but
+  // must not touch the single per-session flow-control counter — two windows
+  // acking the same bytes would drive it negative and disable backpressure. The
+  // owner's ack still bounds the producer, so the mirror can't lag unboundedly.
   const ackData = (charCount: number) => {
+    if (IS_MIRROR_WINDOW) return;
     unsentAck += charCount;
     while (unsentAck >= ACK_SIZE) {
       unsentAck -= ACK_SIZE;
@@ -581,10 +597,36 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
     }
   };
 
-  // Always write + ack, even when the pane is hidden. xterm.js keeps its own
-  // bounded scrollback, so background terminals stay drained and long-running
-  // processes (AI agents, scripts) never block on a full PTY buffer.
+  // Mirror seeding state: a joining mirror renders nothing until it has a
+  // scrollback snapshot from the owner (or a short fallback fires), so live
+  // output doesn't paint a torn screen ahead of the snapshot. `preSeed` holds
+  // live chunks until then.
+  let seeded = !IS_MIRROR_WINDOW;
+  const preSeed: string[] = [];
+  // A mirror that goes fully hidden (window occluded/minimized) has its xterm
+  // parser throttled by the OS while output keeps arriving — its write backlog
+  // would grow unbounded (the owner's ack governs the PRODUCER, not the mirror).
+  // So a hidden mirror drops output and re-seeds from a fresh snapshot on show.
+  let droppedWhileHidden = false;
+
+  // Always write + ack in the owner, even when the pane is hidden. xterm.js
+  // keeps its own bounded scrollback, so background terminals stay drained and
+  // long-running processes (AI agents, scripts) never block on a full PTY
+  // buffer. A mirror never acks (owner-only) and applies the seeding/memory
+  // gates above before rendering.
   const writeData = (data: string) => {
+    if (IS_MIRROR_WINDOW) {
+      if (document.hidden) {
+        droppedWhileHidden = true;
+        return;
+      }
+      if (!seeded) {
+        preSeed.push(data);
+        return;
+      }
+      term.write(data);
+      return;
+    }
     term.write(data, () => ackData(data.length));
   };
 
@@ -607,8 +649,27 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
     sendTerminalInput(terminalId, data).catch(handleWriteError);
   });
 
-  term.onResize(({ cols, rows }) => {
+  // The owner's host isn't in the DOM yet at session-create and may be mounted
+  // hidden (a detached project kept alive in the main window but not selected).
+  // A hidden host fits to a bogus 80x24 that would then drive the shared PTY, so
+  // the owner only drives geometry while it's actually laid out.
+  const isLaidOut = () =>
+    session.host.isConnected &&
+    session.host.offsetParent !== null &&
+    session.host.clientWidth > 0;
+
+  // One PTY has one geometry: the owner is the sole caller of ResizeTerminal and
+  // publishes the result so the mirror renders at the same cols/rows instead of
+  // mis-wrapping the shared stream. Always paired, so callers can't desync them.
+  const driveOwnerSize = (cols: number, rows: number) => {
     ResizeTerminal(terminalId, cols, rows).catch(() => {});
+    broadcastMirrorSize(terminalId, { cols, rows });
+  };
+
+  term.onResize(({ cols, rows }) => {
+    if (IS_MIRROR_WINDOW) return;
+    if (!isLaidOut()) return;
+    driveOwnerSize(cols, rows);
   });
 
   term.onScroll(() => {
@@ -617,7 +678,9 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
     session.onScrollState?.(atBottom);
   });
 
-  ResizeTerminal(terminalId, term.cols, term.rows).catch(() => {});
+  if (!IS_MIRROR_WINDOW && isLaidOut()) {
+    driveOwnerSize(term.cols, term.rows);
+  }
 
   // Attached to term.textarea — that's where xterm.js focuses and receives paste events.
   const handlePaste = (e: ClipboardEvent) => {
@@ -682,10 +745,119 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
     },
   );
 
+  // Cross-window mirroring wiring.
+  let cleanupMirror: (() => void) | null = null;
+  if (IS_MIRROR_WINDOW) {
+    // Render the owner's authoritative geometry (the mirror never fits its own
+    // container — that would mis-wrap the shared stream).
+    const applySize = (cols: number, rows: number) => {
+      if (!cols || !rows) return;
+      try {
+        term.resize(cols, rows);
+      } catch {}
+    };
+    const offSize = onMirrorSize(terminalId, ({ cols, rows }) => applySize(cols, rows));
+
+    let snapTimer: ReturnType<typeof setInterval> | null = null;
+    const stopSnapTimer = () => {
+      if (snapTimer) {
+        clearInterval(snapTimer);
+        snapTimer = null;
+      }
+    };
+    // Apply the owner's serialized screen as the seed, then release buffered
+    // live output. Discard the pre-seed buffer on a real snapshot: it already
+    // reflects everything up to the owner's serialize point, so replaying would
+    // duplicate scrollback; the sub-frame gap self-heals on the next output.
+    const finishSeed = (snapData?: string) => {
+      if (seeded) return;
+      seeded = true;
+      stopSnapTimer();
+      if (snapData) {
+        try {
+          term.reset();
+        } catch {}
+        try {
+          term.write(snapData);
+        } catch {}
+      } else {
+        for (const d of preSeed) {
+          try {
+            term.write(d);
+          } catch {}
+        }
+      }
+      preSeed.length = 0;
+    };
+    // Self-heal like the tree channel: keep asking until seeded; a bounded
+    // fallback renders the buffer so a silent owner never leaves a blank pane.
+    const startSeeding = () => {
+      seeded = false;
+      preSeed.length = 0;
+      stopSnapTimer();
+      requestMirrorSnapshot(terminalId);
+      let tries = 0;
+      snapTimer = setInterval(() => {
+        if (seeded) {
+          stopSnapTimer();
+          return;
+        }
+        if (++tries >= 4) {
+          finishSeed();
+          return;
+        }
+        requestMirrorSnapshot(terminalId);
+      }, 400);
+    };
+    const offSnap = onMirrorSnapshot(terminalId, ({ data, cols, rows }) => {
+      applySize(cols, rows);
+      finishSeed(data);
+    });
+
+    startSeeding();
+
+    // Re-seed from the current screen when the window is shown after dropping
+    // output while hidden (see writeData's memory bound).
+    const onVis = () => {
+      if (!document.hidden && droppedWhileHidden) {
+        droppedWhileHidden = false;
+        startSeeding();
+      }
+    };
+    document.addEventListener("visibilitychange", onVis);
+
+    cleanupMirror = () => {
+      offSize();
+      offSnap();
+      stopSnapTimer();
+      document.removeEventListener("visibilitychange", onVis);
+    };
+  } else {
+    // Owner: seed a joining mirror's screen, and honor the mirror's DESIRED
+    // geometry only while our own pane is hidden — so a mirror that is the sole
+    // visible view isn't stuck at our stale/default size.
+    const offSnapReq = onMirrorSnapshotRequest(terminalId, () => {
+      replyMirrorSnapshot(terminalId, {
+        data: serialize?.serialize() ?? "",
+        cols: term.cols,
+        rows: term.rows,
+      });
+    });
+    const offDesired = onMirrorDesired(terminalId, ({ cols, rows }) => {
+      if (!cols || !rows || isLaidOut()) return;
+      driveOwnerSize(cols, rows);
+    });
+    cleanupMirror = () => {
+      offSnapReq();
+      offDesired();
+    };
+  }
+
   session.destroy = () => {
     textarea?.removeEventListener("paste", handlePaste, true);
     if (typeof cleanupOutput === "function") cleanupOutput();
     if (typeof cleanupExit === "function") cleanupExit();
+    cleanupMirror?.();
   };
 
   return session;
@@ -700,6 +872,33 @@ function getOrCreateInteractiveSession(terminalId: string, cwd: string): Interac
   const session = createInteractiveSession(terminalId, cwd);
   interactiveSessions.set(terminalId, session);
   return session;
+}
+
+// React to a geometry trigger (mount, container resize, font change, becoming
+// visible): the owner fits its xterm to its container and drives the shared PTY
+// size, while a mirror never fits (that would mis-wrap the shared stream) and
+// instead publishes the size its container could hold for the owner to honor.
+function reconcileGeometry(session: InteractiveSession, terminalId: string): void {
+  if (IS_MIRROR_WINDOW) {
+    const dims = session.fit.proposeDimensions();
+    if (dims && dims.cols && dims.rows) {
+      broadcastMirrorDesired(terminalId, { cols: dims.cols, rows: dims.rows });
+    }
+    return;
+  }
+  try {
+    session.fit.fit();
+  } catch {}
+}
+
+// The owner focuses its terminal on mount/visible unless the composer already
+// holds focus; a mirror never auto-focuses (it can't see the owner window's
+// focus, so grabbing it would steal OS focus from the main window mid-action).
+function shouldAutoFocus(): boolean {
+  return (
+    !IS_MIRROR_WINDOW &&
+    !document.activeElement?.closest("[data-terminal-composer]")
+  );
 }
 
 export function InteractivePane({
@@ -865,9 +1064,12 @@ export function InteractivePane({
 
     el.appendChild(session.host);
 
-    try {
-      session.fit.fit();
-    } catch {}
+    // A mirror renders at the owner's cols/rows (see the mirror-size handler),
+    // so it never fits to its own container — fitting would resize the term
+    // away from the owner's geometry and mis-wrap the shared stream. Instead it
+    // publishes its container's DESIRED size, which the owner honors while the
+    // owner's own pane is hidden.
+    reconcileGeometry(session, terminalId);
 
     // Resize observer — debounced at 200ms to avoid garbled redraws during
     // the sidebar's CSS transition (transition-[width] duration-200)
@@ -877,9 +1079,7 @@ export function InteractivePane({
       resizeTimer = window.setTimeout(() => {
         resizeTimer = 0;
         if (!session.host.clientWidth || !session.host.clientHeight) return;
-        try {
-          session.fit.fit();
-        } catch {}
+        reconcileGeometry(session, terminalId);
       }, 200);
     });
     ro.observe(session.host);
@@ -887,7 +1087,7 @@ export function InteractivePane({
     // A new terminal's composer claims focus in its mount layout-effect, which
     // runs before this passive effect; don't yank focus back to the terminal
     // when the open terminal-input already holds it.
-    if (!document.activeElement?.closest("[data-terminal-composer]")) {
+    if (shouldAutoFocus()) {
       session.term.focus();
     }
 
@@ -921,9 +1121,7 @@ export function InteractivePane({
     if (!session) return;
     session.term.options.fontSize = fontSize;
     filterRef.current?.setFontSize(fontSize);
-    try {
-      session.fit.fit();
-    } catch {}
+    reconcileGeometry(session, terminalId);
   }, [fontSize]);
 
   useEffect(() => {
@@ -940,17 +1138,14 @@ export function InteractivePane({
     const session = sessionRef.current;
     if (!session) return;
     const term = session.term;
-    const fit = session.fit;
     requestAnimationFrame(() => {
-      try {
-        fit.fit();
-      } catch {}
+      reconcileGeometry(session, terminalId);
       try {
         term.refresh(0, term.rows - 1);
       } catch {}
       // Don't yank focus out of an open terminal-input composer that just
       // claimed it on a tab switch (it focuses synchronously, before this rAF).
-      if (!document.activeElement?.closest("[data-terminal-composer]")) {
+      if (shouldAutoFocus()) {
         term.focus();
       }
     });

--- a/desktop/frontend/src/components/InteractivePane.tsx
+++ b/desktop/frontend/src/components/InteractivePane.tsx
@@ -36,8 +36,46 @@ import {
   replyMirrorSnapshot,
   requestMirrorSnapshot,
   onMirrorSnapshot,
+  broadcastMirrorAcking,
+  onMirrorAcking,
 } from "../mirror";
 import "@xterm/xterm/css/xterm.css";
+
+// Cross-window flow-control ack authority (one window acks a PTY's output; two
+// desync the shared counter). Window-level state shared by every session.
+//
+// Mirror-side: this window is the acker while it's focused AND visible — then
+// it's not OS-throttled, so its acks keep the producer flowing in real time.
+// Owner-side: mirrorIsAckAuthority tracks whether a mirror currently owns acking
+// so the owner can defer. Both default to "owner acks", so a window with no
+// mirror behaves exactly as before.
+let mirrorAmAckAuthority = false;
+let mirrorIsAckAuthority = false;
+if (IS_MIRROR_WINDOW) {
+  const publishAcking = () => {
+    const next = document.hasFocus() && !document.hidden;
+    if (next === mirrorAmAckAuthority) return;
+    mirrorAmAckAuthority = next;
+    broadcastMirrorAcking(next);
+  };
+  window.addEventListener("focus", publishAcking);
+  window.addEventListener("blur", publishAcking);
+  document.addEventListener("visibilitychange", publishAcking);
+  window.addEventListener("beforeunload", () => {
+    if (mirrorAmAckAuthority) broadcastMirrorAcking(false);
+  });
+  publishAcking();
+} else {
+  onMirrorAcking((acking) => {
+    mirrorIsAckAuthority = acking;
+  });
+  // Safety net: whenever this owner window is focused, it acks — no other window
+  // can be the ack authority (macOS focuses one at a time). This also clears a
+  // stale claim left by a mirror that closed without broadcasting a release.
+  window.addEventListener("focus", () => {
+    mirrorIsAckAuthority = false;
+  });
+}
 
 export interface InteractivePaneHandle {
   clear: () => void;
@@ -584,12 +622,14 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
   ensureThemeObserver();
 
   let unsentAck = 0;
-  // Only the owner window acks. A mirror renders the same global broadcast but
-  // must not touch the single per-session flow-control counter — two windows
-  // acking the same bytes would drive it negative and disable backpressure. The
-  // owner's ack still bounds the producer, so the mirror can't lag unboundedly.
+  // Exactly one window acks a PTY's output — two acking the same bytes would
+  // desync the single shared flow-control counter. The owner acks by default;
+  // when a focused, visible mirror declares itself the ack authority (because
+  // the owner is hidden and its ack loop is throttled), the owner defers and the
+  // mirror acks instead, keeping the producer flowing for the window the user is
+  // actually watching. With no mirror both flags stay false → owner acks, as before.
   const ackData = (charCount: number) => {
-    if (IS_MIRROR_WINDOW) return;
+    if (IS_MIRROR_WINDOW ? !mirrorAmAckAuthority : mirrorIsAckAuthority) return;
     unsentAck += charCount;
     while (unsentAck >= ACK_SIZE) {
       unsentAck -= ACK_SIZE;
@@ -616,6 +656,9 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
   // gates above before rendering.
   const writeData = (data: string) => {
     if (IS_MIRROR_WINDOW) {
+      // Ack on receipt while we're the acker (a focused, visible mirror isn't
+      // throttled, so receipt ≈ render). No-op otherwise.
+      ackData(data.length);
       if (document.hidden) {
         droppedWhileHidden = true;
         return;
@@ -625,6 +668,15 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
         return;
       }
       term.write(data);
+      return;
+    }
+    // Owner. When a mirror holds ack authority and this window is hidden, the
+    // producer is no longer paused on our behalf, so writing would grow xterm's
+    // parse queue unbounded (our parser is OS-throttled while hidden). Drop and
+    // reseed on show — exactly the mirror's memory bound — since the mirror is
+    // the live renderer meanwhile. Never triggers without a mirror (main-only).
+    if (mirrorIsAckAuthority && document.hidden) {
+      droppedWhileHidden = true;
       return;
     }
     term.write(data, () => ackData(data.length));
@@ -658,6 +710,13 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
     session.host.offsetParent !== null &&
     session.host.clientWidth > 0;
 
+  // The owner owns the shared PTY size only while it's the focused, laid-out
+  // view. macOS focuses one window at a time, so when a mirror is focused the
+  // owner is not — deferring on focus keeps the two windows from fighting over
+  // one PTY's geometry. (Main-only: the window is focused whenever it resizes,
+  // so this never withholds a legitimate resize.)
+  const hasSizeAuthority = () => document.hasFocus() && isLaidOut();
+
   // One PTY has one geometry: the owner is the sole caller of ResizeTerminal and
   // publishes the result so the mirror renders at the same cols/rows instead of
   // mis-wrapping the shared stream. Always paired, so callers can't desync them.
@@ -666,9 +725,14 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
     broadcastMirrorSize(terminalId, { cols, rows });
   };
 
+  // Drive the PTY (and mirror) from a local fit only when this window holds size
+  // authority. Without the focus gate an unfocused owner's ResizeObserver — e.g.
+  // triggered by the mirror re-laying-out the owner's panes after a forwarded
+  // divider drag — would refit to the MAIN window's container and clobber the
+  // focused mirror's geometry ~350ms later.
   term.onResize(({ cols, rows }) => {
     if (IS_MIRROR_WINDOW) return;
-    if (!isLaidOut()) return;
+    if (!hasSizeAuthority()) return;
     driveOwnerSize(cols, rows);
   });
 
@@ -678,7 +742,7 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
     session.onScrollState?.(atBottom);
   });
 
-  if (!IS_MIRROR_WINDOW && isLaidOut()) {
+  if (!IS_MIRROR_WINDOW && hasSizeAuthority()) {
     driveOwnerSize(term.cols, term.rows);
   }
 
@@ -767,6 +831,11 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
     };
     const offSize = onMirrorSize(terminalId, ({ cols, rows }) => applySize(cols, rows));
 
+    // Whether the current seed came from a real owner snapshot (vs. the timeout
+    // fallback). A fallback seed is provisional — a snapshot arriving later
+    // corrects it.
+    let seededFromSnapshot = false;
+
     let snapTimer: ReturnType<typeof setInterval> | null = null;
     const stopSnapTimer = () => {
       if (snapTimer) {
@@ -781,11 +850,14 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
     const finishSeed = (snapData?: string) => {
       if (seeded) return;
       seeded = true;
-      stopSnapTimer();
+      seededFromSnapshot = !!snapData;
+      // Always reset first: on a snapshot we replace the screen; on the fallback
+      // we must NOT stack post-show output onto the stale pre-hidden screen
+      // (the hidden-period output was dropped, so the two don't join cleanly).
+      try {
+        term.reset();
+      } catch {}
       if (snapData) {
-        try {
-          term.reset();
-        } catch {}
         try {
           term.write(snapData);
         } catch {}
@@ -798,21 +870,26 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
       }
       preSeed.length = 0;
     };
-    // Self-heal like the tree channel: keep asking until seeded; a bounded
-    // fallback renders the buffer so a silent owner never leaves a blank pane.
+    // Self-heal like the tree channel: keep asking for the owner's snapshot. A
+    // bounded wait renders the live buffer so a silent owner never leaves a
+    // blank pane (a provisional fallback seed), but we keep asking a few more
+    // times afterward so a late snapshot can still replace that provisional
+    // screen — then give up.
     const startSeeding = () => {
       seeded = false;
+      seededFromSnapshot = false;
       preSeed.length = 0;
       stopSnapTimer();
       requestMirrorSnapshot(terminalId);
       let tries = 0;
       snapTimer = setInterval(() => {
-        if (seeded) {
+        tries += 1;
+        if (tries === 4) finishSeed(); // provisional fallback
+        // Keep asking briefly after the fallback so a late snapshot can still
+        // replace the provisional screen, then give up (a silent owner never
+        // replies — no point re-serializing its scrollback indefinitely).
+        if (tries >= 6) {
           stopSnapTimer();
-          return;
-        }
-        if (++tries >= 4) {
-          finishSeed();
           return;
         }
         requestMirrorSnapshot(terminalId);
@@ -820,7 +897,17 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
     };
     const offSnap = onMirrorSnapshot(terminalId, ({ data, cols, rows }) => {
       applySize(cols, rows);
-      finishSeed(data);
+      if (!seeded) {
+        finishSeed(data);
+      } else if (!seededFromSnapshot && data) {
+        // A snapshot that lands after we already fell back to the live buffer:
+        // re-run the seed to replace the provisional fallback screen with the
+        // owner's authoritative one. Once seeded FROM a snapshot there's nothing
+        // to fix. preSeed is already empty here, so this only resets + writes.
+        seeded = false;
+        finishSeed(data);
+      }
+      if (seededFromSnapshot) stopSnapTimer();
     });
 
     startSeeding();
@@ -847,16 +934,19 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
     // hidden) — size authority follows focus. Resize our own xterm to match so
     // this view letterboxes instead of mis-wrapping while the mirror drives.
     const offSnapReq = onMirrorSnapshotRequest(terminalId, () => {
-      replyMirrorSnapshot(terminalId, {
-        data: serialize?.serialize() ?? "",
-        cols: term.cols,
-        rows: term.rows,
+      // Drain xterm's async write queue before serializing, so the snapshot
+      // reflects every byte the owner has received — not just its parsed buffer.
+      // Under heavy streaming to a throttled owner the unparsed backlog can
+      // approach the flow-control window (~100KB); serializing without draining
+      // would silently drop it from the mirror's seed.
+      term.write("", () => {
+        replyMirrorSnapshot(terminalId, {
+          data: serialize?.serialize() ?? "",
+          cols: term.cols,
+          rows: term.rows,
+        });
       });
     });
-    // This window owns the shared PTY size while it's the focused, laid-out
-    // view; only then does it ignore the mirror's desired size and drive its
-    // own. (macOS focuses one window at a time, so authority is never contested.)
-    const hasSizeAuthority = () => document.hasFocus() && isLaidOut();
     const offDesired = onMirrorDesired(terminalId, ({ cols, rows }) => {
       if (!cols || !rows) return;
       if (hasSizeAuthority()) return;
@@ -865,9 +955,22 @@ function createInteractiveSession(terminalId: string, cwd: string): InteractiveS
       } catch {}
       driveOwnerSize(cols, rows);
     });
+    // When this owner was hidden and dropped output (mirror held ack authority),
+    // its buffer has a gap; on show, reset and let the live stream repaint rather
+    // than render a torn screen. Mirrors the mirror's drop-and-reseed tradeoff.
+    const onOwnerVis = () => {
+      if (!document.hidden && droppedWhileHidden) {
+        droppedWhileHidden = false;
+        try {
+          term.reset();
+        } catch {}
+      }
+    };
+    document.addEventListener("visibilitychange", onOwnerVis);
     cleanupMirror = () => {
       offSnapReq();
       offDesired();
+      document.removeEventListener("visibilitychange", onOwnerVis);
     };
   }
 

--- a/desktop/frontend/src/components/PaneView.tsx
+++ b/desktop/frontend/src/components/PaneView.tsx
@@ -2,6 +2,8 @@ import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import type { ITheme } from "@xterm/xterm";
 import { InteractivePane, type InteractivePaneHandle } from "./InteractivePane";
 import { BrowserPane } from "./BrowserPane";
+import { BrowserMirrorPlaceholder } from "./BrowserMirrorPlaceholder";
+import { IS_MIRROR_WINDOW } from "../mirror";
 import { DiffReviewPane } from "./review/DiffReviewPane";
 import { ErrorBoundary } from "./ui/ErrorBoundary";
 import { Pane, type PaneHandle } from "./Pane";
@@ -519,7 +521,11 @@ function PaneViewImpl(props: PaneViewProps) {
               }
             >
               {t.kind === "browser" ? (
-                <BrowserPane id={t.id} active={visible && isActive} />
+                IS_MIRROR_WINDOW ? (
+                  <BrowserMirrorPlaceholder />
+                ) : (
+                  <BrowserPane id={t.id} active={visible && isActive} />
+                )
               ) : t.kind === "review" ? (
                 <ErrorBoundary resetKey={t.id}>
                   <DiffReviewPane

--- a/desktop/frontend/src/components/Sidebar.tsx
+++ b/desktop/frontend/src/components/Sidebar.tsx
@@ -517,7 +517,9 @@ export function Sidebar({ projects, groups, sidebarOrder, selected, collapsed, o
     const status = computeStatus(project);
     const isDetached = detached.has(project.name);
     const isSelf = project.name === detachedSelf;
-    const isSelected = selected === project.name && (!isDetached || isSelf);
+    // A detached project is now mirrored (live in both windows), so the main
+    // window highlights it when selected like any other project.
+    const isSelected = selected === project.name;
     const isContextTarget = contextMenu?.name === project.name;
     const isBusy = duplicatingNames.includes(project.name) || removingNames.has(project.name);
     const parent = project.parentName ? projectByName.get(project.parentName) : undefined;
@@ -584,7 +586,7 @@ export function Sidebar({ projects, groups, sidebarOrder, selected, collapsed, o
           {isDetached && !isSelf && (
             <span
               className="shrink-0 text-[var(--text-muted)]"
-              title="Open in a separate window — click to focus"
+              title="Also open in a separate window"
             >
               <DetachIcon />
             </span>

--- a/desktop/frontend/src/components/TerminalView.tsx
+++ b/desktop/frontend/src/components/TerminalView.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useMemo, useRef, useCallback, useImperativeHandle } from "react";
 import { toast } from "sonner";
 import { EventsOn } from "../../bridge/runtime";
-import { GetServiceLogs, StartLogStreaming, StopLogStreaming, ClearStatus } from "../../bridge/commands";
+import { GetServiceLogs, StartLogStreaming, StopLogStreaming, ClearStatus, FocusMainWindow } from "../../bridge/commands";
+import { IS_MIRROR_WINDOW, requestRunInDuplicates } from "../mirror";
 import type { ITheme } from "@xterm/xterm";
 import { disposePaneSession, type PaneHandle } from "./Pane";
 import { disposeInteractivePaneSession, isInteractivePaneSessionDead, type InteractivePaneHandle } from "./InteractivePane";
@@ -741,7 +742,16 @@ export function TerminalView({ projectName, projectRoot, services, terminalTheme
             duplicateRunHere.current = null;
             setDuplicateSeed(null);
             if (runHere) await runHere();
-            void bulkDuplicate(projectName, count, opts);
+            // In a mirror window, copy #1 runs in the shared PTY here, but the
+            // copies themselves must be created in the main window's store —
+            // that's where they mount and auto-run their seeded tasks. Forward
+            // the request and raise the main window so the user sees them spawn.
+            if (IS_MIRROR_WINDOW) {
+              requestRunInDuplicates({ project: projectName, count, opts: opts as unknown as Record<string, unknown> });
+              void FocusMainWindow(projectName);
+            } else {
+              void bulkDuplicate(projectName, count, opts);
+            }
           }}
         />
       )}

--- a/desktop/frontend/src/components/TerminalView.tsx
+++ b/desktop/frontend/src/components/TerminalView.tsx
@@ -3,6 +3,11 @@ import { toast } from "sonner";
 import { EventsOn } from "../../bridge/runtime";
 import { GetServiceLogs, StartLogStreaming, StopLogStreaming, ClearStatus, FocusMainWindow } from "../../bridge/commands";
 import { IS_MIRROR_WINDOW, requestRunInDuplicates } from "../mirror";
+
+// Log streaming is refcounted per viewer in Rust; the two windows that can watch
+// one project's logs must identify themselves so pausing one doesn't stop the
+// shared poller for the other.
+const LOG_VIEWER = IS_MIRROR_WINDOW ? "mirror" : "main";
 import type { ITheme } from "@xterm/xterm";
 import { disposePaneSession, type PaneHandle } from "./Pane";
 import { disposeInteractivePaneSession, isInteractivePaneSessionDead, type InteractivePaneHandle } from "./InteractivePane";
@@ -109,7 +114,15 @@ export function TerminalView({ projectName, projectRoot, services, terminalTheme
 
   const servicesKey = services.map((s) => s.name).join(",");
   const stableServices = useMemo(() => services, [servicesKey]);
-  const servicePorts = useServicePorts(projectName, visible && services.length > 0, servicesKey);
+  // Only the owner runs the 3s system-wide lsof port scan. A detached project is
+  // mounted in both windows, so gating the mirror off avoids doubling a load the
+  // freeze audit already flagged; the mirror's service tabs simply omit port
+  // labels rather than running a second scanner.
+  const servicePorts = useServicePorts(
+    projectName,
+    !IS_MIRROR_WINDOW && visible && services.length > 0,
+    servicesKey,
+  );
 
   // Ensure a root pane exists whenever there's something to host — either
   // a running service (so its tab has somewhere to live) or after the
@@ -334,7 +347,7 @@ export function TerminalView({ projectName, projectRoot, services, terminalTheme
     let prevPollOutputs: string[] = [];
 
     try {
-      StartLogStreaming(projectName).catch(() => {});
+      StartLogStreaming(projectName, LOG_VIEWER).catch(() => {});
       const cancel = EventsOn("log-update", (update: { project: string; pane: number; content: string }) => {
         if (update?.project !== projectName) return;
         setOutputs((prev) => {
@@ -375,14 +388,14 @@ export function TerminalView({ projectName, projectRoot, services, terminalTheme
 
     const onVisibility = () => {
       if (shouldPause()) {
-        StopLogStreaming(projectName).catch(() => {});
+        StopLogStreaming(projectName, LOG_VIEWER).catch(() => {});
         if (pollInterval) {
           clearInterval(pollInterval);
           pollInterval = null;
         }
       } else {
         if (streaming) {
-          StartLogStreaming(projectName).catch(() => {});
+          StartLogStreaming(projectName, LOG_VIEWER).catch(() => {});
         } else if (!pollInterval) {
           poll();
           pollInterval = setInterval(poll, 1000);
@@ -394,7 +407,7 @@ export function TerminalView({ projectName, projectRoot, services, terminalTheme
     return () => {
       if (eventCleanup) eventCleanup();
       if (pollInterval) clearInterval(pollInterval);
-      StopLogStreaming(projectName).catch(() => {});
+      StopLogStreaming(projectName, LOG_VIEWER).catch(() => {});
       document.removeEventListener("visibilitychange", onVisibility);
     };
   }, [projectName, stableServices]);
@@ -406,9 +419,9 @@ export function TerminalView({ projectName, projectRoot, services, terminalTheme
     }
     if (stableServices.length === 0) return;
     if (visible) {
-      StartLogStreaming(projectName).catch(() => {});
+      StartLogStreaming(projectName, LOG_VIEWER).catch(() => {});
     } else {
-      StopLogStreaming(projectName).catch(() => {});
+      StopLogStreaming(projectName, LOG_VIEWER).catch(() => {});
     }
   }, [visible, projectName, stableServices.length]);
 

--- a/desktop/frontend/src/hooks/useTerminals.ts
+++ b/desktop/frontend/src/hooks/useTerminals.ts
@@ -41,6 +41,13 @@ import {
 } from "../paneTree";
 import { useTabScroll } from "../store/tabScroll";
 import { disambiguateLabel, pickTerminalLabel } from "../terminalLabels";
+import {
+  IS_MIRROR_WINDOW,
+  broadcastMirrorTree,
+  onMirrorTree,
+  onMirrorTreeRequest,
+  requestMirrorTree,
+} from "../mirror";
 
 export interface TerminalStartOpts {
   configName?: string;
@@ -153,8 +160,14 @@ export function useTerminals(
   const pendingInjectCleanups = useRef<Set<() => void>>(new Set());
   const deferredPersistTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const mirrorActiveRef = useRef(false);
+  const broadcastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const persist = useCallback(
     (next: PaneNode | null) => {
+      // A mirror window never owns the persisted tree — the owner (main
+      // window) is the single source of truth for terminals.json.
+      if (IS_MIRROR_WINDOW) return;
       const focusedId = focusedRef.current;
       // serviceFilterModes is a removed field (filter mode is now a single
       // global setting); strip it so a dead key from an earlier build doesn't
@@ -296,6 +309,30 @@ export function useTerminals(
   // previous conversation instead of restarting fresh). Falls back to
   // converting the legacy terminals[] array into a single root pane.
   useEffect(() => {
+    // Mirror window: don't reify fresh PTYs. Adopt the owner's LIVE tree (same
+    // process-global PTY ids) over the cross-window channel and keep it synced.
+    // Re-request until the owner answers so mount ordering doesn't matter.
+    if (IS_MIRROR_WINDOW) {
+      let gotTree = false;
+      const off = onMirrorTree(projectName, (payload) => {
+        gotTree = true;
+        setTree(payload.tree);
+        setFocusedPaneId(payload.focusedPaneId);
+        onCountRef.current?.(payload.tree ? collectTerminals(payload.tree).length : 0);
+      });
+      requestMirrorTree(projectName);
+      const retry = setInterval(() => {
+        if (gotTree) clearInterval(retry);
+        else requestMirrorTree(projectName);
+      }, 500);
+      const stopRetry = setTimeout(() => clearInterval(retry), 10000);
+      return () => {
+        off();
+        clearInterval(retry);
+        clearTimeout(stopRetry);
+      };
+    }
+
     const saved = getProjectTerminals(projectName);
     const persistedTree = saved.panes ?? legacyEntriesToTree(saved.terminals);
     if (!persistedTree) return;
@@ -332,6 +369,37 @@ export function useTerminals(
     };
   }, [projectName, scheduleCmdInject]);
 
+  // Owner side of the mirror channel: answer a mirror window's request for the
+  // current live tree, and lazily arm change-broadcasting (only once a mirror
+  // has actually asked, so non-mirrored projects stay silent).
+  useEffect(() => {
+    if (IS_MIRROR_WINDOW) return;
+    return onMirrorTreeRequest(projectName, () => {
+      mirrorActiveRef.current = true;
+      broadcastMirrorTree(projectName, {
+        tree: treeRef.current,
+        focusedPaneId: focusedRef.current,
+      });
+    });
+  }, [projectName]);
+
+  // Re-broadcast the live tree whenever it changes so the mirror follows adds,
+  // closes, splits, tab switches, and divider drags. Debounced so a divider
+  // drag coalesces to ~one emit per frame-burst.
+  useEffect(() => {
+    if (IS_MIRROR_WINDOW || !mirrorActiveRef.current) return;
+    if (broadcastTimer.current) clearTimeout(broadcastTimer.current);
+    broadcastTimer.current = setTimeout(() => {
+      broadcastMirrorTree(projectName, {
+        tree: treeRef.current,
+        focusedPaneId: focusedRef.current,
+      });
+    }, 80);
+    return () => {
+      if (broadcastTimer.current) clearTimeout(broadcastTimer.current);
+    };
+  }, [projectName, tree, focusedPaneId]);
+
   // Central path for adding a terminal: either to an explicit pane, the
   // focused pane, or a fresh root pane if the tree is empty.
   const addTerminal = useCallback(
@@ -356,6 +424,7 @@ export function useTerminals(
   );
 
   const createTerminal = useCallback(async () => {
+    if (IS_MIRROR_WINDOW) return;
     try {
       const id = await StartTerminal(projectName);
       addTerminal(makeTerminal(id, pickTerminalLabel(treeRef.current)));
@@ -364,6 +433,7 @@ export function useTerminals(
 
   const createTerminalWithCmd = useCallback(
     async (label: string, cmd: string, opts?: TerminalStartOpts) => {
+      if (IS_MIRROR_WINDOW) return;
       // When reuse is requested, find an existing live terminal tagged with
       // the same actionName. A dead session (process exited) falls through
       // so the user gets a fresh PTY instead of typing into a dead tab.
@@ -435,6 +505,7 @@ export function useTerminals(
 
   const resumeFromHistory = useCallback(
     async (entry: PersistedHistoryEntry) => {
+      if (IS_MIRROR_WINDOW) return;
       let id: string;
       try {
         id = entry.actionName
@@ -461,6 +532,7 @@ export function useTerminals(
 
   const addTerminalToPane = useCallback(
     async (paneId: string) => {
+      if (IS_MIRROR_WINDOW) return;
       try {
         const id = await StartTerminal(projectName);
         addTerminal(makeTerminal(id, pickTerminalLabel(treeRef.current)), paneId);
@@ -472,6 +544,7 @@ export function useTerminals(
   // Browser tabs have no PTY — no StartTerminal, just a webview keyed by id.
   const addBrowserToPane = useCallback(
     (paneId?: string) => {
+      if (IS_MIRROR_WINDOW) return;
       addTerminal(makeBrowser(nextId("browser")), paneId);
     },
     [addTerminal],
@@ -480,6 +553,7 @@ export function useTerminals(
   // Review tabs have no PTY — they render the git diff review pane keyed by id.
   const addReviewToPane = useCallback(
     (paneId?: string) => {
+      if (IS_MIRROR_WINDOW) return;
       addTerminal(makeReview(nextId("review")), paneId);
     },
     [addTerminal],
@@ -536,6 +610,7 @@ export function useTerminals(
 
   const closeTerminal = useCallback(
     (paneId: string, tabIdx: number) => {
+      if (IS_MIRROR_WINDOW) return;
       const current = treeRef.current;
       if (!current) return;
       const pane = findPane(current, paneId);
@@ -564,6 +639,7 @@ export function useTerminals(
   // needs no collapse. The kept tab becomes active.
   const closeOtherTerminals = useCallback(
     (paneId: string, tabIdx: number) => {
+      if (IS_MIRROR_WINDOW) return;
       const current = treeRef.current;
       if (!current) return;
       const pane = findPane(current, paneId);
@@ -716,6 +792,7 @@ export function useTerminals(
   // closeTerminal rule — panes with a persistent service tab stay alive.
   const moveTerminal = useCallback(
     (fromPaneId: string, termId: string, toPaneId: string, toIdx?: number) => {
+      if (IS_MIRROR_WINDOW) return;
       if (fromPaneId === toPaneId) return;
       const current = treeRef.current;
       if (!current) return;
@@ -755,6 +832,7 @@ export function useTerminals(
 
   const splitPane = useCallback(
     async (paneId: string, direction: SplitDirection) => {
+      if (IS_MIRROR_WINDOW) return;
       if (!treeRef.current || !findPane(treeRef.current, paneId)) return;
       let newId: string;
       try {
@@ -778,6 +856,7 @@ export function useTerminals(
 
   const closePane = useCallback(
     (paneId: string) => {
+      if (IS_MIRROR_WINDOW) return;
       const current = treeRef.current;
       if (!current) return;
       const pane = findPane(current, paneId);
@@ -845,6 +924,8 @@ export function useTerminals(
       }
       cleanups.forEach((fn) => fn());
       cleanups.clear();
+      // A mirror window adopts the owner's PTYs; closing it must not stop them.
+      if (IS_MIRROR_WINDOW) return;
       const current = treeRef.current;
       if (current) {
         collectTerminals(current).forEach((t) => {

--- a/desktop/frontend/src/hooks/useTerminals.ts
+++ b/desktop/frontend/src/hooks/useTerminals.ts
@@ -47,6 +47,8 @@ import {
   onMirrorTree,
   onMirrorTreeRequest,
   requestMirrorTree,
+  requestMirrorAction,
+  onMirrorAction,
 } from "../mirror";
 
 export interface TerminalStartOpts {
@@ -162,6 +164,20 @@ export function useTerminals(
 
   const mirrorActiveRef = useRef(false);
   const broadcastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const ratioForwardTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Mirror -> owner action forwarding: the mirror can't spawn/stop PTYs or
+  // restructure the tree (its tree is overwritten by every owner broadcast), so
+  // it sends the action by name and the owner executes it; the result comes
+  // back through the tree broadcast. Pure tree actions (focus, rename, reorder)
+  // ALSO apply locally so they feel instant — the owner applies the same change
+  // and the echoed broadcast is a no-op.
+  const forward = useCallback(
+    (kind: string, ...args: unknown[]) => {
+      requestMirrorAction(projectName, kind, args);
+    },
+    [projectName],
+  );
 
   const persist = useCallback(
     (next: PaneNode | null) => {
@@ -326,10 +342,16 @@ export function useTerminals(
         else requestMirrorTree(projectName);
       }, 500);
       const stopRetry = setTimeout(() => clearInterval(retry), 10000);
+      // Self-heal on activation: if this mirror's tree went stale for any
+      // reason (owner remounted and lost its armed state, retries expired,
+      // a broadcast was missed), re-syncing costs one request+answer.
+      const onWinFocus = () => requestMirrorTree(projectName);
+      window.addEventListener("focus", onWinFocus);
       return () => {
         off();
         clearInterval(retry);
         clearTimeout(stopRetry);
+        window.removeEventListener("focus", onWinFocus);
       };
     }
 
@@ -424,16 +446,16 @@ export function useTerminals(
   );
 
   const createTerminal = useCallback(async () => {
-    if (IS_MIRROR_WINDOW) return;
+    if (IS_MIRROR_WINDOW) return forward("createTerminal");
     try {
       const id = await StartTerminal(projectName);
       addTerminal(makeTerminal(id, pickTerminalLabel(treeRef.current)));
     } catch {}
-  }, [projectName, addTerminal]);
+  }, [projectName, addTerminal, forward]);
 
   const createTerminalWithCmd = useCallback(
     async (label: string, cmd: string, opts?: TerminalStartOpts) => {
-      if (IS_MIRROR_WINDOW) return;
+      if (IS_MIRROR_WINDOW) return forward("createTerminalWithCmd", label, cmd, opts);
       // When reuse is requested, find an existing live terminal tagged with
       // the same actionName. A dead session (process exited) falls through
       // so the user gets a fresh PTY instead of typing into a dead tab.
@@ -500,12 +522,12 @@ export function useTerminals(
       const folded = foldAgentPrompt(cmd, opts?.prompt);
       scheduleCmdInject(id, folded.cmd, folded.prompt);
     },
-    [projectName, addTerminal, applyTree, scheduleCmdInject, scheduleSeedInject],
+    [projectName, addTerminal, applyTree, scheduleCmdInject, scheduleSeedInject, forward],
   );
 
   const resumeFromHistory = useCallback(
     async (entry: PersistedHistoryEntry) => {
-      if (IS_MIRROR_WINDOW) return;
+      if (IS_MIRROR_WINDOW) return forward("resumeFromHistory", entry);
       let id: string;
       try {
         id = entry.actionName
@@ -527,36 +549,37 @@ export function useTerminals(
       addTerminal(term);
       scheduleCmdInject(id, entry.resumeCmd);
     },
-    [projectName, addTerminal, scheduleCmdInject],
+    [projectName, addTerminal, scheduleCmdInject, forward],
   );
 
   const addTerminalToPane = useCallback(
     async (paneId: string) => {
-      if (IS_MIRROR_WINDOW) return;
+      if (IS_MIRROR_WINDOW) return forward("addTerminalToPane", paneId);
       try {
         const id = await StartTerminal(projectName);
         addTerminal(makeTerminal(id, pickTerminalLabel(treeRef.current)), paneId);
       } catch {}
     },
-    [projectName, addTerminal],
+    [projectName, addTerminal, forward],
   );
 
   // Browser tabs have no PTY — no StartTerminal, just a webview keyed by id.
+  // Still owner-created so the tab id is minted once, in the tree of record.
   const addBrowserToPane = useCallback(
     (paneId?: string) => {
-      if (IS_MIRROR_WINDOW) return;
+      if (IS_MIRROR_WINDOW) return forward("addBrowserToPane", paneId);
       addTerminal(makeBrowser(nextId("browser")), paneId);
     },
-    [addTerminal],
+    [addTerminal, forward],
   );
 
   // Review tabs have no PTY — they render the git diff review pane keyed by id.
   const addReviewToPane = useCallback(
     (paneId?: string) => {
-      if (IS_MIRROR_WINDOW) return;
+      if (IS_MIRROR_WINDOW) return forward("addReviewToPane", paneId);
       addTerminal(makeReview(nextId("review")), paneId);
     },
-    [addTerminal],
+    [addTerminal, forward],
   );
 
   // Drop a pane from the tree, moving focus to its visual neighbor (or the
@@ -610,7 +633,7 @@ export function useTerminals(
 
   const closeTerminal = useCallback(
     (paneId: string, tabIdx: number) => {
-      if (IS_MIRROR_WINDOW) return;
+      if (IS_MIRROR_WINDOW) return forward("closeTerminal", paneId, tabIdx);
       const current = treeRef.current;
       if (!current) return;
       const pane = findPane(current, paneId);
@@ -631,7 +654,7 @@ export function useTerminals(
       const next = mapPane(current, paneId, (p) => ({ ...p, tabs: newTabs, activeTabIdx: newActive }));
       applyTree(next);
     },
-    [applyTree, collapsePane, disposeTabs],
+    [applyTree, collapsePane, disposeTabs, forward],
   );
 
   // Closes every unpinned tab in the pane except the one at `tabIdx`; pinned
@@ -639,7 +662,7 @@ export function useTerminals(
   // needs no collapse. The kept tab becomes active.
   const closeOtherTerminals = useCallback(
     (paneId: string, tabIdx: number) => {
-      if (IS_MIRROR_WINDOW) return;
+      if (IS_MIRROR_WINDOW) return forward("closeOtherTerminals", paneId, tabIdx);
       const current = treeRef.current;
       if (!current) return;
       const pane = findPane(current, paneId);
@@ -654,7 +677,7 @@ export function useTerminals(
       const next = mapPane(current, paneId, (p) => ({ ...p, tabs: newTabs, activeTabIdx: newActive }));
       applyTree(next);
     },
-    [applyTree, disposeTabs],
+    [applyTree, disposeTabs, forward],
   );
 
   const focusTerminal = useCallback(
@@ -664,6 +687,7 @@ export function useTerminals(
       const pane = findPane(current, paneId);
       if (!pane) return;
       if (pane.activeTabIdx === tabIdx && pane.activeServiceName === undefined) return;
+      if (IS_MIRROR_WINDOW) forward("focusTerminal", paneId, tabIdx);
       const next = mapPane(current, paneId, (p) => ({
         ...p,
         activeTabIdx: tabIdx,
@@ -671,7 +695,7 @@ export function useTerminals(
       }));
       applyTree(next, paneId);
     },
-    [applyTree],
+    [applyTree, forward],
   );
 
   const focusService = useCallback(
@@ -680,10 +704,11 @@ export function useTerminals(
       if (!current) return;
       const pane = findPane(current, paneId);
       if (!pane || pane.activeServiceName === serviceName) return;
+      if (IS_MIRROR_WINDOW) forward("focusService", paneId, serviceName);
       const next = mapPane(current, paneId, (p) => ({ ...p, activeServiceName: serviceName }));
       applyTree(next, paneId);
     },
-    [applyTree],
+    [applyTree, forward],
   );
 
   const focusAdjacentPaneItem = useCallback(
@@ -706,18 +731,21 @@ export function useTerminals(
   const ensureRootPane = useCallback(
     (initialServiceName?: string) => {
       if (treeRef.current) return;
+      // Owner-only: the pane id must be minted once, in the tree of record.
+      if (IS_MIRROR_WINDOW) return forward("ensureRootPane", initialServiceName);
       const paneId = nextId("pane");
       const pane = makePaneLeaf(paneId, [], 0);
       if (initialServiceName) pane.activeServiceName = initialServiceName;
       applyTree(pane, paneId);
     },
-    [applyTree],
+    [applyTree, forward],
   );
 
   const renameTerminal = useCallback(
     (paneId: string, tabIdx: number, label: string, emoji?: string) => {
       const current = treeRef.current;
       if (!current) return;
+      if (IS_MIRROR_WINDOW) forward("renameTerminal", paneId, tabIdx, label, emoji);
       const next = mapPane(current, paneId, (p) => ({
         ...p,
         tabs: p.tabs.map((t, i) =>
@@ -733,7 +761,7 @@ export function useTerminals(
       }));
       applyTree(next);
     },
-    [applyTree],
+    [applyTree, forward],
   );
 
   const toggleTabPinned = useCallback(
@@ -742,6 +770,7 @@ export function useTerminals(
       if (!current) return;
       const pane = findPane(current, paneId);
       if (!pane || !pane.tabs[tabIdx]) return;
+      if (IS_MIRROR_WINDOW) forward("toggleTabPinned", paneId, tabIdx);
       const next = mapPane(current, paneId, (p) => ({
         ...p,
         tabs: p.tabs.map((t, i) =>
@@ -750,7 +779,7 @@ export function useTerminals(
       }));
       applyTree(next);
     },
-    [applyTree],
+    [applyTree, forward],
   );
 
   // Reorder follows the active terminal by id rather than by index so the
@@ -778,6 +807,7 @@ export function useTerminals(
         return;
       }
 
+      if (IS_MIRROR_WINDOW) forward("reorderTerminals", paneId, order);
       const next = mapPane(current, paneId, (p) => ({
         ...p,
         tabs: newTabs,
@@ -785,15 +815,15 @@ export function useTerminals(
       }));
       applyTree(next);
     },
-    [applyTree],
+    [applyTree, forward],
   );
 
   // Collapses the source pane when the move empties it, matching the
   // closeTerminal rule — panes with a persistent service tab stay alive.
   const moveTerminal = useCallback(
     (fromPaneId: string, termId: string, toPaneId: string, toIdx?: number) => {
-      if (IS_MIRROR_WINDOW) return;
       if (fromPaneId === toPaneId) return;
+      if (IS_MIRROR_WINDOW) forward("moveTerminal", fromPaneId, termId, toPaneId, toIdx);
       const current = treeRef.current;
       if (!current) return;
       const fromPane = findPane(current, fromPaneId);
@@ -827,12 +857,12 @@ export function useTerminals(
 
       applyTree(next, toPaneId);
     },
-    [applyTree],
+    [applyTree, forward],
   );
 
   const splitPane = useCallback(
     async (paneId: string, direction: SplitDirection) => {
-      if (IS_MIRROR_WINDOW) return;
+      if (IS_MIRROR_WINDOW) return forward("splitPane", paneId, direction);
       if (!treeRef.current || !findPane(treeRef.current, paneId)) return;
       let newId: string;
       try {
@@ -851,12 +881,12 @@ export function useTerminals(
       const newPane = makePaneLeaf(newPaneId, [makeTerminal(newId, pickTerminalLabel(current))], 0);
       applyTree(splitAtPane(current, paneId, direction, newPane), newPaneId);
     },
-    [projectName, applyTree],
+    [projectName, applyTree, forward],
   );
 
   const closePane = useCallback(
     (paneId: string) => {
-      if (IS_MIRROR_WINDOW) return;
+      if (IS_MIRROR_WINDOW) return forward("closePane", paneId);
       const current = treeRef.current;
       if (!current) return;
       const pane = findPane(current, paneId);
@@ -870,7 +900,7 @@ export function useTerminals(
       recordClosingTabs(pane.tabs);
       collapsePane(current, paneId);
     },
-    [collapsePane, recordClosingTabs, projectName],
+    [collapsePane, recordClosingTabs, projectName, forward],
   );
 
   // Divider drag mutates the tree on every frame. setRatioAtPath returns
@@ -883,9 +913,20 @@ export function useTerminals(
       const next = setRatioAtPath(current, path, ratio);
       if (next === current) return;
       setTree(next);
+      if (IS_MIRROR_WINDOW) {
+        // Local-first for a smooth drag; forward only the settled ratio so the
+        // owner's echoed broadcasts (up to 80ms stale) can't rubber-band the
+        // divider mid-drag.
+        if (ratioForwardTimer.current) clearTimeout(ratioForwardTimer.current);
+        ratioForwardTimer.current = setTimeout(() => {
+          ratioForwardTimer.current = null;
+          forward("setRatio", path, ratio);
+        }, 150);
+        return;
+      }
       schedulePersist();
     },
-    [schedulePersist],
+    [schedulePersist, forward],
   );
 
   const focusPane = useCallback(
@@ -893,12 +934,13 @@ export function useTerminals(
       if (focusedRef.current === paneId) return;
       const current = treeRef.current;
       if (!current || !findPane(current, paneId)) return;
+      if (IS_MIRROR_WINDOW) forward("focusPane", paneId);
       setFocusedPaneId(paneId);
       // Sync ref so the debounced persist reads the just-clicked pane id.
       focusedRef.current = paneId;
       schedulePersist();
     },
-    [schedulePersist],
+    [schedulePersist, forward],
   );
 
   const getFocusedPane = useCallback((): PaneLeaf | null => {
@@ -911,6 +953,52 @@ export function useTerminals(
     return treeRef.current ? findPane(treeRef.current, paneId) : null;
   }, []);
 
+  // Owner side of action forwarding: execute the actions a mirror window sends
+  // for this project against the authoritative tree. This map is the single
+  // list of everything a mirror may do; the result flows back to the mirror
+  // through the tree broadcast. Pane/tab ids in the args are valid here because
+  // the mirror's tree is a verbatim copy of this window's.
+  const forwardable = {
+    createTerminal,
+    createTerminalWithCmd,
+    resumeFromHistory,
+    addTerminalToPane,
+    addBrowserToPane,
+    addReviewToPane,
+    closeTerminal,
+    closeOtherTerminals,
+    focusTerminal,
+    focusService,
+    renameTerminal,
+    toggleTabPinned,
+    reorderTerminals,
+    moveTerminal,
+    splitPane,
+    closePane,
+    setRatio,
+    focusPane,
+    ensureRootPane,
+  };
+  const forwardableRef = useRef(forwardable);
+  forwardableRef.current = forwardable;
+
+  useEffect(() => {
+    if (IS_MIRROR_WINDOW) return;
+    return onMirrorAction(projectName, (kind, args) => {
+      // A forwarded action is proof a mirror is attached: arm change
+      // broadcasting even if the arm-on-request signal was missed (e.g. this
+      // hook instance remounted after the mirror joined), so the action's
+      // resulting tree change always makes it back to the mirror.
+      mirrorActiveRef.current = true;
+      const actions = forwardableRef.current;
+      if (!Object.prototype.hasOwnProperty.call(actions, kind)) return;
+      const fn = actions[kind as keyof typeof actions] as unknown as (
+        ...a: unknown[]
+      ) => unknown;
+      void fn(...args);
+    });
+  }, [projectName]);
+
   // Cleanup all terminals and pending command injections on unmount.
   // Flush any debounced persist first so in-flight ratio changes aren't
   // lost.
@@ -921,6 +1009,10 @@ export function useTerminals(
         clearTimeout(deferredPersistTimer.current);
         deferredPersistTimer.current = null;
         persist(treeRef.current);
+      }
+      if (ratioForwardTimer.current) {
+        clearTimeout(ratioForwardTimer.current);
+        ratioForwardTimer.current = null;
       }
       cleanups.forEach((fn) => fn());
       cleanups.clear();

--- a/desktop/frontend/src/hooks/useTerminals.ts
+++ b/desktop/frontend/src/hooks/useTerminals.ts
@@ -40,6 +40,7 @@ import {
   isTabPinned,
 } from "../paneTree";
 import { useTabScroll } from "../store/tabScroll";
+import { useAppStore } from "../store/app";
 import { disambiguateLabel, pickTerminalLabel } from "../terminalLabels";
 import {
   IS_MIRROR_WINDOW,
@@ -405,6 +406,16 @@ export function useTerminals(
     });
   }, [projectName]);
 
+  // Disarm broadcasting once the project is no longer detached (mirror window
+  // closed / re-attached). Otherwise mirrorActiveRef stays latched for the rest
+  // of the session and every tree/focus change keeps serializing + emitting the
+  // pane tree over IPC to a listener that no longer exists.
+  const isDetached = useAppStore((s) => s.detached.has(projectName));
+  useEffect(() => {
+    if (IS_MIRROR_WINDOW) return;
+    if (!isDetached) mirrorActiveRef.current = false;
+  }, [isDetached]);
+
   // Re-broadcast the live tree whenever it changes so the mirror follows adds,
   // closes, splits, tab switches, and divider drags. Debounced so a divider
   // drag coalesces to ~one emit per frame-burst.
@@ -633,9 +644,18 @@ export function useTerminals(
 
   const closeTerminal = useCallback(
     (paneId: string, tabIdx: number) => {
-      if (IS_MIRROR_WINDOW) return forward("closeTerminal", paneId, tabIdx);
+      // Forward by tab id, not index: the mirror's local tree lags the owner's
+      // echoed broadcast, so a second close click within that window would carry
+      // a stale index and the owner would close whatever tab now sits there —
+      // potentially killing a live session's PTY. The owner resolves the id
+      // against its authoritative tree (or no-ops if already gone).
       const current = treeRef.current;
       if (!current) return;
+      if (IS_MIRROR_WINDOW) {
+        const id = findPane(current, paneId)?.tabs[tabIdx]?.id;
+        if (id) forward("closeTerminalById", paneId, id);
+        return;
+      }
       const pane = findPane(current, paneId);
       if (!pane || !pane.tabs[tabIdx]) return;
       if (isTabPinned(pane, tabIdx)) return;
@@ -662,9 +682,15 @@ export function useTerminals(
   // needs no collapse. The kept tab becomes active.
   const closeOtherTerminals = useCallback(
     (paneId: string, tabIdx: number) => {
-      if (IS_MIRROR_WINDOW) return forward("closeOtherTerminals", paneId, tabIdx);
+      // Forward by the kept tab's id (see closeTerminal) so a stale index can't
+      // make the owner keep the wrong tab and close everything else.
       const current = treeRef.current;
       if (!current) return;
+      if (IS_MIRROR_WINDOW) {
+        const id = findPane(current, paneId)?.tabs[tabIdx]?.id;
+        if (id) forward("closeOthersById", paneId, id);
+        return;
+      }
       const pane = findPane(current, paneId);
       const keptTab = pane?.tabs[tabIdx];
       if (!pane || !keptTab) return;
@@ -953,6 +979,25 @@ export function useTerminals(
     return treeRef.current ? findPane(treeRef.current, paneId) : null;
   }, []);
 
+  // Owner-side resolvers for the mirror's id-addressed close actions: map the
+  // terminal id back to its current index in the authoritative tree, then run
+  // the normal close. A no-longer-present id is a safe no-op (the tab already
+  // closed), which is exactly the double-click case index-based close got wrong.
+  const closeTerminalById = useCallback(
+    (paneId: string, termId: string) => {
+      const idx = getPane(paneId)?.tabs.findIndex((t) => t.id === termId) ?? -1;
+      if (idx >= 0) closeTerminal(paneId, idx);
+    },
+    [getPane, closeTerminal],
+  );
+  const closeOthersById = useCallback(
+    (paneId: string, termId: string) => {
+      const idx = getPane(paneId)?.tabs.findIndex((t) => t.id === termId) ?? -1;
+      if (idx >= 0) closeOtherTerminals(paneId, idx);
+    },
+    [getPane, closeOtherTerminals],
+  );
+
   // Owner side of action forwarding: execute the actions a mirror window sends
   // for this project against the authoritative tree. This map is the single
   // list of everything a mirror may do; the result flows back to the mirror
@@ -965,8 +1010,8 @@ export function useTerminals(
     addTerminalToPane,
     addBrowserToPane,
     addReviewToPane,
-    closeTerminal,
-    closeOtherTerminals,
+    closeTerminalById,
+    closeOthersById,
     focusTerminal,
     focusService,
     renameTerminal,

--- a/desktop/frontend/src/main.tsx
+++ b/desktop/frontend/src/main.tsx
@@ -13,11 +13,10 @@ import { useComposerStore } from "./store/composer";
 import { initTTSEvents } from "./store/tts";
 import { useGeneratorsStore } from "./store/generators";
 import { queryClient } from "./queryClient";
+import { MIRROR_PROJECT } from "./mirror";
 import "./styles/globals.css";
 
-const detachedProject = new URLSearchParams(window.location.search).get(
-  "detached",
-);
+const detachedProject = MIRROR_PROJECT;
 
 Promise.all([loadSettings(), loadTerminals(), loadGroups(), hydrateComposerActions()]).then(([s, , g]) => {
   applyTheme(s.theme);

--- a/desktop/frontend/src/mirror.ts
+++ b/desktop/frontend/src/mirror.ts
@@ -1,0 +1,117 @@
+import { EventsEmit, EventsOn } from "../bridge/runtime";
+import type { PaneNode } from "./paneTree";
+
+// A project's terminals are owned by the main window; a detached window is a
+// live, co-interactive MIRROR that adopts the main window's PTYs rather than
+// spawning its own. Mirror-ness is a property of the webview realm, not of any
+// single terminal: the detached window (identified by the `?detached=` param it
+// was opened with) mirrors every terminal it shows, and the main window owns
+// every terminal it shows. So a single per-realm flag drives all of the
+// role-specific behavior (adopt vs. reify, render vs. ack, follow vs. drive the
+// PTY size) without threading a prop through the pane tree.
+const detachedParam = new URLSearchParams(window.location.search).get("detached");
+export const IS_MIRROR_WINDOW = detachedParam !== null;
+export const MIRROR_PROJECT = detachedParam;
+
+// Cross-window transport is Tauri's global event bus (EventsEmit/EventsOn): an
+// emit from either window is delivered to listeners in every window, the same
+// mechanism `pty-output-<id>` already rides. The protocol is self-healing: the
+// owner answers requests and re-broadcasts on change, the mirror re-requests
+// until it hears back, so mount ordering doesn't matter.
+//
+// Project-keyed channels carry the project in the PAYLOAD and filter on receipt
+// (project names contain spaces/dots that Tauri event NAMES disallow). Terminal-
+// keyed channels are safe to put in the name because PTY ids are already
+// sanitized (`event_safe(project)-<counter>`, alnum/-/_ only).
+const TREE = "mirror-tree";
+const TREE_REQ = "mirror-tree-request";
+const sizeEvt = (id: string) => `mirror-size-${id}`;
+const desiredEvt = (id: string) => `mirror-desired-${id}`;
+const snapReqEvt = (id: string) => `mirror-snap-request-${id}`;
+const snapEvt = (id: string) => `mirror-snap-${id}`;
+
+export interface MirrorTreePayload {
+  tree: PaneNode | null;
+  focusedPaneId: string | null;
+}
+
+export interface MirrorSize {
+  cols: number;
+  rows: number;
+}
+
+export interface MirrorSnapshot {
+  data: string;
+  cols: number;
+  rows: number;
+}
+
+// --- live pane tree (owner -> mirror) ---
+export function broadcastMirrorTree(project: string, payload: MirrorTreePayload): void {
+  EventsEmit(TREE, { project, ...payload });
+}
+export function onMirrorTree(project: string, cb: (p: MirrorTreePayload) => void): () => void {
+  return EventsOn(TREE, (m: MirrorTreePayload & { project?: string }) => {
+    if (m && m.project === project) cb(m);
+  });
+}
+
+// --- tree request (mirror -> owner) ---
+export function requestMirrorTree(project: string): void {
+  EventsEmit(TREE_REQ, { project });
+}
+export function onMirrorTreeRequest(project: string, cb: () => void): () => void {
+  return EventsOn(TREE_REQ, (m: { project?: string }) => {
+    if (m && m.project === project) cb();
+  });
+}
+
+// --- authoritative per-terminal geometry (owner -> mirror). One PTY has one
+//     size, so the owner is the sole caller of ResizeTerminal and publishes the
+//     result; the mirror renders at these cols/rows. ---
+export function broadcastMirrorSize(id: string, size: MirrorSize): void {
+  EventsEmit(sizeEvt(id), size);
+}
+export function onMirrorSize(id: string, cb: (s: MirrorSize) => void): () => void {
+  return EventsOn(sizeEvt(id), cb);
+}
+
+// --- the mirror's DESIRED geometry (mirror -> owner). The owner honors this
+//     only while its own pane is hidden (mounted-but-not-selected), so a mirror
+//     that's the sole visible view isn't stuck at a stale/default 80x24. ---
+export function broadcastMirrorDesired(id: string, size: MirrorSize): void {
+  EventsEmit(desiredEvt(id), size);
+}
+export function onMirrorDesired(id: string, cb: (s: MirrorSize) => void): () => void {
+  return EventsOn(desiredEvt(id), cb);
+}
+
+// --- run-in-duplicates (mirror -> owner). Creating project copies + queuing
+//     their seeded tasks must happen in the main window's store, where the
+//     copies actually mount and auto-run; a mirror only forwards the request. ---
+export interface MirrorRunDuplicates {
+  project: string;
+  count: number;
+  opts: Record<string, unknown>;
+}
+export function requestRunInDuplicates(p: MirrorRunDuplicates): void {
+  EventsEmit("mirror-run-duplicates", p);
+}
+export function onRunInDuplicates(cb: (p: MirrorRunDuplicates) => void): () => void {
+  return EventsOn("mirror-run-duplicates", cb);
+}
+
+// --- scrollback snapshot (mirror requests on adopt/re-show; owner replies with
+//     its xterm's serialized buffer + current size). ---
+export function requestMirrorSnapshot(id: string): void {
+  EventsEmit(snapReqEvt(id), null);
+}
+export function onMirrorSnapshotRequest(id: string, cb: () => void): () => void {
+  return EventsOn(snapReqEvt(id), cb);
+}
+export function replyMirrorSnapshot(id: string, snap: MirrorSnapshot): void {
+  EventsEmit(snapEvt(id), snap);
+}
+export function onMirrorSnapshot(id: string, cb: (snap: MirrorSnapshot) => void): () => void {
+  return EventsOn(snapEvt(id), cb);
+}

--- a/desktop/frontend/src/mirror.ts
+++ b/desktop/frontend/src/mirror.ts
@@ -86,6 +86,30 @@ export function onMirrorDesired(id: string, cb: (s: MirrorSize) => void): () => 
   return EventsOn(desiredEvt(id), cb);
 }
 
+// --- forwarded terminal actions (mirror -> owner). A mirror can't spawn/stop
+//     PTYs or restructure the pane tree itself — its tree is a copy the owner
+//     overwrites on every broadcast. So the mirror forwards the action by name,
+//     the owner executes it against the authoritative tree (spawn, labeling,
+//     command injection, persistence all stay in one place), and the result
+//     comes back through the tree broadcast. ---
+const ACTION = "mirror-terminal-action";
+export function requestMirrorAction(project: string, kind: string, args: unknown[]): void {
+  // Trailing omitted optionals would JSON-serialize to null and stop reading
+  // as "not provided" on the owner side (e.g. renameTerminal's emoji, where
+  // undefined means "keep" but null-ish means "clear").
+  const trimmed = [...args];
+  while (trimmed.length > 0 && trimmed[trimmed.length - 1] === undefined) trimmed.pop();
+  EventsEmit(ACTION, { project, kind, args: trimmed });
+}
+export function onMirrorAction(
+  project: string,
+  cb: (kind: string, args: unknown[]) => void,
+): () => void {
+  return EventsOn(ACTION, (m: { project?: string; kind?: string; args?: unknown[] }) => {
+    if (m && m.project === project && m.kind) cb(m.kind, m.args ?? []);
+  });
+}
+
 // --- run-in-duplicates (mirror -> owner). Creating project copies + queuing
 //     their seeded tasks must happen in the main window's store, where the
 //     copies actually mount and auto-run; a mirror only forwards the request. ---

--- a/desktop/frontend/src/mirror.ts
+++ b/desktop/frontend/src/mirror.ts
@@ -110,6 +110,22 @@ export function onMirrorAction(
   });
 }
 
+// --- flow-control ack authority (mirror -> owner). Only ONE window may ack a
+//     PTY's output; two would desync the single shared unacked counter. The
+//     owner acks by default, but when the owner window is hidden its ack loop
+//     (driven by xterm's write-completion callback) is OS-throttled and starves
+//     flow control for a visible mirror. So a focused, visible mirror announces
+//     that it is the acker and the owner defers (and drops+reseeds its own now-
+//     unbackpressured output) while that holds. macOS focuses one window at a
+//     time, so at most one window ever claims acking. This is a window-level
+//     property, so it rides one global channel rather than a per-terminal one. ---
+export function broadcastMirrorAcking(acking: boolean): void {
+  EventsEmit("mirror-acking", { acking });
+}
+export function onMirrorAcking(cb: (acking: boolean) => void): () => void {
+  return EventsOn("mirror-acking", (m: { acking?: boolean }) => cb(!!m?.acking));
+}
+
 // --- run-in-duplicates (mirror -> owner). Creating project copies + queuing
 //     their seeded tasks must happen in the main window's store, where the
 //     copies actually mount and auto-run; a mirror only forwards the request. ---

--- a/desktop/frontend/src/store/app.ts
+++ b/desktop/frontend/src/store/app.ts
@@ -1139,6 +1139,12 @@ export const useAppStore = create<AppState>((set, get) => ({
     try {
       const raw = (await ListDetachedProjects()) as string[] | null;
       const next = new Set<string>(raw ?? []);
+      // Every detached project must stay marked visited so the main window (the
+      // terminals' owner) keeps its ProjectDetail mounted even when unselected.
+      // Windows restored at launch reach the store only through this path — not
+      // detachProject — so without this a restored detached window's close would
+      // unmount the owner and StopTerminal-kill the project's live PTYs.
+      for (const name of next) get().markVisited(name);
       set((s) => {
         if (s.detached.size === next.size && [...s.detached].every((n) => next.has(n))) {
           return s;

--- a/desktop/frontend/src/store/app.ts
+++ b/desktop/frontend/src/store/app.ts
@@ -1153,16 +1153,17 @@ export const useAppStore = create<AppState>((set, get) => ({
   detachProject: async (name) => {
     try {
       await DetachProject(name);
+      // Mark visited so the main window keeps this project's ProjectDetail
+      // mounted (as the terminals' owner) even when it isn't selected — and so
+      // closing the detached window later doesn't unmount + kill the live PTYs
+      // the user never selected it inline.
+      get().markVisited(name);
       set((s) => {
-        const detached = s.detached.has(name)
-          ? s.detached
-          : new Set<string>([...s.detached, name]);
-        // Clear inline selection so lastSelectedProject persistence
-        // doesn't carry the now-detached project, and so EmptyState
-        // shows in the main pane without needing a derived guard.
-        const selected = s.selected === name ? null : s.selected;
-        if (detached === s.detached && selected === s.selected) return s;
-        return { detached, selected };
+        if (s.detached.has(name)) return s;
+        // Keep the project selected in the main window: the main window stays
+        // the owner of its live terminals, and the detached window opens as a
+        // co-interactive mirror of them — the project is now live in both.
+        return { detached: new Set<string>([...s.detached, name]) };
       });
     } catch (err) {
       toast.error(`Failed to detach ${name}: ${err}`);


### PR DESCRIPTION
Detached project windows now mirror the main window’s live terminal sessions instead of owning separate terminal state. The main window remains the source of truth for PTYs, pane trees, persistence, and duplicate creation while detached windows render synchronized views.

- Keeps detached projects mounted and selectable inline in the main window
- Adds mirror sync for pane trees, terminal sizing, scrollback snapshots, and live output seeding
- Prevents mirror windows from creating, closing, persisting, resizing, or acking shared terminal sessions
- Shows a browser placeholder in mirror windows since native webviews can only be owned by one window
- Forwards “run in duplicates” requests from mirror windows to the main window
- Updates sidebar selection and detached-window messaging for mirrored projects