### PR TITLE
Fix stale agent statuses after interrupted turns

### DIFF
--- a/desktop/frontend/src-tauri/src/agent_limits.rs
+++ b/desktop/frontend/src-tauri/src/agent_limits.rs
@@ -173,11 +173,11 @@ fn emit_snapshot(app: &AppHandle, store: &AgentLimitsStore) {
 
 // ---- Codex ------------------------------------------------------------------
 
-fn codex_sessions_dir() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_default()
-        .join(".codex")
-        .join("sessions")
+/// Codex's session archive. Built on the same `codex_home` the rest of the tree
+/// resolves through, so a user with `CODEX_HOME` set is not silently looked up
+/// in an empty `~/.codex`.
+pub(crate) fn codex_sessions_dir() -> PathBuf {
+    crate::agent_session_titles::codex_home().join("sessions")
 }
 
 /// One rate-limit window from Codex's `primary`/`secondary` object. Accepts both
@@ -256,7 +256,7 @@ fn parse_codex_file(path: &Path, now: i64, updated_at: i64) -> Option<ProviderLi
 
 /// Read at most the last `max_bytes` of a file as UTF-8 (lossy), dropping a
 /// leading partial line so callers only see whole lines.
-fn read_tail(path: &Path, max_bytes: u64) -> Option<String> {
+pub(crate) fn read_tail(path: &Path, max_bytes: u64) -> Option<String> {
     let mut f = std::fs::File::open(path).ok()?;
     let len = f.metadata().ok()?.len();
     let start = len.saturating_sub(max_bytes);

--- a/desktop/frontend/src-tauri/src/agentnest.rs
+++ b/desktop/frontend/src-tauri/src/agentnest.rs
@@ -79,6 +79,14 @@ fn parse_table(out: &str) -> Table {
 
 /// pid -> (ppid, comm) for every process on the machine. Empty when `ps` is
 /// unavailable, which reads as "nothing known" and so accepts every report.
+///
+/// `comm=` is the expensive half of this scan — 20ms against 12ms without it,
+/// because macOS recovers argv[0] per process to produce it — and it is NOT
+/// interchangeable with the cheap `ucomm=`. `ucomm` is `p_comm`, the basename of
+/// the EXECUTABLE, and claude's executable is its version directory: a live
+/// claude reports `ucomm=2.1.238` where `comm=claude`. Swapping them stops every
+/// Claude agent being recognised as one, silently. The same applies to libproc's
+/// `PROC_PIDT_SHORTBSDINFO`, which returns that same `p_comm`.
 fn scan() -> Table {
     let Ok(out) = Command::new("ps")
         .args(["-e", "-o", "pid=,ppid=,comm="])
@@ -112,30 +120,66 @@ fn is_agent(comm: &str) -> bool {
     AGENT_COMMS.contains(&name)
 }
 
-/// Whether `reporter` sits under an agent that itself sits under `pane_shell`.
-/// Split from [`is_nested_agent`] so the walk is testable against a fixed table.
-fn nested_in_table(table: &Table, reporter: i32, pane_shell: i32) -> bool {
-    if reporter <= 1 || pane_shell <= 1 {
-        return false;
+/// Agent processes on the path from `pid` up to `pane_shell`, counting `pid`
+/// itself. None when the shell is not on that path at all — a pane inside tmux
+/// hangs off the server, not off the tab's shell — or when the walk runs out of
+/// table before reaching it.
+///
+/// One number answers both questions this module asks: the pane's own agent has
+/// exactly one agent on its path, and anything it launched has at least two.
+fn agents_up_to(table: &Table, pid: i32, pane_shell: i32) -> Option<usize> {
+    if pid <= 1 || pane_shell <= 1 {
+        return None;
     }
-    let mut pid = reporter;
+    let mut at = pid;
     let mut agents = 0;
     for _ in 0..MAX_DEPTH {
-        if pid == pane_shell {
-            return agents >= 2;
+        if at == pane_shell {
+            return Some(agents);
         }
-        let Some(proc) = table.get(&pid) else {
-            return false;
-        };
+        let proc = table.get(&at)?;
         if is_agent(&proc.comm) {
             agents += 1;
         }
         if proc.ppid <= 1 {
-            return false;
+            return None;
         }
-        pid = proc.ppid;
+        at = proc.ppid;
     }
-    false
+    None
+}
+
+/// Whether `reporter` sits under an agent that itself sits under `pane_shell`.
+/// Split from [`is_nested_agent`] so the walk is testable against a fixed table.
+fn nested_in_table(table: &Table, reporter: i32, pane_shell: i32) -> bool {
+    agents_up_to(table, reporter, pane_shell).is_some_and(|agents| agents >= 2)
+}
+
+/// The agent process a pane is running, if exactly one is unambiguously ITS
+/// agent — the one whose path to the shell holds only itself. Split from
+/// [`pane_agent_pid`] so it is testable against a fixed table.
+///
+/// None when the pane runs no agent, and also when two of them qualify: a split
+/// running two agents has no single process that speaks for the tab, and a
+/// caller reading one of their lifetimes would be reading the wrong one.
+fn pane_agent_in_table(table: &Table, pane_shell: i32) -> Option<i32> {
+    let mut found = None;
+    for (&pid, proc) in table {
+        if !is_agent(&proc.comm) || agents_up_to(table, pid, pane_shell) != Some(1) {
+            continue;
+        }
+        if found.is_some() {
+            return None;
+        }
+        found = Some(pid);
+    }
+    found
+}
+
+/// The agent process this pane is running. Its pid is how the agent's own live
+/// state is found on disk (agentstop.rs) — Claude keys that file by pid.
+pub fn pane_agent_pid(pane_shell: i32) -> Option<i32> {
+    pane_agent_in_table(&process_table(false), pane_shell)
 }
 
 /// True when the process that reported is an agent another agent in the same
@@ -279,6 +323,48 @@ mod tests {
         );
         assert_eq!(t[&100].ppid, 24);
         assert!(is_agent(&t[&100].comm));
+    }
+
+    /// shell -> claude: the one process that speaks for the tab.
+    #[test]
+    fn finds_the_pane_agent() {
+        let t = table(&[(10, 1, "-zsh"), (20, 10, "claude"), (99, 1, "claude")]);
+        assert_eq!(pane_agent_in_table(&t, 10), Some(20));
+    }
+
+    /// The agent a pane's agent launched is not the pane's agent, and must not
+    /// be mistaken for it — its lifetime says nothing about the tab.
+    #[test]
+    fn ignores_an_agent_the_pane_agent_launched() {
+        let t = table(&[
+            (10, 1, "-zsh"),
+            (20, 10, "claude"),
+            (30, 20, "zsh"),
+            (40, 30, "claude"),
+        ]);
+        assert_eq!(pane_agent_in_table(&t, 10), Some(20));
+    }
+
+    /// A split running two agents has no single process that speaks for the tab.
+    #[test]
+    fn declines_when_two_agents_both_answer_to_the_pane() {
+        let t = table(&[(10, 1, "-zsh"), (20, 10, "claude"), (21, 10, "codex")]);
+        assert_eq!(pane_agent_in_table(&t, 10), None);
+    }
+
+    #[test]
+    fn finds_nothing_in_a_pane_running_no_agent() {
+        let t = table(&[(10, 1, "-zsh"), (20, 10, "vim"), (99, 1, "claude")]);
+        assert_eq!(pane_agent_in_table(&t, 10), None);
+        assert_eq!(pane_agent_in_table(&t, 0), None);
+    }
+
+    /// A shell between the pane and the agent (a wrapper, `script`, `env`)
+    /// still leaves the agent the pane's own.
+    #[test]
+    fn reaches_an_agent_a_level_down() {
+        let t = table(&[(10, 1, "-zsh"), (15, 10, "sh"), (20, 15, "claude")]);
+        assert_eq!(pane_agent_in_table(&t, 10), Some(20));
     }
 
     /// The launching agent's own report primes the cache moments before the

--- a/desktop/frontend/src-tauri/src/agentstop.rs
+++ b/desktop/frontend/src-tauri/src/agentstop.rs
@@ -1,0 +1,428 @@
+// Noticing that an agent stopped when no hook says so.
+//
+// A turn the user interrupts ends without a Stop hook. Claude Code documents it
+// — "Stop … does not run if the stoppage occurred due to a user interrupt" — and
+// Codex has no abort event at all. The tab is left holding the Running its last
+// PreToolUse reported and shimmers on, until some later turn happens to end
+// normally. Nothing in the hook set can close that gap: StopFailure is API
+// errors, SessionEnd needs the session to actually end, and Notification's idle
+// signal is a minute late and suppressed exactly when the user is at the
+// keyboard.
+//
+// Both agents write the truth to disk regardless.
+//
+//   Claude keeps a live record per agent process at `<config>/sessions/<pid>.json`
+//   whose `status` leaves `busy` the moment the turn does — measured at 0.16s
+//   after Esc. The pid is the agent process's own, which is how a pane finds its
+//   record (agentnest::pane_agent_pid).
+//
+//   Codex appends `{"type":"turn_aborted","reason":"interrupted"}` to its session
+//   rollout, and never follows it with the `task_complete` that would have ended
+//   the turn. A pane finds its rollout by the session id its SessionStart hook
+//   already reports (socketsrv::cmd_set_resume).
+//
+// Neither file is a supported contract, so every uncertainty leaves the badge
+// alone: no record, no pid, an unparsable file, two agents in one pane, a remote
+// pane whose agent runs on another machine's process table. A Running that
+// lingers is the bug we started with; a Running cleared out from under a working
+// agent is a worse one.
+//
+// This only ever CLEARS. It must never report Done: Done rings the finish chime
+// and pushes "Agent finished" to paired phones (statusnotify.rs), and nobody
+// finished.
+//
+// KNOWN GAP. `claude_stop_cmd` holds Running past the end of a turn whenever
+// work is still in flight behind it, and the agent's own record does not say so
+// for every kind. A backgrounded Bash is covered — the record says `shell` and
+// this reads that as working — but an MCP task, a long-running cloud agent, and
+// the agent's own background scans all leave the record on `idle` while that
+// hook is deliberately holding Running. The badge then goes dark until the
+// harness re-prompts and a PreToolUse lights it again. Closing that needs a
+// signal the record doesn't carry; re-checking the Stop payload is not possible
+// from here, and the entry's own timestamp cannot stand in for one because the
+// store dedups a re-reported Running without advancing it (status.rs).
+use crate::status::{KeyProvider, StatusStore};
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+use tauri::{AppHandle, Emitter, Manager};
+
+/// How often a Running badge is checked against its agent. Only panes actually
+/// holding one are looked at, so an idle app does no work at all.
+const POLL: Duration = Duration::from_secs(2);
+
+/// Enough of a rollout's tail to hold the current turn's events.
+const ROLLOUT_TAIL_BYTES: u64 = 1 << 20;
+
+/// How long a rollout that could not be found stays not-found. Long enough that
+/// a pane whose rollout will never appear stops re-walking the archive every
+/// poll, short enough that one Codex writes moments after reporting its id is
+/// still picked up.
+const MISS_TTL: Duration = Duration::from_secs(30);
+
+/// What an agent's own state says about the turn a badge is still claiming.
+#[derive(PartialEq, Debug)]
+enum Liveness {
+    /// The agent says it is working; leave the badge alone.
+    Working,
+    /// The turn ended without a hook to say so; retire the badge.
+    Stopped,
+    /// Nothing legible. Leave the badge alone.
+    Unknown,
+}
+
+/// The session id each pane's agent reported at SessionStart, which is how a
+/// Codex pane is matched to its rollout. Claude needs no entry here — its record
+/// is keyed by pid, which the process tree already answers.
+#[derive(Default)]
+pub struct PaneSessions(Mutex<HashMap<String, String>>);
+
+impl PaneSessions {
+    pub fn set(&self, pane_id: &str, session_id: &str) {
+        if pane_id.is_empty() || session_id.is_empty() {
+            return;
+        }
+        self.0
+            .lock()
+            .unwrap()
+            .insert(pane_id.to_string(), session_id.to_string());
+    }
+
+    fn get(&self, pane_id: &str) -> Option<String> {
+        self.0.lock().unwrap().get(pane_id).cloned()
+    }
+}
+
+/// Claude's live record for the agent running in `pane_id`. Every step that can
+/// come back empty means the same thing — nothing legible — so the whole lookup
+/// is one `?` chain and the fallback is stated once.
+fn claude_liveness(app: &AppHandle, pane_id: &str, root: &Path) -> Liveness {
+    claude_record(app, pane_id, root).unwrap_or(Liveness::Unknown)
+}
+
+fn claude_record(app: &AppHandle, pane_id: &str, root: &Path) -> Option<Liveness> {
+    let state = app.state::<crate::pty::PtyState>();
+    // None for a remote pane: its agent lives in another machine's process
+    // table, and its record is on that machine's disk.
+    let shell = crate::pty::local_session_pid(&state, pane_id)?;
+    let pid = crate::agentnest::pane_agent_pid(shell)?;
+    // The record is removed when the agent exits, and a session that inherits
+    // CLAUDE_CODE_* never registers one at all.
+    let text = std::fs::read_to_string(root.join(format!("{pid}.json"))).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&text).ok()?;
+    Some(claude_status_liveness(
+        json.get("status").and_then(|v| v.as_str()),
+    ))
+}
+
+/// Read the `status` of a Claude session record. Only `idle` retires a badge.
+///
+/// `waiting` is the agent blocked on the user mid-turn, and clearing then would
+/// take away the one hint that something needs answering.
+///
+/// `shell` looks like a finish and is not one: the agent writes it for a turn
+/// that ended while a backgrounded Bash is still running, which is exactly the
+/// state `claude_stop_cmd` re-asserts Running for (see the `background_tasks`
+/// reasoning in hooks.rs). Reading it as stopped would delete the badge that
+/// hook deliberately wrote, and leave the tab dark for the whole background
+/// command. An interrupt lands on `idle`, never here, so nothing is lost.
+///
+/// An unrecognised state is a future word, so it says nothing.
+fn claude_status_liveness(status: Option<&str>) -> Liveness {
+    match status {
+        Some("busy") | Some("waiting") | Some("shell") => Liveness::Working,
+        Some("idle") => Liveness::Stopped,
+        _ => Liveness::Unknown,
+    }
+}
+
+/// Find the rollout Codex is writing for `session_id` by the id its filename
+/// carries, walking the YYYY/MM/DD layout. `file_type()` comes from the
+/// directory entry itself, so recursing costs no extra syscall.
+fn search_rollout(session_id: &str) -> Option<PathBuf> {
+    let suffix = format!("{session_id}.jsonl");
+    let mut stack = vec![crate::agent_limits::codex_sessions_dir()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if entry.file_type().is_ok_and(|t| t.is_dir()) {
+                stack.push(entry.path());
+                continue;
+            }
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else { continue };
+            // The id is unique, so the first match is the only match.
+            if name.starts_with("rollout-") && name.ends_with(&suffix) {
+                return Some(entry.path());
+            }
+        }
+    }
+    None
+}
+
+/// What is known about one session's rollout.
+enum Rollout {
+    At(PathBuf),
+    /// Searched and not found, at this time. Remembered too: a lookup that keeps
+    /// missing is the expensive one — a full walk of an archive that only grows,
+    /// repeated for as long as the pane holds its badge.
+    Missing(Instant),
+}
+
+/// The rollout for `session_id`, remembered either way.
+///
+/// A hit is dropped the moment the file stops existing, so a pruned or moved
+/// rollout is looked up again. A miss expires on [`MISS_TTL`] rather than being
+/// permanent, because the legitimate miss is a rollout Codex has not written
+/// YET: SessionStart reports the id first, and the file follows.
+fn rollout_for(session_id: &str) -> Option<PathBuf> {
+    static KNOWN: OnceLock<Mutex<HashMap<String, Rollout>>> = OnceLock::new();
+    let cell = KNOWN.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut known = cell.lock().unwrap();
+    remembered(&mut known, session_id, search_rollout)
+}
+
+/// The memo itself, with the search injected so what it chooses to re-run is
+/// testable without a Codex archive on disk.
+fn remembered(
+    known: &mut HashMap<String, Rollout>,
+    session_id: &str,
+    search: impl Fn(&str) -> Option<PathBuf>,
+) -> Option<PathBuf> {
+    match known.get(session_id) {
+        Some(Rollout::At(path)) if path.exists() => return Some(path.clone()),
+        Some(Rollout::Missing(at)) if at.elapsed() < MISS_TTL => return None,
+        _ => {}
+    }
+    let found = search(session_id);
+    known.insert(
+        session_id.to_string(),
+        match &found {
+            Some(path) => Rollout::At(path.clone()),
+            None => Rollout::Missing(Instant::now()),
+        },
+    );
+    found
+}
+
+/// Whether the last turn in a rollout tail was aborted. Only the three events
+/// that bound a turn are read, so anything an agent merely printed — including a
+/// transcript quoting these very names — cannot be mistaken for one.
+fn aborted_in_tail(text: &str) -> Liveness {
+    for line in text.lines().rev() {
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if json.get("type").and_then(|v| v.as_str()) != Some("event_msg") {
+            continue;
+        }
+        match json
+            .get("payload")
+            .and_then(|p| p.get("type"))
+            .and_then(|v| v.as_str())
+        {
+            Some("turn_aborted") => return Liveness::Stopped,
+            // Either other boundary means a turn that is running or finished
+            // cleanly — the hooks speak for both.
+            Some("task_started") | Some("task_complete") => return Liveness::Working,
+            _ => {}
+        }
+    }
+    Liveness::Unknown
+}
+
+fn codex_liveness(app: &AppHandle, pane_id: &str) -> Liveness {
+    codex_rollout(app, pane_id).unwrap_or(Liveness::Unknown)
+}
+
+fn codex_rollout(app: &AppHandle, pane_id: &str) -> Option<Liveness> {
+    // A remote pane writes its rollout on the host, so searching this machine's
+    // archive for it can only ever fail — expensively, and forever.
+    let state = app.state::<crate::pty::PtyState>();
+    crate::pty::local_session_pid(&state, pane_id)?;
+    let session_id = app.state::<Arc<PaneSessions>>().get(pane_id)?;
+    let path = rollout_for(&session_id)?;
+    let text = crate::agent_limits::read_tail(&path, ROLLOUT_TAIL_BYTES)?;
+    Some(aborted_in_tail(&text))
+}
+
+/// Retire every Running badge whose agent says the turn is over.
+///
+/// A project's Claude config dir is resolved once here rather than per entry:
+/// finding it parses the project's YAML off disk (config.rs), and several panes
+/// of one project would otherwise each pay for that on every tick.
+fn reconcile(app: &AppHandle, store: &StatusStore) {
+    let mut roots: HashMap<String, PathBuf> = HashMap::new();
+    let mut changed: HashSet<String> = HashSet::new();
+    for (project, key, pane_id) in store.running_agents() {
+        let verdict = match crate::status::key_provider(&key) {
+            Some(KeyProvider::Claude) => {
+                let root = roots.entry(project.clone()).or_insert_with(|| {
+                    crate::hooks::claude_records_dir(
+                        crate::config::claude_env_for_project_readonly(&project),
+                    )
+                });
+                claude_liveness(app, &pane_id, root)
+            }
+            Some(KeyProvider::Codex) => codex_liveness(app, &pane_id),
+            // Somebody's own key, via `lpm set-status`. It speaks for itself.
+            None => Liveness::Unknown,
+        };
+        if verdict != Liveness::Stopped {
+            continue;
+        }
+        // Re-read rather than trusting the snapshot: a Done or Waiting may have
+        // landed while the agent's own state was being read, and that report is
+        // the better answer.
+        if store.clear_if_value(&project, &key, crate::status::STATUS_RUNNING) {
+            changed.insert(project);
+        }
+    }
+    for project in changed {
+        let _ = app.emit("status-changed", &project);
+    }
+}
+
+pub fn start(app: AppHandle, store: Arc<StatusStore>) {
+    std::thread::spawn(move || loop {
+        std::thread::sleep(POLL);
+        reconcile(&app, &store);
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn line(payload_type: &str) -> String {
+        format!(r#"{{"type":"event_msg","payload":{{"type":"{payload_type}"}}}}"#)
+    }
+
+    #[test]
+    fn an_aborted_turn_is_stopped() {
+        let text = [line("task_started"), line("turn_aborted")].join("\n");
+        assert_eq!(aborted_in_tail(&text), Liveness::Stopped);
+    }
+
+    #[test]
+    fn a_turn_started_after_an_abort_is_working_again() {
+        let text = [
+            line("task_started"),
+            line("turn_aborted"),
+            line("task_started"),
+        ]
+        .join("\n");
+        assert_eq!(aborted_in_tail(&text), Liveness::Working);
+    }
+
+    #[test]
+    fn a_completed_turn_leaves_the_badge_to_its_own_hook() {
+        let text = [line("task_started"), line("task_complete")].join("\n");
+        assert_eq!(aborted_in_tail(&text), Liveness::Working);
+    }
+
+    #[test]
+    fn a_tail_with_no_turn_boundary_says_nothing() {
+        assert_eq!(aborted_in_tail(""), Liveness::Unknown);
+        assert_eq!(aborted_in_tail(&line("token_count")), Liveness::Unknown);
+        assert_eq!(aborted_in_tail("not json at all"), Liveness::Unknown);
+    }
+
+    /// A rollout holds whatever an agent read or wrote, so the words themselves
+    /// appear in it constantly. Only a real event record counts.
+    #[test]
+    fn text_quoting_the_event_names_is_not_an_event() {
+        let quoted = r#"{"type":"response_item","payload":{"type":"message","text":"if (t===\"turn_aborted\") ..."}}"#;
+        assert_eq!(aborted_in_tail(quoted), Liveness::Unknown);
+        let as_response = r#"{"type":"response_item","payload":{"type":"turn_aborted"}}"#;
+        assert_eq!(aborted_in_tail(as_response), Liveness::Unknown);
+    }
+
+    #[test]
+    fn only_a_finished_turn_retires_a_claude_badge() {
+        assert_eq!(claude_status_liveness(Some("busy")), Liveness::Working);
+        // Blocked on the user is still inside the turn: clearing here would take
+        // away the only hint that something needs answering.
+        assert_eq!(claude_status_liveness(Some("waiting")), Liveness::Working);
+        // `shell` is a turn that ended with a backgrounded Bash still running —
+        // the state claude_stop_cmd re-asserts Running for on purpose.
+        assert_eq!(claude_status_liveness(Some("shell")), Liveness::Working);
+        assert_eq!(claude_status_liveness(Some("idle")), Liveness::Stopped);
+        // A word this doesn't know is not a verdict.
+        assert_eq!(
+            claude_status_liveness(Some("compacting")),
+            Liveness::Unknown
+        );
+        assert_eq!(claude_status_liveness(None), Liveness::Unknown);
+    }
+
+    /// A miss is the expensive lookup — a full walk of an archive that only
+    /// grows — so it must not repeat every poll.
+    #[test]
+    fn a_miss_is_searched_once_and_then_remembered() {
+        use std::cell::Cell;
+        let searches = Cell::new(0);
+        let mut known = HashMap::new();
+        let search = |_: &str| {
+            searches.set(searches.get() + 1);
+            None
+        };
+        assert_eq!(remembered(&mut known, "sid", search), None);
+        assert_eq!(remembered(&mut known, "sid", search), None);
+        assert_eq!(remembered(&mut known, "sid", search), None);
+        assert_eq!(
+            searches.get(),
+            1,
+            "the archive is walked once, not per call"
+        );
+    }
+
+    /// The miss has to expire: Codex writes the rollout shortly AFTER
+    /// SessionStart reports the id, so a permanent miss would be a dead leg.
+    #[test]
+    fn an_expired_miss_is_searched_again() {
+        let mut known = HashMap::new();
+        known.insert(
+            "sid".to_string(),
+            Rollout::Missing(Instant::now() - MISS_TTL - Duration::from_secs(1)),
+        );
+        let found = PathBuf::from("/nonexistent/rollout-sid.jsonl");
+        assert_eq!(
+            remembered(&mut known, "sid", |_| Some(found.clone())),
+            Some(found)
+        );
+    }
+
+    /// A remembered hit that has since been pruned or moved is looked up again
+    /// rather than handed out as a path to nothing.
+    #[test]
+    fn a_vanished_hit_is_searched_again() {
+        let mut known = HashMap::new();
+        known.insert(
+            "sid".to_string(),
+            Rollout::At(PathBuf::from("/nonexistent/gone.jsonl")),
+        );
+        let searched = std::cell::Cell::new(false);
+        remembered(&mut known, "sid", |_| {
+            searched.set(true);
+            None
+        });
+        assert!(
+            searched.get(),
+            "a hit that no longer exists must not be reused"
+        );
+    }
+
+    #[test]
+    fn pane_sessions_ignores_empty_ids() {
+        let map = PaneSessions::default();
+        map.set("", "sid");
+        map.set("pty-1", "");
+        assert_eq!(map.get("pty-1"), None);
+        map.set("pty-1", "sid");
+        assert_eq!(map.get("pty-1").as_deref(), Some("sid"));
+    }
+}

--- a/desktop/frontend/src-tauri/src/config.rs
+++ b/desktop/frontend/src-tauri/src/config.rs
@@ -334,7 +334,11 @@ fn ensure_claude_account_dir(id: &str) -> Result<(), String> {
 /// (deleted accounts fall back to the default login). Claude Code keys its
 /// credential store off the literal CLAUDE_CONFIG_DIR string, so the value
 /// must be derived from the id in this one place and nowhere else.
-pub fn claude_config_dir_for_account(id: &str) -> Option<String> {
+/// Where a pinned account's config lives, resolved and nothing more. Split from
+/// [`claude_config_dir_for_account`] so a caller that only READS from the dir
+/// can ask without triggering the re-link — a background probe must not be
+/// creating directories and symlinks every few seconds.
+fn claude_account_dir_of(id: &str) -> Option<String> {
     if !valid_claude_account_id(id) {
         return None;
     }
@@ -344,10 +348,15 @@ pub fn claude_config_dir_for_account(id: &str) -> Option<String> {
     {
         return None;
     }
+    Some(claude_account_dir(id).to_string_lossy().into_owned())
+}
+
+pub fn claude_config_dir_for_account(id: &str) -> Option<String> {
+    let dir = claude_account_dir_of(id)?;
     // Re-link on every resolve so assets added to ~/.claude after the account
     // was created still reach it.
     let _ = ensure_claude_account_dir(id);
-    Some(claude_account_dir(id).to_string_lossy().into_owned())
+    Some(dir)
 }
 
 /// How a spawned child should treat `CLAUDE_CONFIG_DIR`. `Scrub` is distinct
@@ -418,10 +427,27 @@ fn effective_claude_account(y: &ProjectYaml) -> Option<String> {
 }
 
 pub fn claude_env_for_project(name: &str) -> ClaudeEnv {
+    claude_env_of(name, claude_config_dir_for_account)
+}
+
+/// The same answer for a caller that only READS from the resolved dir. Skips the
+/// re-link that [`claude_config_dir_for_account`] performs, which belongs to
+/// spawning an agent and not to a probe that runs on a timer.
+pub fn claude_env_for_project_readonly(name: &str) -> ClaudeEnv {
+    claude_env_of(name, claude_account_dir_of)
+}
+
+fn claude_env_of(name: &str, resolve: impl Fn(&str) -> Option<String>) -> ClaudeEnv {
     let Ok(y) = parse_project_yaml(name) else {
         return ClaudeEnv::Inherit;
     };
-    claude_env_for_account(effective_claude_account(&y).as_deref())
+    match effective_claude_account(&y).as_deref() {
+        None => ClaudeEnv::Inherit,
+        Some(id) => match resolve(id) {
+            Some(dir) => ClaudeEnv::Dir(dir),
+            None => ClaudeEnv::Scrub,
+        },
+    }
 }
 
 /// Remove an account and its isolated Claude config dir. The id is validated
@@ -2382,7 +2408,8 @@ mod service_deps_tests {
     fn depends_on_alias_parses() {
         let svc: ServiceFull = serde_norway::from_str("cmd: go run .\ndepends_on: [db]\n").unwrap();
         assert_eq!(svc.depends_on, req(&["db"]));
-        let camel: ServiceFull = serde_norway::from_str("cmd: go run .\ndependsOn: [db]\n").unwrap();
+        let camel: ServiceFull =
+            serde_norway::from_str("cmd: go run .\ndependsOn: [db]\n").unwrap();
         assert_eq!(camel.depends_on, req(&["db"]));
     }
 }

--- a/desktop/frontend/src-tauri/src/hooks.rs
+++ b/desktop/frontend/src-tauri/src/hooks.rs
@@ -207,6 +207,12 @@ fn claude_sessions_root(project: &str) -> PathBuf {
     claude_sessions_root_of(crate::config::claude_env_for_project(project))
 }
 
+/// Where claude keeps its live per-process session records — one
+/// `<pid>.json` per running agent, carrying that agent's `status`.
+pub(crate) fn claude_records_dir(env: crate::config::ClaudeEnv) -> PathBuf {
+    claude_sessions_root_of(env).join("sessions")
+}
+
 /// Where claude keeps a project's transcripts — one `<session id>.jsonl` per
 /// conversation.
 pub(crate) fn claude_sessions_dir(env: crate::config::ClaudeEnv, project_root: &str) -> PathBuf {
@@ -632,25 +638,31 @@ fn merge_codex_hooks(data: &[u8]) -> Option<Vec<u8>> {
     let set_running = send_cmd("set_status '$LPM_PROJECT_NAME' codex_$LPM_PANE_ID Running --icon=sparkle --color=#10A37F --pane=$LPM_PANE_ID");
     let set_done = send_cmd("set_status '$LPM_PROJECT_NAME' codex_$LPM_PANE_ID Done --icon=checkmark --color=#4ade80 --pane=$LPM_PANE_ID");
     let set_resume = capture_resume_cmd("codex");
+    // `--pane` carries no meaning to clear_status itself; it is what lets the
+    // socket tell this frame apart from one a nested codex sent under the same
+    // pane-keyed name (socketsrv::nested_agent_report).
+    let clear = send_cmd("clear_status '$LPM_PROJECT_NAME' codex_$LPM_PANE_ID --pane=$LPM_PANE_ID");
     let pre_tool = codex_pre_tool_use_cmd();
     let permission = codex_permission_request_cmd();
 
-    // Each event maps to its ordered list of hook entries. SessionStart carries
-    // two: the status ping plus the resume-capture hook that reports Codex's
-    // real session id back to the socket (Codex has no --session-id-at-launch).
-    // PostToolUse flips Waiting back to Running once a tool (or an answered
-    // request_user_input) completes, so approval/question badges don't stay
-    // pinned for the rest of a long turn.
+    // Each event maps to its ordered list of hook entries.
     let new_events: Vec<(&str, Vec<Value>)> = vec![
-        (
-            "SessionStart",
-            vec![codex_entry(&set_running), codex_entry(&set_resume)],
-        ),
+        // Captures the session id and nothing else (Codex has no
+        // --session-id-at-launch). Deliberately not Running: starting or
+        // resuming a session is not a turn, and the shimmer belongs to work in
+        // flight — UserPromptSubmit lights it when there is any.
+        ("SessionStart", vec![codex_entry(&set_resume)]),
         ("UserPromptSubmit", vec![codex_entry(&set_running)]),
         ("PreToolUse", vec![codex_entry(&pre_tool)]),
+        // Flips Waiting back to Running once a tool (or an answered
+        // request_user_input) completes, so an approval badge doesn't stay
+        // pinned for the rest of a long turn.
         ("PostToolUse", vec![codex_entry(&set_running)]),
         ("PermissionRequest", vec![codex_entry(&permission)]),
         ("Stop", vec![codex_entry(&set_done)]),
+        // Retires the badge with the session that earned it — including a
+        // Running an interrupt left behind, which no Stop ever came to clear.
+        ("SessionEnd", vec![codex_entry(&clear)]),
     ];
 
     let original = serde_json::from_slice::<Value>(data).ok();
@@ -2600,6 +2612,7 @@ mod tests {
             "PostToolUse",
             "PermissionRequest",
             "Stop",
+            "SessionEnd",
         ] {
             assert!(hooks.contains_key(ev), "missing {ev}");
         }
@@ -2610,18 +2623,27 @@ mod tests {
             waiting.contains("codex_$LPM_PANE_ID Waiting"),
             "PermissionRequest must set Waiting: {waiting}"
         );
-        // SessionStart holds the status ping AND the resume-capture hook.
         let start = v["hooks"]["SessionStart"].as_array().unwrap();
-        assert_eq!(start.len(), 2, "SessionStart should carry two lpm hooks");
-        let has_resume = start.iter().any(|e| {
-            e["hooks"][0]["command"]
-                .as_str()
-                .map(|c| c.contains("set_resume") && c.contains("session_id"))
-                .unwrap_or(false)
-        });
+        assert_eq!(start.len(), 1, "SessionStart should carry one lpm hook");
+        let cmd = start[0]["hooks"][0]["command"].as_str().unwrap();
         assert!(
-            has_resume,
-            "SessionStart missing set_resume hook: {start:?}"
+            cmd.contains("set_resume") && cmd.contains("session_id"),
+            "SessionStart missing set_resume hook: {cmd}"
+        );
+        assert!(
+            !cmd.contains("Running"),
+            "SessionStart must not report Running: {cmd}"
+        );
+        let end = v["hooks"]["SessionEnd"][0]["hooks"][0]["command"]
+            .as_str()
+            .unwrap();
+        assert!(
+            end.contains("clear_status '$LPM_PROJECT_NAME' codex_$LPM_PANE_ID"),
+            "SessionEnd must clear the pane's status: {end}"
+        );
+        assert!(
+            end.contains("--pane=$LPM_PANE_ID"),
+            "SessionEnd clear must carry its pane: {end}"
         );
         assert!(has_marker(&v["hooks"]));
     }

--- a/desktop/frontend/src-tauri/src/lib.rs
+++ b/desktop/frontend/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod agent_sessions_codex;
 mod agent_usage;
 mod agent_caps;
 mod agentnest;
+mod agentstop;
 mod aigen;
 mod autosync;
 mod bounds;
@@ -232,6 +233,7 @@ pub fn run() {
         .manage(message_history::MessageHistoryState::default())
         .manage(std::sync::Arc::new(status::StatusStore::new()))
         .manage(std::sync::Arc::new(agent_limits::AgentLimitsStore::new()))
+        .manage(std::sync::Arc::new(agentstop::PaneSessions::default()))
         .manage(updates::UpdateState::default())
         .manage(tts::TtsState::default())
         .manage(portforward::PortFwdState::default())
@@ -284,7 +286,10 @@ pub fn run() {
                 handle.clone(),
                 true,
             );
-            status::start_pid_sweep(store, handle.clone());
+            status::start_pid_sweep(store.clone(), handle.clone());
+            // A turn the user interrupts ends with no hook to say so; this reads
+            // the agent's own liveness and retires the badge it left behind.
+            agentstop::start(handle.clone(), store);
             // Keep each SSH host's `ssh -R` status forward alive for as long as it
             // has a live pane — without it a dropped forward silently ends remote
             // agent status (and its sound) for the rest of the session.

--- a/desktop/frontend/src-tauri/src/socketsrv.rs
+++ b/desktop/frontend/src-tauri/src/socketsrv.rs
@@ -5,7 +5,7 @@
 //   ping
 //   set_status <project> <key> <value> [--icon=X] [--color=X] [--priority=N] [--pid=N]
 //               [--pane=X] [--reporter-pid=N]
-//   clear_status <project> <key>
+//   clear_status <project> <key> [--pane=X] [--reporter-pid=N]
 //   list_status <project>
 //   start_project <project> [--profile=X]
 //   stop_project <project>
@@ -616,6 +616,14 @@ fn cmd_set_resume(args: &[String], app: &AppHandle) -> String {
             if nested_agent_report(app, &a.pane_id, &options) {
                 return "OK".into();
             }
+            // Remembered so a Codex pane can be matched to the rollout it is
+            // writing, which is where an interrupted turn is recorded. Claude
+            // needs no entry: its record is keyed by pid, which the process tree
+            // already answers.
+            if a.provider == "codex" {
+                app.state::<Arc<crate::agentstop::PaneSessions>>()
+                    .set(&a.pane_id, &a.session_id);
+            }
             let _ = app.emit(
                 "agent-session",
                 serde_json::json!({
@@ -851,22 +859,6 @@ fn opt_or_positional(
         .or_else(|| positional.get(index).cloned())
 }
 
-/// The keys the agent hooks report under (hooks.rs). A key outside these is a
-/// caller's own — `lpm set-status` — and speaks for whatever it likes.
-fn is_agent_key(key: &str) -> bool {
-    key.starts_with("claude_code_") || key.starts_with("codex_")
-}
-
-/// A key naming the pane rather than a session is one the tab's own agent
-/// reports under too: every codex hook keys that way, and the claude hooks fall
-/// back to it for a payload carrying no session id. Retiring such an entry
-/// because a launched agent reported under it would take the tab's own row.
-fn key_names_the_pane(key: &str, pane_id: &str) -> bool {
-    !pane_id.is_empty()
-        && (key.strip_prefix("codex_") == Some(pane_id)
-            || key.strip_prefix("claude_code_") == Some(pane_id))
-}
-
 /// Whether this frame came from an agent that the pane's own agent launched.
 /// Every hook reports `--reporter-pid`, so a frame without one is an older
 /// install or a hand-rolled caller and is taken at its word, as is any pane whose
@@ -925,8 +917,12 @@ fn cmd_set_status(args: &[String], store: &StatusStore, app: &AppHandle) -> Stri
     // own "done". Retire anything it managed to store before its process tree was
     // visible, so a dropped frame can't leave a row nothing will ever clear —
     // unless the key is the tab's own, in which case that entry is the tab's.
-    if is_agent_key(&entry.key) && nested_agent_report(app, &entry.pane_id, &options) {
-        if !key_names_the_pane(&entry.key, &entry.pane_id) && store.clear(project, &entry.key) {
+    if crate::status::key_provider(&entry.key).is_some()
+        && nested_agent_report(app, &entry.pane_id, &options)
+    {
+        if !crate::status::key_names_pane(&entry.key, &entry.pane_id)
+            && store.clear(project, &entry.key)
+        {
             let _ = app.emit("status-changed", project);
         }
         return "OK".into();
@@ -945,6 +941,15 @@ fn cmd_clear_status(args: &[String], store: &StatusStore, app: &AppHandle) -> St
     let (Some(project), Some(key)) = (positional.first(), key) else {
         return "ERROR: usage: clear_status <project> <key>".into();
     };
+    // A key naming the pane is the tab's own, and an agent the tab's agent
+    // launched shares it — its SessionEnd would otherwise retire the tab's
+    // status on the way out. A session-keyed clear needs no such guard: it can
+    // only reach the reporter's own entry.
+    let pane_id = options.get("pane").cloned().unwrap_or_default();
+    if crate::status::key_names_pane(&key, &pane_id) && nested_agent_report(app, &pane_id, &options)
+    {
+        return "OK".into();
+    }
     if store.clear(project, &key) {
         let _ = app.emit("status-changed", project);
     }
@@ -1131,30 +1136,6 @@ mod tests {
                 "{bad} must be refused on the remote socket"
             );
         }
-    }
-
-    #[test]
-    fn a_pane_keyed_entry_belongs_to_the_tab_not_to_what_it_launched() {
-        // Every codex hook keys on the pane, so a codex a codex tab shelled out
-        // to reports under the tab's own key — dropping its frame must not take
-        // the tab's status with it.
-        assert!(key_names_the_pane("codex_pty-3", "pty-3"));
-        assert!(key_names_the_pane("claude_code_pty-3", "pty-3"));
-        // A session-keyed entry can only be the reporter's own.
-        assert!(!key_names_the_pane("claude_code_9a15513b", "pty-3"));
-        assert!(!key_names_the_pane("codex_pty-30", "pty-3"));
-        assert!(!key_names_the_pane("codex_", ""));
-    }
-
-    #[test]
-    fn agent_keys_are_the_ones_the_hooks_report_under() {
-        assert!(is_agent_key("claude_code_9a15513b-e4a3"));
-        assert!(is_agent_key("codex_pty-3"));
-        // A caller's own key: `lpm set-status` names whatever it likes, and the
-        // nested-agent rule has no business second-guessing it.
-        assert!(!is_agent_key("deploy"));
-        assert!(!is_agent_key("claude"));
-        assert!(!is_agent_key("my_codex_run"));
     }
 
     #[test]

--- a/desktop/frontend/src-tauri/src/status.rs
+++ b/desktop/frontend/src-tauri/src/status.rs
@@ -10,11 +10,45 @@ use std::sync::{Arc, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, State};
 
-#[allow(dead_code)] // agents send "Running"; kept for the full StatusKind set
 pub const STATUS_RUNNING: &str = "Running";
 pub const STATUS_DONE: &str = "Done";
 pub const STATUS_WAITING: &str = "Waiting";
 pub const STATUS_ERROR: &str = "Error";
+
+/// Which agent a status key belongs to. The hooks key every report by provider
+/// (hooks.rs), and several readers need to know which one wrote an entry — keep
+/// that knowledge here, beside the values, rather than re-spelling the prefixes
+/// at each of them.
+#[derive(PartialEq, Debug, Clone, Copy)]
+pub enum KeyProvider {
+    Claude,
+    Codex,
+}
+
+const CLAUDE_KEY_PREFIX: &str = "claude_code_";
+const CODEX_KEY_PREFIX: &str = "codex_";
+
+/// The agent that reports under `key`, or None for a key nobody's hooks write —
+/// `lpm set-status` names whatever it likes and speaks for itself.
+pub fn key_provider(key: &str) -> Option<KeyProvider> {
+    if key.starts_with(CLAUDE_KEY_PREFIX) {
+        Some(KeyProvider::Claude)
+    } else if key.starts_with(CODEX_KEY_PREFIX) {
+        Some(KeyProvider::Codex)
+    } else {
+        None
+    }
+}
+
+/// Whether `key` names the pane rather than a session within it. Every codex
+/// hook keys that way, and the claude hooks fall back to it for a payload
+/// carrying no session id — so such an entry belongs to the tab itself, and an
+/// agent the tab's agent launched reports under the very same name.
+pub fn key_names_pane(key: &str, pane_id: &str) -> bool {
+    !pane_id.is_empty()
+        && (key.strip_prefix(CODEX_KEY_PREFIX) == Some(pane_id)
+            || key.strip_prefix(CLAUDE_KEY_PREFIX) == Some(pane_id))
+}
 
 fn is_zero(v: &i64) -> bool {
     *v == 0
@@ -130,6 +164,13 @@ impl StatusStore {
         true
     }
 
+    /// Remove `key` only while it still holds `value`. The reconcile that reads
+    /// an agent's own liveness (agentstop.rs) decides on a snapshot, and a real
+    /// report can land in between — that report is the better answer, so it wins.
+    pub fn clear_if_value(&self, project: &str, key: &str, value: &str) -> bool {
+        self.retain_where(project, |e| e.key == key && e.value == value)
+    }
+
     /// Drop every entry of `project` for which `drop` returns true, removing the
     /// project bucket once it empties. Returns whether anything was removed.
     fn retain_where<F: Fn(&StatusEntry) -> bool>(&self, project: &str, drop: F) -> bool {
@@ -219,18 +260,32 @@ impl StatusStore {
         out
     }
 
+    /// Every entry `pick` says yes to, addressed by (project, key) and carrying
+    /// whatever `pick` pulled off it. The background reconcilers all want the
+    /// same thing — a snapshot they can act on without holding the lock.
+    fn candidates<T>(&self, pick: impl Fn(&StatusEntry) -> Option<T>) -> Vec<(String, String, T)> {
+        let m = self.entries.read().unwrap();
+        m.iter()
+            .flat_map(|(project, bucket)| {
+                bucket
+                    .iter()
+                    .filter_map(|(key, e)| pick(e).map(|held| (project.clone(), key.clone(), held)))
+            })
+            .collect()
+    }
+
+    /// (project, key, pane) for every entry still reporting Running against a
+    /// pane. The only entries worth reconciling against an agent's own liveness:
+    /// a turn that ended any other way already said so.
+    pub fn running_agents(&self) -> Vec<(String, String, String)> {
+        self.candidates(|e| {
+            (e.value == STATUS_RUNNING && !e.pane_id.is_empty()).then(|| e.pane_id.clone())
+        })
+    }
+
     /// (project, key, pid) for every entry carrying a live agent PID — feeds the sweep.
     fn pid_candidates(&self) -> Vec<(String, String, i64)> {
-        let m = self.entries.read().unwrap();
-        let mut out = Vec::new();
-        for (project, bucket) in m.iter() {
-            for (key, e) in bucket {
-                if e.agent_pid > 0 {
-                    out.push((project.clone(), key.clone(), e.agent_pid));
-                }
-            }
-        }
-        out
+        self.candidates(|e| (e.agent_pid > 0).then_some(e.agent_pid))
     }
 }
 
@@ -432,6 +487,59 @@ mod tests {
             !s.clear_by_pane_value("p", "p-1", "Done"),
             "second clear is a no-op"
         );
+    }
+
+    #[test]
+    fn key_provider_reads_the_prefixes_the_hooks_write() {
+        assert_eq!(
+            key_provider("claude_code_9a15513b-e4a3"),
+            Some(KeyProvider::Claude)
+        );
+        assert_eq!(key_provider("codex_pty-3"), Some(KeyProvider::Codex));
+        // A caller's own key: `lpm set-status` names whatever it likes, and the
+        // agent rules have no business second-guessing it.
+        assert_eq!(key_provider("deploy"), None);
+        assert_eq!(key_provider("claude"), None);
+        assert_eq!(key_provider("my_codex_run"), None);
+    }
+
+    #[test]
+    fn a_pane_keyed_entry_belongs_to_the_tab_not_to_what_it_launched() {
+        // Every codex hook keys on the pane, so a codex a codex tab shelled out
+        // to reports under the tab's own key.
+        assert!(key_names_pane("codex_pty-3", "pty-3"));
+        assert!(key_names_pane("claude_code_pty-3", "pty-3"));
+        // A session-keyed entry can only be the reporter's own.
+        assert!(!key_names_pane("claude_code_9a15513b", "pty-3"));
+        assert!(!key_names_pane("codex_pty-30", "pty-3"));
+        assert!(!key_names_pane("codex_", ""));
+    }
+
+    #[test]
+    fn clear_if_value_yields_to_a_report_that_landed_first() {
+        let s = StatusStore::new();
+        s.set("p", entry("k", "Running", 0, 1, "p-1"));
+        // A Done landing between the reconcile's read and its write is the
+        // better answer, and keeps its entry.
+        s.set("p", entry("k", "Done", 0, 2, "p-1"));
+        assert!(!s.clear_if_value("p", "k", "Running"));
+        assert_eq!(s.list("p").len(), 1);
+        assert!(s.clear_if_value("p", "k", "Done"));
+        assert!(s.list("p").is_empty());
+        assert!(!s.clear_if_value("p", "k", "Done"), "already gone");
+        assert!(!s.clear_if_value("missing", "k", "Done"));
+    }
+
+    #[test]
+    fn running_agents_lists_only_running_entries_with_a_pane() {
+        let s = StatusStore::new();
+        s.set("p", entry("run", "Running", 0, 1, "p-1"));
+        s.set("p", entry("done", "Done", 0, 1, "p-2"));
+        s.set("p", entry("wait", "Waiting", 0, 1, "p-3"));
+        s.set("p", entry("paneless", "Running", 0, 1, ""));
+        let mut got: Vec<String> = s.running_agents().into_iter().map(|(_, k, _)| k).collect();
+        got.sort();
+        assert_eq!(got, vec!["run".to_string()]);
     }
 
     #[test]


### PR DESCRIPTION
Fixes stale “Running” indicators when Claude or Codex turns are interrupted without emitting stop hooks. A background reconciler now checks each agent’s persisted session state and safely clears only confirmed stale statuses.

- Detect Claude turn completion from per-process session records, including support for configured account directories
- Detect Codex interruptions from `turn_aborted` events in session rollout files, respecting `CODEX_HOME`
- Track pane-to-session mappings and identify the pane’s active agent through the process tree
- Avoid false clears for active, waiting, background-shell, remote, nested, or ambiguous agent sessions
- Cache Codex rollout lookups and emit status updates only when stale entries are actually removed
- Add focused tests for liveness parsing, process discovery, cache behavior, session mapping, and conditional status clearing