### PR TITLE
feat(sidebar): sort duplicates inside a folder by drag and drop

### DIFF
--- a/desktop/frontend/src-tauri/src/config.rs
+++ b/desktop/frontend/src-tauri/src/config.rs
@@ -2927,3 +2927,43 @@ mod action_input_tests {
         assert_eq!(build_input_infos(&map)[0].kind, "text");
     }
 }
+
+#[cfg(test)]
+mod project_order_tests {
+    use super::*;
+
+    fn names(projects: Vec<Value>) -> Vec<String> {
+        projects.iter().map(|p| name_of(p).to_string()).collect()
+    }
+
+    fn ordered(order: &[&str], projects: Vec<Value>) -> Vec<String> {
+        let order: Vec<String> = order.iter().map(|s| s.to_string()).collect();
+        names(apply_project_order(projects, &order))
+    }
+
+    /// The sidebar sorts a duplicate by writing its slot into `projectOrder`;
+    /// regrouping must not shuffle the siblings back.
+    #[test]
+    fn duplicates_keep_their_saved_order_under_the_parent() {
+        let projects = vec![
+            json!({"name": "api"}),
+            json!({"name": "api-1", "parentName": "api"}),
+            json!({"name": "api-2", "parentName": "api"}),
+            json!({"name": "web"}),
+        ];
+        assert_eq!(
+            ordered(&["api", "api-2", "api-1", "web"], projects),
+            ["api", "api-2", "api-1", "web"],
+        );
+    }
+
+    #[test]
+    fn an_unordered_duplicate_still_follows_its_parent() {
+        let projects = vec![
+            json!({"name": "api-1", "parentName": "api"}),
+            json!({"name": "web"}),
+            json!({"name": "api"}),
+        ];
+        assert_eq!(ordered(&[], projects), ["web", "api", "api-1"]);
+    }
+}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -87,6 +87,7 @@ export default function App() {
   const renameProject = useAppStore((s) => s.renameProject);
   const moveProjectRoot = useAppStore((s) => s.moveProjectRoot);
   const applySidebarLayout = useAppStore((s) => s.applySidebarLayout);
+  const reorderDuplicate = useAppStore((s) => s.reorderDuplicate);
   const createGroup = useAppStore((s) => s.createGroup);
   const renameGroup = useAppStore((s) => s.renameGroup);
   const deleteGroup = useAppStore((s) => s.deleteGroup);
@@ -272,6 +273,7 @@ export default function App() {
           onRenameProject={renameProject}
           onMoveProjectRoot={moveProjectRoot}
           onApplySidebarLayout={applySidebarLayout}
+          onReorderDuplicate={reorderDuplicate}
           onCreateGroup={createGroup}
           onRenameGroup={renameGroup}
           onDeleteGroup={deleteGroup}

--- a/desktop/frontend/src/DetachedApp.tsx
+++ b/desktop/frontend/src/DetachedApp.tsx
@@ -45,6 +45,7 @@ export function DetachedApp({ projectName }: DetachedAppProps) {
   const renameProject = useAppStore((s) => s.renameProject);
   const moveProjectRoot = useAppStore((s) => s.moveProjectRoot);
   const applySidebarLayout = useAppStore((s) => s.applySidebarLayout);
+  const reorderDuplicate = useAppStore((s) => s.reorderDuplicate);
   const createGroup = useAppStore((s) => s.createGroup);
   const renameGroup = useAppStore((s) => s.renameGroup);
   const deleteGroup = useAppStore((s) => s.deleteGroup);
@@ -127,6 +128,7 @@ export function DetachedApp({ projectName }: DetachedAppProps) {
           onRenameProject={renameProject}
           onMoveProjectRoot={moveProjectRoot}
           onApplySidebarLayout={applySidebarLayout}
+          onReorderDuplicate={reorderDuplicate}
           onCreateGroup={createGroup}
           onRenameGroup={renameGroup}
           onDeleteGroup={deleteGroup}

--- a/desktop/frontend/src/components/Sidebar.tsx
+++ b/desktop/frontend/src/components/Sidebar.tsx
@@ -12,7 +12,7 @@ import {
   type DragEndEvent,
   type DragStartEvent,
 } from "@dnd-kit/core";
-import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { SortableContext, verticalListSortingStrategy, type SortingStrategy } from "@dnd-kit/sortable";
 import { StatusDot, dotKind } from "./StatusDot";
 import { getSettings, saveSettings, useSettingsStore } from "../store/settings";
 import { useAppStore } from "../store/app";
@@ -46,6 +46,7 @@ import {
   peerSlugOfToken,
   peerToken,
   rangeBetween,
+  resolveDuplicateDrop,
   resolveSidebarDrop,
   syncPeerTokens,
 } from "./sidebarLayout";
@@ -137,6 +138,7 @@ interface SidebarProps {
   onRenameProject: (name: string, label: string) => void;
   onMoveProjectRoot: (name: string, newRoot: string) => Promise<void>;
   onApplySidebarLayout: (layout: SidebarLayout) => void;
+  onReorderDuplicate: (name: string, overName: string) => void;
   onCreateGroup: (name: string, opts?: { initialMembers?: string[] }) => void;
   onRenameGroup: (id: string, name: string) => void;
   onDeleteGroup: (id: string) => void;
@@ -176,7 +178,7 @@ type TreeItem =
   | { kind: "empty"; group: ProjectGroup }
   | { kind: "peer"; section: PeerSection };
 
-export function Sidebar({ projects, groups, sidebarOrder, selected, collapsed, onCollapsedChange, onSelect, onOpenProjectView, onToggle, onTerminals, onFleet, onStats, onUsage, onScheduled, onMobile, onFeedback, onSettings, onAddProject, onBulkDuplicate, onRemoveProject, onRemoveProjectCascade, onRemoveProjectFromDisk, onRemoveProjectsBatch, onRenameProject, onMoveProjectRoot, onApplySidebarLayout, onCreateGroup, onRenameGroup, onDeleteGroup, onToggleGroupCollapsed, onMoveProjectToGroup, onMoveProjectsToGroup, onDetachProject, onAttachProject, detached, detachedSelf, showTerminals, showFleet, showStats, showUsage, showMobile, showScheduled, showSettings, duplicatingNames, removingNames }: SidebarProps) {
+export function Sidebar({ projects, groups, sidebarOrder, selected, collapsed, onCollapsedChange, onSelect, onOpenProjectView, onToggle, onTerminals, onFleet, onStats, onUsage, onScheduled, onMobile, onFeedback, onSettings, onAddProject, onBulkDuplicate, onRemoveProject, onRemoveProjectCascade, onRemoveProjectFromDisk, onRemoveProjectsBatch, onRenameProject, onMoveProjectRoot, onApplySidebarLayout, onReorderDuplicate, onCreateGroup, onRenameGroup, onDeleteGroup, onToggleGroupCollapsed, onMoveProjectToGroup, onMoveProjectsToGroup, onDetachProject, onAttachProject, detached, detachedSelf, showTerminals, showFleet, showStats, showUsage, showMobile, showScheduled, showSettings, duplicatingNames, removingNames }: SidebarProps) {
   const [updateInfo, setUpdateInfo] = useState<{ latestVersion: string } | null>(null);
   const [installing, setInstalling] = useState(false);
   const [progress, setProgress] = useState(-1); // -1 = no progress yet
@@ -335,7 +337,7 @@ export function Sidebar({ projects, groups, sidebarOrder, selected, collapsed, o
   // interleaved order. Duplicates ride immediately after their parent;
   // brand-new projects not yet in the persisted order are appended loose so
   // they never vanish.
-  const { items, sortableIds, projectByName, memberOf } = useMemo(() => {
+  const { items, sortableIds, projectByName, memberOf, childrenOf, childOf } = useMemo(() => {
     const byName = new Map<string, ProjectInfo>();
     for (const p of localProjects) byName.set(p.name, p);
     const sectionBySlug = new Map(peerSections.map((s) => [s.slug, s]));
@@ -361,6 +363,7 @@ export function Sidebar({ projects, groups, sidebarOrder, selected, collapsed, o
       rendered.add(p.name);
       for (const child of childrenByParent.get(p.name) ?? []) {
         out.push({ kind: "project", project: child, isChild: true, folderId });
+        ids.push(child.name);
         rendered.add(child.name);
       }
     };
@@ -422,7 +425,22 @@ export function Sidebar({ projects, groups, sidebarOrder, selected, collapsed, o
       if (membership.has(p.name)) continue;
       pushProject(p);
     }
-    return { items: out, sortableIds: ids, projectByName: byName, memberOf: membership };
+    // Sibling sets for the duplicate drag: the names under each parent, and the
+    // way back from a duplicate to that parent.
+    const childrenOf = new Map<string, string[]>();
+    const childOf = new Map<string, string>();
+    for (const [parent, children] of childrenByParent) {
+      childrenOf.set(parent, children.map((c) => c.name));
+      for (const child of children) childOf.set(child.name, parent);
+    }
+    return {
+      items: out,
+      sortableIds: ids,
+      projectByName: byName,
+      memberOf: membership,
+      childrenOf,
+      childOf,
+    };
   }, [localProjects, groups, order, peerSections]);
 
   // Project names in rendered top-to-bottom order — the axis a shift-click
@@ -735,17 +753,48 @@ export function Sidebar({ projects, groups, sidebarOrder, selected, collapsed, o
     );
   };
 
+  // A nested duplicate only ever changes places with its siblings, so freeze
+  // every other row while one is dragged: the default strategy shifts the whole
+  // list below the pointer, which reads as if other folders were about to move.
+  const draggedDuplicateParent = activeId ? childOf.get(activeId) : undefined;
+  const sortingStrategy = useMemo<SortingStrategy>(() => {
+    if (!draggedDuplicateParent) return verticalListSortingStrategy;
+    const siblings = childrenOf.get(draggedDuplicateParent) ?? [];
+    const first = sortableIds.indexOf(siblings[0]);
+    const last = sortableIds.indexOf(siblings[siblings.length - 1]);
+    // The parent sits right above its first child, and dropping on it is a move
+    // to the top of the siblings — so it counts as an in-range target.
+    return (args) =>
+      args.index < first ||
+      args.index > last ||
+      args.overIndex < first - 1 ||
+      args.overIndex > last
+        ? null
+        : verticalListSortingStrategy(args);
+  }, [draggedDuplicateParent, childrenOf, sortableIds]);
+
   const onDragStart = (e: DragStartEvent) => setActiveId(String(e.active.id));
   const onDragCancel = () => setActiveId(null);
   const onDragEnd = (e: DragEndEvent) => {
     setActiveId(null);
     const { active, over } = e;
     if (!over) return;
-    if (isPeerRowId(String(active.id))) {
-      reorderPeerRow(String(active.id), String(over.id));
+    const activeId = String(active.id);
+    const overId = String(over.id);
+    if (isPeerRowId(activeId)) {
+      reorderPeerRow(activeId, overId);
       return;
     }
-    const next = resolveSidebarDrop(layoutRef.current, String(active.id), String(over.id));
+    // A nested duplicate has no slot of its own: dragging one only sorts it
+    // among its siblings.
+    const parentName = childOf.get(activeId);
+    if (parentName) {
+      const target = resolveDuplicateDrop(childrenOf, parentName, activeId, overId);
+      if (target) onReorderDuplicate(activeId, target);
+      return;
+    }
+    // Dropping onto a nested duplicate targets the slot its parent occupies.
+    const next = resolveSidebarDrop(layoutRef.current, activeId, childOf.get(overId) ?? overId);
     if (next) onApplySidebarLayout(next);
   };
 
@@ -908,7 +957,7 @@ export function Sidebar({ projects, groups, sidebarOrder, selected, collapsed, o
     );
   };
 
-  const renderRow = (item: TreeItem) => {
+  const renderRow = (item: TreeItem, connector?: React.ReactNode) => {
     if (item.kind === "group") {
       const selectedProject =
         item.group.collapsed && selected !== null ? projectByName.get(selected) : undefined;
@@ -930,10 +979,18 @@ export function Sidebar({ projects, groups, sidebarOrder, selected, collapsed, o
           onMore={(x, y) => setGroupMenu({ id: item.group.id, x, y })}
         />
       );
-      if (selectMode) return <div key={groupToken(item.group.id)}>{header}</div>;
+      if (selectMode) {
+        return (
+          <div key={groupToken(item.group.id)} className="relative">
+            {connector}
+            {header}
+          </div>
+        );
+      }
       return (
         <SortableItem key={groupToken(item.group.id)} id={groupToken(item.group.id)}>
           <div className="relative">
+            {connector}
             {header}
             <FolderDropZone id={folderNestId(item.group.id)} overlay />
           </div>
@@ -977,14 +1034,15 @@ export function Sidebar({ projects, groups, sidebarOrder, selected, collapsed, o
       );
     }
 
-    const { project, isChild } = item;
+    const { project } = item;
     const row = renderProjectRow(project, item.folderId !== undefined);
-    if (isChild || selectMode) {
-      return <div key={project.name}>{row}</div>;
+    const body = connector ? <div className="relative">{connector}{row}</div> : row;
+    if (selectMode) {
+      return <div key={project.name}>{body}</div>;
     }
     return (
       <SortableItem key={project.name} id={project.name}>
-        {row}
+        {body}
       </SortableItem>
     );
   };
@@ -1041,6 +1099,31 @@ export function Sidebar({ projects, groups, sidebarOrder, selected, collapsed, o
   const TREE_X = "left-[15px]";
   // From TREE_X out to the member's status dot at 27px.
   const ELBOW_W = "w-[12px]";
+  // Each row carries its own piece of the tree inside its sortable box, so a
+  // live drag moves the lines with the rows instead of stranding them — no
+  // folder loses its connector just because a drag is in progress.
+  const folderConnector = (
+    <span
+      aria-hidden
+      className={`pointer-events-none absolute ${TREE_X} top-[26px] bottom-0 z-10 w-px ${TRUNK_BG}`}
+    />
+  );
+  const rowConnector = (isLast: boolean) => (
+    <>
+      <span
+        aria-hidden
+        style={{ height: ROW_HALF }}
+        className={`pointer-events-none absolute ${TREE_X} top-0 z-10 ${ELBOW_W} rounded-bl-[6px] border-b border-l ${ELBOW_BORDER}`}
+      />
+      {!isLast && (
+        <span
+          aria-hidden
+          style={{ top: ROW_HALF }}
+          className={`pointer-events-none absolute ${TREE_X} bottom-0 z-10 w-px ${TRUNK_BG}`}
+        />
+      )}
+    </>
+  );
   const renderFolderBlock = (
     groupItem: Extract<TreeItem, { kind: "group" }>,
     body: TreeItem[],
@@ -1050,49 +1133,11 @@ export function Sidebar({ projects, groups, sidebarOrder, selected, collapsed, o
       if (it.kind === "project") lastProjectIndex = i;
     });
     const hasProjects = lastProjectIndex !== -1;
-    // Connectors are absolute siblings of the sortable rows, so a live drag's
-    // row transform would leave them stranded — hide the whole tree while any
-    // drag is active; it reappears on drop.
-    const showConnectors = !activeId;
     return (
       <div key={groupToken(groupItem.group.id)}>
-        <div className="relative">
-          {renderRow(groupItem)}
-          {hasProjects && showConnectors && (
-            <span
-              aria-hidden
-              className={`pointer-events-none absolute ${TREE_X} top-[26px] bottom-0 z-10 w-px ${TRUNK_BG}`}
-            />
-          )}
-        </div>
-        {body.length > 0 && (
-          <div className="relative">
-            {body.map((it, i) =>
-              it.kind === "project" ? (
-                <div key={it.project.name} className="relative">
-                  {showConnectors && (
-                    <>
-                      <span
-                        aria-hidden
-                        style={{ height: ROW_HALF }}
-                        className={`pointer-events-none absolute ${TREE_X} top-0 z-10 ${ELBOW_W} rounded-bl-[6px] border-b border-l ${ELBOW_BORDER}`}
-                      />
-                      {i !== lastProjectIndex && (
-                        <span
-                          aria-hidden
-                          style={{ top: ROW_HALF }}
-                          className={`pointer-events-none absolute ${TREE_X} bottom-0 z-10 w-px ${TRUNK_BG}`}
-                        />
-                      )}
-                    </>
-                  )}
-                  {renderRow(it)}
-                </div>
-              ) : (
-                renderRow(it)
-              ),
-            )}
-          </div>
+        {renderRow(groupItem, hasProjects ? folderConnector : undefined)}
+        {body.map((it, i) =>
+          it.kind === "project" ? renderRow(it, rowConnector(i === lastProjectIndex)) : renderRow(it),
         )}
       </div>
     );
@@ -1180,7 +1225,7 @@ export function Sidebar({ projects, groups, sidebarOrder, selected, collapsed, o
             onDragEnd={onDragEnd}
             onDragCancel={onDragCancel}
           >
-            <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+            <SortableContext items={sortableIds} strategy={sortingStrategy}>
               {navItems}
             </SortableContext>
             <DragOverlay className="pointer-events-none">

--- a/desktop/frontend/src/components/sidebarLayout.test.ts
+++ b/desktop/frontend/src/components/sidebarLayout.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { ProjectGroup } from "../types";
+import type { ProjectGroup, ProjectInfo } from "../types";
 import {
   type SidebarLayout,
   groupToken,
@@ -17,6 +17,8 @@ import {
   renameGroup,
   setGroupCollapsed,
   flattenForProjectOrder,
+  nestedDuplicates,
+  resolveDuplicateDrop,
   reconcile,
   forgetProjects,
   layoutsEqual,
@@ -31,6 +33,10 @@ import {
 
 function g(id: string, members: string[], extra: Partial<ProjectGroup> = {}): ProjectGroup {
   return { id, name: id, members, ...extra };
+}
+
+function p(name: string, parentName?: string): ProjectInfo {
+  return { name, parentName } as ProjectInfo;
 }
 
 // api, [Front: web, admin], scripts, [Exp: e1, e2], landing
@@ -179,9 +185,82 @@ describe("renameGroup / setGroupCollapsed", () => {
   });
 });
 
+describe("nestedDuplicates", () => {
+  it("groups duplicates under their parent in project-list order", () => {
+    const projects = [p("api"), p("api-2", "api"), p("api-1", "api"), p("web")];
+    expect(nestedDuplicates([], projects)).toEqual(new Map([["api", ["api-2", "api-1"]]]));
+  });
+
+  it("leaves out a duplicate that is an explicit folder member", () => {
+    const projects = [p("api"), p("api-1", "api"), p("api-2", "api")];
+    expect(nestedDuplicates([g("Front", ["api-2"])], projects)).toEqual(
+      new Map([["api", ["api-1"]]]),
+    );
+  });
+
+  it("ignores a project whose parent is gone", () => {
+    expect(nestedDuplicates([], [p("api-1", "api")])).toEqual(new Map());
+  });
+});
+
+describe("resolveDuplicateDrop", () => {
+  const nested = new Map([["api", ["api-1", "api-2", "api-3"]]]);
+
+  it("takes the sibling slot it was dropped on", () => {
+    expect(resolveDuplicateDrop(nested, "api", "api-3", "api-1")).toBe("api-1");
+  });
+
+  it("goes to the top of the siblings when dropped on the parent", () => {
+    expect(resolveDuplicateDrop(nested, "api", "api-3", "api")).toBe("api-1");
+  });
+
+  it("stays put when dropped on itself or outside its siblings", () => {
+    expect(resolveDuplicateDrop(nested, "api", "api-2", "api-2")).toBeNull();
+    expect(resolveDuplicateDrop(nested, "api", "api-1", "api")).toBeNull();
+    expect(resolveDuplicateDrop(nested, "api", "api-2", "web")).toBeNull();
+    expect(resolveDuplicateDrop(nested, "api", "api-2", groupToken("Front"))).toBeNull();
+  });
+});
+
 describe("flattenForProjectOrder", () => {
+  it("trails every project with its nested duplicates", () => {
+    const projects = [
+      p("api"),
+      p("api-2", "api"),
+      p("api-1", "api"),
+      p("web"),
+      p("web-1", "web"),
+      p("admin"),
+      p("scripts"),
+      p("e1"),
+      p("e2"),
+      p("landing"),
+    ];
+    expect(flattenForProjectOrder(sample(), projects)).toEqual([
+      "api",
+      "api-2",
+      "api-1",
+      "web",
+      "web-1",
+      "admin",
+      "scripts",
+      "e1",
+      "e2",
+      "landing",
+    ]);
+  });
+
+  it("keeps a folder-member duplicate at its own slot", () => {
+    const layout: SidebarLayout = {
+      order: [groupToken("Front")],
+      groups: [g("Front", ["web-1", "web"])],
+    };
+    const projects = [p("web"), p("web-1", "web"), p("web-2", "web")];
+    expect(flattenForProjectOrder(layout, projects)).toEqual(["web-1", "web", "web-2"]);
+  });
+
   it("expands folders into their members in display order", () => {
-    expect(flattenForProjectOrder(sample())).toEqual([
+    expect(flattenForProjectOrder(sample(), [])).toEqual([
       "api",
       "web",
       "admin",
@@ -301,7 +380,7 @@ describe("peer slots in the layout", () => {
   });
 
   it("stays out of the flattened project order", () => {
-    expect(flattenForProjectOrder(layout())).toEqual(["api", "web", "admin", "scripts"]);
+    expect(flattenForProjectOrder(layout(), [])).toEqual(["api", "web", "admin", "scripts"]);
   });
 
   it("survives reconcile, which can't see the pairing list", () => {

--- a/desktop/frontend/src/components/sidebarLayout.ts
+++ b/desktop/frontend/src/components/sidebarLayout.ts
@@ -1,4 +1,4 @@
-import type { ProjectGroup, ProjectInfo } from "../types";
+import { isDuplicate, type ProjectGroup, type ProjectInfo } from "../types";
 import { arrayEq } from "./actionsDndLayout";
 
 // Pure model + move math for the sidebar's interleaved folders/projects list.
@@ -274,21 +274,64 @@ export function setGroupCollapsed(
   };
 }
 
+// parent name -> its nested duplicates, in project-list order. A duplicate
+// explicitly placed in a folder is excluded: it renders as a member on the
+// folder's level instead of under its parent.
+export function nestedDuplicates(
+  groups: ProjectGroup[],
+  projects: ProjectInfo[],
+): Map<string, string[]> {
+  const byName = new Map(projects.map((p) => [p.name, p]));
+  const claimed = membershipMap(groups);
+  const out = new Map<string, string[]>();
+  for (const p of projects) {
+    if (!isDuplicate(p, byName) || claimed.has(p.name)) continue;
+    const siblings = out.get(p.parentName!);
+    if (siblings) siblings.push(p.name);
+    else out.set(p.parentName!, [p.name]);
+  }
+  return out;
+}
+
+// The sibling slot a dragged nested duplicate should take, or null when the drop
+// leaves it where it is. Dropping it on its parent row sends it to the top of
+// the siblings; anything outside the sibling set is a no-op, since a duplicate
+// can only leave its parent's nesting by joining a folder.
+export function resolveDuplicateDrop(
+  nested: Map<string, string[]>,
+  parentName: string,
+  activeId: string,
+  overId: string,
+): string | null {
+  const siblings = nested.get(parentName) ?? [];
+  const over = overId === parentName ? siblings[0] : overId;
+  return over !== activeId && siblings.includes(over) ? over : null;
+}
+
 // The flat all-projects order written to settings.projectOrder for the backend.
 // Walk top-level order, expanding each folder into its members and skipping peer
-// slots (a Mac's projects are listed by that Mac, not here). A folder member may
-// be a duplicate; the backend re-groups every duplicate after its parent on its
-// own, so a duplicate's position here is only advisory.
-export function flattenForProjectOrder(layout: SidebarLayout): string[] {
+// slots (a Mac's projects are listed by that Mac, not here), and trail every
+// project with its nested duplicates. Those have no slot of their own, so this
+// is where their within-parent order is kept: the backend regroups duplicates
+// after their parent but preserves the relative order it reads here.
+export function flattenForProjectOrder(
+  layout: SidebarLayout,
+  projects: ProjectInfo[],
+): string[] {
   const byId = new Map(layout.groups.map((g) => [g.id, g]));
+  const nested = nestedDuplicates(layout.groups, projects);
   const out: string[] = [];
+  const push = (name: string) => {
+    out.push(name);
+    out.push(...(nested.get(name) ?? []));
+  };
   for (const token of layout.order) {
     const gid = groupIdOf(token);
     if (gid) {
       const g = byId.get(gid);
-      if (g) out.push(...g.members);
+      if (g) g.members.forEach(push);
     } else if (!isPeerToken(token)) {
-      out.push(token);
+      push(token);
     }
   }
   return out;

--- a/desktop/frontend/src/store/app.ts
+++ b/desktop/frontend/src/store/app.ts
@@ -330,6 +330,8 @@ interface AppState {
   moveProjectsToGroup: (names: string[], groupId: string | null) => Promise<void>;
   // Commit a full sidebar layout (on DnD drop): persists folders + order.
   applySidebarLayout: (layout: SidebarLayout) => Promise<void>;
+  // Move a nested duplicate to another slot among the siblings under its parent.
+  reorderDuplicate: (name: string, overName: string) => Promise<void>;
   // Re-place duplicates + append new projects after a project list refresh.
   // Never drops a name it can't see — only `forgetProjects` does that.
   reconcileSidebarLayout: (projects: ProjectInfo[]) => void;
@@ -808,6 +810,7 @@ async function persistSidebarLayout(
   layout: SidebarLayout,
   base: SidebarLayout,
   known: Set<string>,
+  projects: ProjectInfo[],
 ): Promise<SidebarLayout> {
   let merged = layout;
   try {
@@ -821,7 +824,7 @@ async function persistSidebarLayout(
     saveGroups({ groups: merged.groups }),
     saveSettings({
       sidebarOrder: merged.order,
-      projectOrder: flattenForProjectOrder(merged),
+      projectOrder: flattenForProjectOrder(merged, projects),
     }),
   ]);
   return merged;
@@ -939,7 +942,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     );
     if (layoutsEqual(before, after)) return;
     set({ sidebarOrder: after.order, groups: after.groups });
-    persistSidebarLayout(after, before, layoutNames(projects))
+    persistSidebarLayout(after, before, layoutNames(projects), projects)
       .then((merged) => get().adoptSidebarLayout(merged))
       .catch(() => undefined);
   },
@@ -1685,12 +1688,36 @@ export const useAppStore = create<AppState>((set, get) => ({
     // update state but skip the persist.
     if (layoutsEqual(prev, next)) return;
     try {
-      get().adoptSidebarLayout(await persistSidebarLayout(next, prev, layoutNames(projects)));
+      get().adoptSidebarLayout(
+        await persistSidebarLayout(next, prev, layoutNames(projects), projects),
+      );
     } catch (err) {
       toast.error(`Failed to save folders: ${err}`);
       const cfg = await loadGroups();
       const fresh = await loadSettings();
       set({ groups: cfg.groups, sidebarOrder: fresh.sidebarOrder ?? [] });
+    }
+  },
+
+  // A nested duplicate has no slot in the sidebar layout — it rides with its
+  // parent, in project-list order. So its within-parent order lives in the
+  // project list itself: move it there, then re-persist the flattened
+  // projectOrder the backend reads that order back from.
+  reorderDuplicate: async (name, overName) => {
+    const projects = get().projects;
+    const from = projects.findIndex((p) => p.name === name);
+    const to = projects.findIndex((p) => p.name === overName);
+    if (from < 0 || to < 0 || from === to) return;
+    const next = projects.slice();
+    const [moved] = next.splice(from, 1);
+    next.splice(to, 0, moved);
+    set({ projects: next });
+    const layout: SidebarLayout = { order: get().sidebarOrder, groups: get().groups };
+    try {
+      await saveSettings({ projectOrder: flattenForProjectOrder(layout, next) });
+    } catch (err) {
+      toast.error(`Failed to save order: ${err}`);
+      set({ projects });
     }
   },
 


### PR DESCRIPTION
## Summary

Duplicates nested under a project could not be dragged at all — they rendered as plain rows, outside the sortable list — and their order was never written to `settings.projectOrder`, so every refresh put them back in filesystem order. Now they sort like any other row inside a folder, and the order sticks.

## Changes

- **Sortable duplicates.** Every project row is a `SortableItem` and its id joins `sortableIds`. A dragged duplicate only changes places with its siblings under the same parent; dropping it on the parent row sends it to the top of them. A drop anywhere else leaves it where it is — a duplicate still only leaves its parent's nesting by joining a folder.
- **The rest of the list holds still.** A scoped sorting strategy limits the drag's transforms to the sibling block, so dragging a copy no longer shifts every row (and every other folder) below the pointer.
- **The order persists.** `flattenForProjectOrder` now trails each project with its nested duplicates. The backend regroups duplicates after their parent but preserves the relative order it reads there, so a within-parent drag survives the next refresh. `reorderDuplicate` moves the row in the project list and re-persists `projectOrder`, rolling back if the write fails.
- **Connectors ride with the rows.** Each row carries its own piece of the folder tree inside its sortable box, replacing `showConnectors = !activeId` — a drag no longer blanks the tree lines of every folder on screen.

## Test plan

- `sidebarLayout.test.ts`: 8 new cases covering `nestedDuplicates`, `resolveDuplicateDrop` (sibling slot, drop-on-parent, out-of-set no-ops) and `flattenForProjectOrder` with nested and folder-member duplicates.
- `config.rs`: 2 new cases pinning the contract this relies on — `apply_project_order` keeps the saved sibling order when it regroups duplicates after their parent.
- Full suite green: 1456 frontend tests, 952 Rust tests, production build passes.
- Worth an eyeball in the app: drag a copy up and down inside a folder, drop one on its parent, and drag a folder member while another folder is on screen.
